### PR TITLE
Add franchise dealer management and portal

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -284,6 +284,8 @@ function confirmSoftDelete(){
       <span class="title-chip">Salon: <?=h($VNAME)?></span>
       <a class="text-decoration-none" href="<?=h(BASE_URL)?>/admin/venues.php">Salon Değiştir</a>
       <span>•</span>
+      <a class="text-decoration-none" href="<?=h(BASE_URL)?>/admin/dealers.php">Bayiler</a>
+      <span>•</span>
       <span>Admin: <?= h($me['name'] ?? ($_SESSION['uname'] ?? 'Kullanıcı')) ?></span>
       <span>•</span>
 

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -7,7 +7,6 @@ require_once __DIR__.'/../includes/auth.php';
 
 require_admin();
 install_schema();
-
 $me = admin_user();
 
 /* Salon doğrulaması */

--- a/admin/dealers.php
+++ b/admin/dealers.php
@@ -1,0 +1,397 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/auth.php';
+
+require_admin();
+install_schema();
+
+function parse_license_input(?string $input): ?string {
+  if (!$input) return null;
+  try {
+    $dt = new DateTime($input);
+    return $dt->format('Y-m-d H:i:s');
+  } catch (Throwable $e) {
+    return null;
+  }
+}
+
+$action = $_POST['do'] ?? '';
+if ($action) {
+  csrf_or_die();
+}
+
+if ($action === 'create') {
+  $name  = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $phone = trim($_POST['phone'] ?? '');
+  $company = trim($_POST['company'] ?? '');
+  $notes = trim($_POST['notes'] ?? '');
+  $status = $_POST['status'] ?? DEALER_STATUS_PENDING;
+  $licenseInput = $_POST['license_expires_at'] ?? '';
+  $license = parse_license_input($licenseInput);
+
+  if ($name === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err', 'Ad ve geçerli e-posta gerekli.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+  if (dealer_find_by_email($email)) {
+    flash('err', 'Bu e-posta zaten kayıtlı.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+
+  $pdo = pdo();
+  $pdo->prepare("INSERT INTO dealers (name,email,phone,company,notes,status,license_expires_at,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?)")
+      ->execute([$name,$email,$phone,$company,$notes,$status,$license, now(), now()]);
+  $dealerId = (int)$pdo->lastInsertId();
+  dealer_ensure_codes($dealerId);
+
+  if ($status === DEALER_STATUS_ACTIVE) {
+    $plain = dealer_random_password();
+    $hash  = password_hash($plain, PASSWORD_DEFAULT);
+    $pdo->prepare("UPDATE dealers SET password_hash=?, approved_at=?, updated_at=? WHERE id=?")
+        ->execute([$hash, now(), now(), $dealerId]);
+    $dealer = dealer_get($dealerId);
+    dealer_send_welcome_mail($dealer, $plain);
+  }
+
+  flash('ok', 'Bayi kaydedildi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'update') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+
+  $name  = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $phone = trim($_POST['phone'] ?? '');
+  $company = trim($_POST['company'] ?? '');
+  $notes = trim($_POST['notes'] ?? '');
+  $status = $_POST['status'] ?? DEALER_STATUS_PENDING;
+  $licenseInput = $_POST['license_expires_at'] ?? '';
+  $license = parse_license_input($licenseInput);
+
+  if ($name === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err','Ad ve geçerli e-posta gerekli.');
+    redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+  }
+  $st = pdo()->prepare("SELECT id FROM dealers WHERE email=? AND id<>? LIMIT 1");
+  $st->execute([$email, $dealerId]);
+  if ($st->fetch()) {
+    flash('err','Bu e-posta başka bir bayide kayıtlı.');
+    redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+  }
+
+  pdo()->prepare("UPDATE dealers SET name=?, email=?, phone=?, company=?, notes=?, status=?, license_expires_at=?, updated_at=? WHERE id=?")
+      ->execute([$name,$email,$phone,$company,$notes,$status,$license, now(), $dealerId]);
+
+  if ($status === DEALER_STATUS_ACTIVE && empty($dealer['password_hash'])) {
+    $plain = dealer_random_password();
+    $hash  = password_hash($plain, PASSWORD_DEFAULT);
+    pdo()->prepare("UPDATE dealers SET password_hash=?, approved_at=?, updated_at=? WHERE id=?")
+        ->execute([$hash, now(), now(), $dealerId]);
+    $dealer = dealer_get($dealerId);
+    dealer_send_welcome_mail($dealer, $plain);
+  }
+
+  flash('ok','Bilgiler güncellendi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'assign_venues') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  $venues = $_POST['venue_ids'] ?? [];
+  dealer_assign_venues($dealerId, $venues);
+  flash('ok','Salon atamaları güncellendi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'regenerate_code') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $type = $_POST['type'] ?? DEALER_CODE_TRIAL;
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  dealer_regenerate_code($dealerId, $type);
+  flash('ok','Kod güncellendi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'set_code_event') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $type = $_POST['type'] ?? DEALER_CODE_STATIC;
+  $eventId = (int)($_POST['event_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  if ($eventId && !dealer_event_belongs_to_dealer($dealerId, $eventId)) {
+    flash('err','Seçilen düğün bu bayiye ait değil.');
+  } else {
+    dealer_set_code_target($dealerId, $type, $eventId ?: null);
+    flash('ok','Kod bağlantısı kaydedildi.');
+  }
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'send_password') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  if ($dealer['status'] !== DEALER_STATUS_ACTIVE) {
+    flash('err','Önce bayiyi aktif hale getirin.');
+    redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+  }
+  $plain = dealer_random_password();
+  $hash = password_hash($plain, PASSWORD_DEFAULT);
+  pdo()->prepare("UPDATE dealers SET password_hash=?, approved_at=COALESCE(approved_at,?), updated_at=? WHERE id=?")
+      ->execute([$hash, now(), now(), $dealerId]);
+  $dealer = dealer_get($dealerId);
+  dealer_send_welcome_mail($dealer, $plain);
+  flash('ok','Yeni şifre e-posta ile gönderildi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+$dealers = pdo()->query("SELECT * FROM dealers ORDER BY created_at DESC")->fetchAll();
+$selectedId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$selectedDealer = $selectedId ? dealer_get($selectedId) : null;
+$selectedCodes = $selectedDealer ? dealer_sync_codes($selectedId) : [];
+$assignedVenues = $selectedDealer ? dealer_fetch_venues($selectedId) : [];
+$assignedVenueIds = array_map(fn($v) => (int)$v['id'], $assignedVenues);
+$allVenues = pdo()->query("SELECT * FROM venues ORDER BY name")->fetchAll();
+$events = $selectedDealer ? dealer_allowed_events($selectedId) : [];
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Yönetimi</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  :root{ --zs:#0ea5b5; }
+  body{background:#f4f6fb;}
+  .card-lite{border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.08);}
+  .badge-status{padding:.35rem .65rem;border-radius:999px;font-size:.75rem;}
+</style>
+</head>
+<body>
+<nav class="navbar bg-white border-bottom">
+  <div class="container d-flex justify-content-between align-items-center py-2">
+    <div class="d-flex align-items-center gap-2">
+      <a class="navbar-brand fw-semibold" href="<?=h(BASE_URL)?>"><?=h(APP_NAME)?></a>
+      <span class="text-muted">/ Bayi Yönetimi</span>
+    </div>
+    <div class="d-flex gap-2">
+      <a href="<?=h(BASE_URL)?>/admin/dashboard.php" class="btn btn-sm btn-outline-secondary">Panel</a>
+      <a href="<?=h(BASE_URL)?>/admin/venues.php" class="btn btn-sm btn-outline-secondary">Salonlar</a>
+      <a href="<?=h(BASE_URL)?>/admin/users.php" class="btn btn-sm btn-outline-secondary">Kullanıcılar</a>
+      <a href="<?=h(BASE_URL)?>/admin/login.php?logout=1" class="btn btn-sm btn-danger">Çıkış</a>
+    </div>
+  </div>
+</nav>
+<div class="container py-4">
+  <?php flash_box(); ?>
+  <div class="row g-4">
+    <div class="col-lg-5">
+      <div class="card-lite p-4 mb-4">
+        <h5 class="mb-3">Yeni Bayi Oluştur</h5>
+        <form method="post" class="row g-2">
+          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+          <input type="hidden" name="do" value="create">
+          <div class="col-12">
+            <label class="form-label">Ad Soyad</label>
+            <input class="form-control" name="name" required>
+          </div>
+          <div class="col-12">
+            <label class="form-label">E-posta</label>
+            <input type="email" class="form-control" name="email" required>
+          </div>
+          <div class="col-6">
+            <label class="form-label">Telefon</label>
+            <input class="form-control" name="phone">
+          </div>
+          <div class="col-6">
+            <label class="form-label">Firma</label>
+            <input class="form-control" name="company">
+          </div>
+          <div class="col-12">
+            <label class="form-label">Not</label>
+            <textarea class="form-control" name="notes" rows="2"></textarea>
+          </div>
+          <div class="col-6">
+            <label class="form-label">Durum</label>
+            <select class="form-select" name="status">
+              <option value="pending">Onay Bekliyor</option>
+              <option value="active">Aktif</option>
+              <option value="inactive">Pasif</option>
+            </select>
+          </div>
+          <div class="col-6">
+            <label class="form-label">Lisans Bitişi</label>
+            <input type="datetime-local" class="form-control" name="license_expires_at">
+          </div>
+          <div class="col-12 d-grid">
+            <button class="btn btn-primary" type="submit">Kaydet</button>
+          </div>
+        </form>
+      </div>
+      <div class="card-lite p-0">
+        <div class="p-3 border-bottom"><h5 class="m-0">Bayiler</h5></div>
+        <div class="list-group list-group-flush" style="max-height:420px;overflow:auto;">
+          <?php foreach ($dealers as $d): ?>
+            <?php
+              $badge = dealer_status_badge($d['status']);
+              $activeClass = ($selectedId === (int)$d['id']) ? 'active' : '';
+              $license = $d['license_expires_at'] ? date('d.m.Y', strtotime($d['license_expires_at'])) : '—';
+            ?>
+            <a href="?id=<?= (int)$d['id'] ?>" class="list-group-item list-group-item-action <?= $activeClass ?>">
+              <div class="fw-semibold"><?=h($d['name'])?></div>
+              <div class="d-flex justify-content-between small text-muted">
+                <span><?=h($badge)?></span>
+                <span>Lisans: <?=h($license)?></span>
+              </div>
+            </a>
+          <?php endforeach; ?>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-7">
+      <?php if (!$selectedDealer): ?>
+        <div class="card-lite p-4">
+          <h5 class="mb-2">Bayi seçin</h5>
+          <p class="text-muted">Soldaki listeden bir bayi seçerek detaylarını görüntüleyin.</p>
+        </div>
+      <?php else: ?>
+        <?php
+          $licenseValue = $selectedDealer['license_expires_at'] ? date('Y-m-d\TH:i', strtotime($selectedDealer['license_expires_at'])) : '';
+          $codes = $selectedCodes;
+        ?>
+        <div class="card-lite p-4 mb-4">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h5 class="m-0"><?=h($selectedDealer['name'])?></h5>
+            <form method="post" class="m-0">
+              <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+              <input type="hidden" name="do" value="send_password">
+              <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+              <button class="btn btn-sm btn-outline-primary" type="submit">Yeni Şifre Gönder</button>
+            </form>
+          </div>
+          <form method="post" class="row g-2">
+            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="do" value="update">
+            <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+            <div class="col-md-6">
+              <label class="form-label">Ad Soyad</label>
+              <input class="form-control" name="name" value="<?=h($selectedDealer['name'])?>" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">E-posta</label>
+              <input type="email" class="form-control" name="email" value="<?=h($selectedDealer['email'])?>" required>
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Telefon</label>
+              <input class="form-control" name="phone" value="<?=h($selectedDealer['phone'])?>">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Firma</label>
+              <input class="form-control" name="company" value="<?=h($selectedDealer['company'])?>">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Durum</label>
+              <select class="form-select" name="status">
+                <option value="pending" <?= $selectedDealer['status']==='pending'?'selected':'' ?>>Onay Bekliyor</option>
+                <option value="active" <?= $selectedDealer['status']==='active'?'selected':'' ?>>Aktif</option>
+                <option value="inactive" <?= $selectedDealer['status']==='inactive'?'selected':'' ?>>Pasif</option>
+              </select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Lisans Bitiş</label>
+              <input type="datetime-local" class="form-control" name="license_expires_at" value="<?=h($licenseValue)?>">
+            </div>
+            <div class="col-12">
+              <label class="form-label">Not</label>
+              <textarea class="form-control" name="notes" rows="2"><?=h($selectedDealer['notes'])?></textarea>
+            </div>
+            <div class="col-12 d-grid">
+              <button class="btn btn-primary" type="submit">Bilgileri Güncelle</button>
+            </div>
+          </form>
+        </div>
+
+        <div class="card-lite p-4 mb-4">
+          <h5 class="mb-3">Salon Atamaları</h5>
+          <form method="post" class="row g-3">
+            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="do" value="assign_venues">
+            <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+            <div class="col-12">
+              <select class="form-select" name="venue_ids[]" multiple size="8">
+                <?php foreach ($allVenues as $v): ?>
+                  <option value="<?= (int)$v['id'] ?>" <?= in_array((int)$v['id'], $assignedVenueIds, true) ? 'selected' : '' ?>><?=h($v['name'])?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <div class="col-12 d-grid">
+              <button class="btn btn-outline-primary" type="submit">Atamaları Kaydet</button>
+            </div>
+          </form>
+        </div>
+
+        <div class="card-lite p-4">
+          <h5 class="mb-3">Kodlar</h5>
+          <div class="row g-3">
+            <?php foreach ([DEALER_CODE_STATIC=>'Kalıcı Kod', DEALER_CODE_TRIAL=>'Deneme Kodu'] as $type=>$label):
+              $code = $codes[$type] ?? null;
+              $url = $code ? BASE_URL.'/qr.php?code='.urlencode($code['code']) : '';
+            ?>
+            <div class="col-md-6">
+              <div class="border rounded-3 p-3 h-100">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                  <h6 class="mb-0"><?=h($label)?></h6>
+                  <form method="post" class="m-0">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="regenerate_code">
+                    <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+                    <input type="hidden" name="type" value="<?=h($type)?>">
+                    <button class="btn btn-sm btn-outline-secondary" type="submit">Yenile</button>
+                  </form>
+                </div>
+                <?php if ($code): ?>
+                  <p class="fw-semibold">Kod: <?=h($code['code'])?></p>
+                  <p class="small text-muted"><a href="<?=h($url)?>" target="_blank">QR bağlantısı</a></p>
+                  <form method="post" class="vstack gap-2">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="set_code_event">
+                    <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+                    <input type="hidden" name="type" value="<?=h($type)?>">
+                    <label class="form-label small">Bağlı düğün</label>
+                    <select class="form-select form-select-sm" name="event_id">
+                      <option value="0">— Seçili değil —</option>
+                      <?php foreach ($events as $ev): ?>
+                        <?php
+                          $sel = ($code['target_event_id'] ?? null) == $ev['id'] ? 'selected' : '';
+                          $dateLabel = $ev['event_date'] ? date('d.m.Y', strtotime($ev['event_date'])) : 'Tarihsiz';
+                        ?>
+                        <option value="<?= (int)$ev['id'] ?>" <?=$sel?>><?=h($dateLabel.' • '.$ev['title'])?></option>
+                      <?php endforeach; ?>
+                    </select>
+                    <button class="btn btn-sm btn-primary" type="submit">Kaydet</button>
+                  </form>
+                <?php else: ?>
+                  <p class="text-muted">Kod oluşturulamadı.</p>
+                <?php endif; ?>
+              </div>
+            </div>
+            <?php endforeach; ?>
+          </div>
+        </div>
+      <?php endif; ?>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/admin/users.php
+++ b/admin/users.php
@@ -161,9 +161,11 @@ if ($detail_id) {
 <nav class="navbar bg-white border-bottom no-print">
   <div class="container">
     <a class="navbar-brand fw-semibold" href="<?=h(BASE_URL)?>"><?=h(APP_NAME)?></a>
-    <div class="small">
+    <div class="small d-flex align-items-center gap-2">
       <a href="<?=h(BASE_URL)?>/admin/dashboard.php" class="text-decoration-none">Panel</a>
-      <span class="mx-2">•</span>
+      <span>•</span>
+      <a href="<?=h(BASE_URL)?>/admin/dealers.php" class="text-decoration-none">Bayiler</a>
+      <span>•</span>
       <a href="<?=h(BASE_URL)?>/admin/login.php?logout=1" class="text-decoration-none">Çıkış</a>
     </div>
   </div>

--- a/admin/venues.php
+++ b/admin/venues.php
@@ -177,6 +177,8 @@ function askToggle(){
       <!-- Yeni: Kullanıcılar (liste sayfasına gider) -->
       <a href="<?=h(BASE_URL)?>/admin/users.php" class="btn btn-sm btn-zs">Kullanıcılar</a>
 
+      <a href="<?=h(BASE_URL)?>/admin/dealers.php" class="btn btn-sm btn-zs-outline">Bayiler</a>
+
       <span class="text-muted px-1">•</span>
 
       <a href="<?=h(BASE_URL)?>/admin/login.php?logout=1" class="btn btn-sm btn-outline-secondary">Çıkış</a>

--- a/dealer/apply.php
+++ b/dealer/apply.php
@@ -1,0 +1,93 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+
+install_schema();
+
+$submitted = isset($_GET['done']);
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  csrf_or_die();
+  $name = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $phone = trim($_POST['phone'] ?? '');
+  $company = trim($_POST['company'] ?? '');
+  $notes = trim($_POST['notes'] ?? '');
+
+  if ($name === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err', 'Lütfen adınızı ve geçerli bir e-posta adresini girin.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+
+  if (dealer_find_by_email($email)) {
+    flash('err', 'Bu e-posta ile kayıtlı bir bayi başvurusu bulunuyor.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+
+  $st = pdo()->prepare("INSERT INTO dealers (name,email,phone,company,notes,status,created_at) VALUES (?,?,?,?,?,'pending',?)");
+  $st->execute([$name,$email,$phone,$company,$notes, now()]);
+  $dealerId = (int)pdo()->lastInsertId();
+  dealer_ensure_codes($dealerId);
+
+  $dealer = dealer_get($dealerId);
+  dealer_notify_new_application($dealer);
+  dealer_send_application_receipt($dealer);
+
+  flash('ok', 'Başvurunuz alınmıştır. En kısa sürede sizinle iletişime geçeceğiz.');
+  redirect($_SERVER['PHP_SELF'].'?done=1');
+}
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Başvurusu</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:linear-gradient(180deg,#fff5f7,#ffffff);}
+  .hero{max-width:640px;margin:40px auto;padding:32px;border-radius:18px;background:#fff;box-shadow:0 12px 40px rgba(15,23,42,.08);}
+</style>
+</head>
+<body>
+<div class="hero">
+  <h1 class="h3 mb-3">Bayi Başvuru Formu</h1>
+  <p class="text-muted">Düğün salonunuz veya organizasyon şirketiniz için başvuru yapın, yönetici onayıyla bayilik paneliniz açılsın.</p>
+  <?php if ($submitted): ?>
+    <?php flash_box(); ?>
+  <?php else: ?>
+    <?php flash_box(); ?>
+    <form method="post" class="row g-3">
+      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+      <div class="col-md-6">
+        <label class="form-label">Ad Soyad</label>
+        <input class="form-control" name="name" required>
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Firma Adı</label>
+        <input class="form-control" name="company">
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">E-posta</label>
+        <input type="email" class="form-control" name="email" required>
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Telefon</label>
+        <input class="form-control" name="phone">
+      </div>
+      <div class="col-12">
+        <label class="form-label">Notlar</label>
+        <textarea class="form-control" name="notes" rows="4" placeholder="Salon sayısı, bulunduğunuz şehir vb."></textarea>
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary" type="submit">Başvuruyu Gönder</button>
+      </div>
+    </form>
+  <?php endif; ?>
+  <div class="mt-4 text-center">
+    <a href="login.php" class="small text-decoration-none">Zaten bayimiz misiniz? Giriş yapın.</a>
+  </div>
+</div>
+</body>
+</html>

--- a/dealer/dashboard.php
+++ b/dealer/dashboard.php
@@ -1,0 +1,167 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+
+install_schema();
+
+dealer_require_login();
+$sessionDealer = dealer_user();
+$dealer = dealer_get((int)$sessionDealer['id']);
+if (!$dealer) {
+  dealer_logout();
+  redirect('login.php');
+}
+
+dealer_refresh_session((int)$dealer['id']);
+
+$action = $_POST['do'] ?? '';
+if ($action) {
+  csrf_or_die();
+  if ($action === 'set_code') {
+    $type = $_POST['type'] ?? DEALER_CODE_STATIC;
+    $eventId = (int)($_POST['event_id'] ?? 0);
+    if ($eventId > 0 && !dealer_event_belongs_to_dealer((int)$dealer['id'], $eventId)) {
+      flash('err', 'Bu etkinliği yönetme yetkiniz yok.');
+    } else {
+      dealer_set_code_target((int)$dealer['id'], $type, $eventId > 0 ? $eventId : null);
+      flash('ok', 'Kod bağlantısı güncellendi.');
+    }
+    redirect($_SERVER['PHP_SELF']);
+  }
+  if ($action === 'refresh_trial') {
+    dealer_regenerate_code((int)$dealer['id'], DEALER_CODE_TRIAL);
+    flash('ok', 'Deneme kodu yenilendi.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+}
+
+$codes   = dealer_sync_codes((int)$dealer['id']);
+$venues  = dealer_fetch_venues((int)$dealer['id']);
+$events  = dealer_allowed_events((int)$dealer['id']);
+$warning = dealer_license_warning($dealer);
+$canCreate = dealer_can_manage_events($dealer);
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Paneli</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:linear-gradient(180deg,#f4f9fb,#fff) no-repeat;font-family:'Inter',sans-serif;}
+  .topbar{background:#fff;border-bottom:1px solid #e5e7eb;}
+  .card-lite{border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.08);}
+  .code-pill{font-family:'Fira Code',monospace;font-size:1.1rem;padding:.35rem .8rem;border-radius:10px;background:#f1f5f9;display:inline-block;}
+</style>
+</head>
+<body>
+<nav class="topbar py-3">
+  <div class="container d-flex justify-content-between align-items-center">
+    <span class="fw-semibold"><?=h(APP_NAME)?> — Bayi Paneli</span>
+    <div class="d-flex align-items-center gap-3 small">
+      <span><?=h($dealer['name'])?></span>
+      <span>•</span>
+      <a class="text-decoration-none" href="login.php?logout=1">Çıkış</a>
+    </div>
+  </div>
+</nav>
+<div class="container py-4">
+  <?php flash_box(); ?>
+  <div class="row g-4">
+    <div class="col-lg-4">
+      <div class="card-lite p-4 h-100">
+        <h5 class="mb-3">Lisans Durumu</h5>
+        <p class="mb-1"><strong>Bitiş:</strong> <?=h(dealer_license_label($dealer))?></p>
+        <p class="text-muted small">Durum: <?= dealer_has_valid_license($dealer) ? 'Geçerli' : 'Geçersiz' ?></p>
+        <?php if ($warning): ?>
+          <div class="alert alert-warning small mb-0"><?=h($warning)?></div>
+        <?php endif; ?>
+      </div>
+    </div>
+    <div class="col-lg-8">
+      <div class="card-lite p-4">
+        <h5 class="mb-3">Kalıcı & Deneme Kodları</h5>
+        <div class="row g-4">
+          <?php foreach ([DEALER_CODE_STATIC=>'Kalıcı Kod', DEALER_CODE_TRIAL=>'Deneme Kodu'] as $type=>$label):
+            $code = $codes[$type] ?? null;
+            $url = $code ? BASE_URL.'/qr.php?code='.urlencode($code['code']) : '';
+          ?>
+          <div class="col-md-6">
+            <div class="border rounded-3 p-3 h-100">
+              <div class="d-flex justify-content-between align-items-center mb-2">
+                <h6 class="mb-0"><?=h($label)?></h6>
+                <?php if ($type === DEALER_CODE_TRIAL): ?>
+                  <form method="post" class="m-0">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="refresh_trial">
+                    <button class="btn btn-sm btn-outline-secondary">Yenile</button>
+                  </form>
+                <?php endif; ?>
+              </div>
+              <?php if ($code): ?>
+                <div class="code-pill mb-2"><?=h($code['code'])?></div>
+                <p class="small text-muted mb-2"><a href="<?=h($url)?>" target="_blank">QR bağlantısı</a></p>
+                <form method="post" class="vstack gap-2">
+                  <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                  <input type="hidden" name="do" value="set_code">
+                  <input type="hidden" name="type" value="<?=h($type)?>">
+                  <label class="form-label small mb-1">Bağlı düğün</label>
+                  <select class="form-select form-select-sm" name="event_id">
+                    <option value="0">— Seçili değil —</option>
+                    <?php foreach ($events as $ev): ?>
+                      <?php
+                        $selected = ($code['target_event_id'] ?? null) == $ev['id'] ? 'selected' : '';
+                        $dateLabel = $ev['event_date'] ? date('d.m.Y', strtotime($ev['event_date'])) : 'Tarihsiz';
+                      ?>
+                      <option value="<?= (int)$ev['id'] ?>" <?=$selected?>><?=h($dateLabel.' • '.$ev['title'])?></option>
+                    <?php endforeach; ?>
+                  </select>
+                  <button class="btn btn-sm btn-primary" type="submit">Kaydet</button>
+                </form>
+              <?php else: ?>
+                <p class="text-muted small">Kod oluşturulamadı.</p>
+              <?php endif; ?>
+            </div>
+          </div>
+          <?php endforeach; ?>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card-lite p-4 mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h5 class="mb-0">Salonlarınız</h5>
+      <a class="btn btn-sm btn-outline-primary" href="mailto:<?=h(MAIL_FROM ?? 'info@localhost')?>?subject=Bayi%20Salon%20Talebi">Yeni salon talep et</a>
+    </div>
+    <?php if (!$venues): ?>
+      <p class="text-muted">Henüz size atanmış salon bulunmuyor. Lütfen yönetici ile iletişime geçin.</p>
+    <?php else: ?>
+      <div class="table-responsive">
+        <table class="table align-middle">
+          <thead><tr><th>Salon</th><th>Durum</th><th></th></tr></thead>
+          <tbody>
+            <?php foreach ($venues as $v): ?>
+              <tr>
+                <td>
+                  <div class="fw-semibold"><?=h($v['name'])?></div>
+                  <div class="small text-muted">Slug: <?=h($v['slug'])?></div>
+                </td>
+                <td><?= $v['is_active'] ? 'Aktif' : 'Pasif' ?></td>
+                <td class="text-end">
+                  <a class="btn btn-sm btn-primary" href="venue_events.php?venue_id=<?= (int)$v['id'] ?>">Düğünleri Yönet</a>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php endif; ?>
+  </div>
+</div>
+</body>
+</html>

--- a/dealer/login.php
+++ b/dealer/login.php
@@ -1,0 +1,63 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+require_once __DIR__.'/../includes/dealers.php';
+
+install_schema();
+
+if (isset($_GET['logout'])) {
+  dealer_logout();
+  flash('ok', 'Oturum kapatıldı.');
+}
+
+if (dealer_user()) {
+  redirect('dashboard.php');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $email = trim($_POST['email'] ?? '');
+  $pass  = (string)($_POST['password'] ?? '');
+  if (dealer_login($email, $pass)) {
+    $next = $_GET['next'] ?? 'dashboard.php';
+    redirect($next);
+  } else {
+    flash('err', 'Giriş başarısız. Bilgilerinizi kontrol edin.');
+  }
+}
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Girişi</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:#f4f6fb;}
+  .login-card{max-width:420px;margin:80px auto;padding:32px;border-radius:16px;background:#fff;box-shadow:0 12px 40px rgba(15,23,42,.12);}
+</style>
+</head>
+<body>
+<div class="login-card">
+  <h2 class="h4 mb-3 text-center">Bayi Paneli</h2>
+  <p class="text-muted small text-center mb-4">Bayi kodlarınızı ve düğünlerinizi buradan yönetin.</p>
+  <?php flash_box(); ?>
+  <form method="post" class="vstack gap-3">
+    <div>
+      <label class="form-label">E-posta</label>
+      <input type="email" name="email" class="form-control" required>
+    </div>
+    <div>
+      <label class="form-label">Şifre</label>
+      <input type="password" name="password" class="form-control" required>
+    </div>
+    <button class="btn btn-primary w-100" type="submit">Giriş Yap</button>
+  </form>
+  <div class="text-center mt-3">
+    <a class="small" href="apply.php">Bayi olmak için başvurun</a>
+  </div>
+</div>
+</body>
+</html>

--- a/dealer/venue_events.php
+++ b/dealer/venue_events.php
@@ -1,0 +1,219 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+
+install_schema();
+
+dealer_require_login();
+$sessionDealer = dealer_user();
+$dealer = dealer_get((int)$sessionDealer['id']);
+if (!$dealer) {
+  dealer_logout();
+  redirect('login.php');
+}
+
+$venueId = (int)($_GET['venue_id'] ?? 0);
+if ($venueId <= 0) {
+  flash('err', 'Salon seçilmedi.');
+  redirect('dashboard.php');
+}
+
+$st = pdo()->prepare("SELECT v.* FROM venues v INNER JOIN dealer_venues dv ON dv.venue_id=v.id WHERE dv.dealer_id=? AND v.id=? LIMIT 1");
+$st->execute([(int)$dealer['id'], $venueId]);
+$venue = $st->fetch();
+if (!$venue) {
+  flash('err', 'Bu salona erişiminiz yok.');
+  redirect('dashboard.php');
+}
+
+$canManage = dealer_can_manage_events($dealer);
+
+$action = $_POST['do'] ?? '';
+if ($action === 'create_event') {
+  csrf_or_die();
+  if (!$canManage) {
+    flash('err', 'Lisans süreniz dolduğu için yeni düğün oluşturamazsınız.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+
+  $title = trim($_POST['title'] ?? '');
+  $date  = trim($_POST['event_date'] ?? '');
+  $email = trim($_POST['couple_email'] ?? '');
+  $pass  = (string)($_POST['couple_pass'] ?? '');
+
+  if ($title === '' || $email === '' || $pass === '') {
+    flash('err', 'Başlık, e-posta ve şifre alanları zorunlu.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+  if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err', 'Geçerli bir e-posta girin.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+  if (strlen($pass) < 6) {
+    flash('err', 'Geçici şifre en az 6 karakter olmalı.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+
+  $slug = slugify($title);
+  if ($slug === '') $slug = 'event-'.bin2hex(random_bytes(3));
+  $base = $slug; $i = 1;
+  while (true) {
+    $chk = pdo()->prepare("SELECT id FROM events WHERE venue_id=? AND slug=? LIMIT 1");
+    $chk->execute([$venueId, $slug]);
+    if (!$chk->fetch()) break;
+    $slug = $base.'-'.$i++;
+  }
+
+  $same = pdo()->prepare("SELECT id FROM events WHERE couple_username=? LIMIT 1");
+  $same->execute([$email]);
+  if ($same->fetch()) {
+    flash('err', 'Bu e-posta farklı bir düğün için kullanılıyor.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+
+  $key  = bin2hex(random_bytes(16));
+  $hash = password_hash($pass, PASSWORD_DEFAULT);
+  $primary = '#0ea5b5';
+  $accent  = '#e0f7fb';
+
+  $sql = "INSERT INTO events (venue_id,dealer_id,user_id,title,slug,couple_panel_key,theme_primary,theme_accent,event_date,created_at,couple_username,couple_password_hash,couple_force_reset,contact_email) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+  pdo()->prepare($sql)->execute([
+    $venueId,
+    (int)$dealer['id'],
+    null,
+    $title,
+    $slug,
+    $key,
+    $primary,
+    $accent,
+    $date ?: null,
+    now(),
+    $email,
+    $hash,
+    1,
+    $email,
+  ]);
+
+  $eventId = (int)pdo()->lastInsertId();
+  $loginUrl = BASE_URL.'/couple/login.php?event='.$eventId;
+  $html = '<h3>'.h(APP_NAME).' Çift Paneli</h3>'
+        . '<p>Düğün paneliniz oluşturuldu.</p>'
+        . '<p><strong>Kullanıcı adı:</strong> '.h($email).'<br>'
+        . '<strong>Geçici şifre:</strong> '.h($pass).'</p>'
+        . '<p><a href="'.h($loginUrl).'">Panele giriş yapın</a> ve ilk girişte şifrenizi değiştirin.</p>';
+  send_mail_simple($email, 'Çift paneliniz hazır', $html);
+
+  flash('ok', 'Düğün oluşturuldu ve bilgiler çifte e-posta ile gönderildi.');
+  redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+}
+
+if ($action === 'toggle' && isset($_POST['event_id'])) {
+  csrf_or_die();
+  $eventId = (int)$_POST['event_id'];
+  if (!dealer_event_belongs_to_dealer((int)$dealer['id'], $eventId)) {
+    flash('err', 'Bu düğünü yönetme yetkiniz yok.');
+  } else {
+    pdo()->prepare("UPDATE events SET is_active=1-is_active WHERE id=? AND venue_id=?")
+        ->execute([$eventId, $venueId]);
+    flash('ok', 'Durum güncellendi.');
+  }
+  redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+}
+
+$events = [];
+$st = pdo()->prepare("SELECT * FROM events WHERE venue_id=? ORDER BY event_date DESC, id DESC");
+$st->execute([$venueId]);
+$events = $st->fetchAll();
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h($venue['name'])?> — Düğünler</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:#f4f6fb;}
+  .card-lite{border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.06);}
+</style>
+</head>
+<body>
+<nav class="navbar bg-white border-bottom mb-4">
+  <div class="container d-flex justify-content-between align-items-center py-2">
+    <div>
+      <a class="navbar-brand fw-semibold" href="dashboard.php">← Bayi Paneli</a>
+      <span class="ms-2 text-muted">Salon: <?=h($venue['name'])?></span>
+    </div>
+    <a class="text-decoration-none" href="login.php?logout=1">Çıkış</a>
+  </div>
+</nav>
+<div class="container pb-5">
+  <?php flash_box(); ?>
+  <div class="card-lite p-4 mb-4">
+    <h5 class="mb-3">Yeni Düğün Oluştur</h5>
+    <?php if (!$canManage): ?>
+      <div class="alert alert-warning">Lisans süreniz geçersiz olduğu için yeni düğün oluşturamazsınız. Lütfen yönetici ile iletişime geçin.</div>
+    <?php endif; ?>
+    <form method="post" class="row g-3" autocomplete="off">
+      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+      <input type="hidden" name="do" value="create_event">
+      <div class="col-md-6">
+        <label class="form-label">Düğün Başlığı</label>
+        <input class="form-control" name="title" required <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Düğün Tarihi</label>
+        <input type="date" class="form-control" name="event_date" <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Çift E-postası</label>
+        <input type="email" class="form-control" name="couple_email" required <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Geçici Şifre</label>
+        <input type="text" class="form-control" name="couple_pass" minlength="6" required <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-9 d-flex align-items-end">
+        <button class="btn btn-primary" type="submit" <?= $canManage ? '' : 'disabled' ?>>Düğünü Oluştur</button>
+      </div>
+    </form>
+  </div>
+
+  <div class="card-lite p-4">
+    <h5 class="mb-3">Düğün Listesi</h5>
+    <?php if (!$events): ?>
+      <p class="text-muted">Bu salona ait düğün bulunmuyor.</p>
+    <?php else: ?>
+      <div class="table-responsive">
+        <table class="table align-middle">
+          <thead><tr><th>Başlık</th><th>Tarih</th><th>Durum</th><th></th></tr></thead>
+          <tbody>
+            <?php foreach ($events as $ev): ?>
+              <tr>
+                <td>
+                  <div class="fw-semibold"><?=h($ev['title'])?></div>
+                  <div class="small text-muted">Çift e-postası: <?=h($ev['couple_username'] ?? $ev['contact_email'])?></div>
+                </td>
+                <td><?= $ev['event_date'] ? h(date('d.m.Y', strtotime($ev['event_date']))) : '—' ?></td>
+                <td><?= $ev['is_active'] ? 'Aktif' : 'Pasif' ?></td>
+                <td class="text-end">
+                  <form method="post" class="d-inline">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="toggle">
+                    <input type="hidden" name="event_id" value="<?= (int)$ev['id'] ?>">
+                    <button class="btn btn-sm btn-outline-secondary" type="submit">Durumu Değiştir</button>
+                  </form>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php endif; ?>
+  </div>
+</div>
+</body>
+</html>

--- a/includes/db.php
+++ b/includes/db.php
@@ -39,10 +39,28 @@ function install_schema(){
     is_active TINYINT(1) NOT NULL DEFAULT 1
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
+  /* dealers */
+  pdo()->exec("CREATE TABLE IF NOT EXISTS dealers(
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(190) NOT NULL,
+    email VARCHAR(190) NOT NULL UNIQUE,
+    phone VARCHAR(64) NULL,
+    company VARCHAR(190) NULL,
+    notes TEXT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT 'pending',
+    license_expires_at DATETIME NULL,
+    password_hash VARCHAR(255) NULL,
+    approved_at DATETIME NULL,
+    last_login_at DATETIME NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NULL
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
   /* events */
   pdo()->exec("CREATE TABLE IF NOT EXISTS events(
     id INT AUTO_INCREMENT PRIMARY KEY,
     venue_id INT NOT NULL,
+    dealer_id INT NULL,
     user_id INT NULL,
     contact_email VARCHAR(190) NULL,
     title VARCHAR(190) NOT NULL,
@@ -58,7 +76,36 @@ function install_schema(){
     updated_at DATETIME NULL,
     UNIQUE KEY uniq_event_slug (venue_id, slug),
     INDEX (venue_id),
+    INDEX (dealer_id),
+    FOREIGN KEY (venue_id) REFERENCES venues(id) ON DELETE CASCADE,
+    FOREIGN KEY (dealer_id) REFERENCES dealers(id) ON DELETE SET NULL
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+  /* dealer_venues (çoktan çoğa) */
+  pdo()->exec("CREATE TABLE IF NOT EXISTS dealer_venues(
+    dealer_id INT NOT NULL,
+    venue_id INT NOT NULL,
+    created_at DATETIME NOT NULL,
+    PRIMARY KEY (dealer_id, venue_id),
+    INDEX (venue_id),
+    FOREIGN KEY (dealer_id) REFERENCES dealers(id) ON DELETE CASCADE,
     FOREIGN KEY (venue_id) REFERENCES venues(id) ON DELETE CASCADE
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+  /* dealer_codes — statik & deneme kodları */
+  pdo()->exec("CREATE TABLE IF NOT EXISTS dealer_codes(
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    dealer_id INT NOT NULL,
+    type VARCHAR(16) NOT NULL,
+    code VARCHAR(64) NOT NULL,
+    target_event_id INT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NULL,
+    UNIQUE KEY uniq_dealer_type (dealer_id, type),
+    UNIQUE KEY uniq_code (code),
+    INDEX (dealer_id, type),
+    FOREIGN KEY (dealer_id) REFERENCES dealers(id) ON DELETE CASCADE,
+    FOREIGN KEY (target_event_id) REFERENCES events(id) ON DELETE SET NULL
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
   /* uploads */
@@ -141,6 +188,15 @@ function install_schema(){
   pdo()->exec("INSERT IGNORE INTO settings (id, created_at) VALUES (1, NOW())");
 
   /* çift hesap alanları + lisans + fatura */
+  if (!column_exists('events','dealer_id')) {
+    try {
+      pdo()->exec("ALTER TABLE events ADD dealer_id INT NULL AFTER venue_id");
+      pdo()->exec("CREATE INDEX idx_events_dealer ON events(dealer_id)");
+      pdo()->exec("ALTER TABLE events ADD CONSTRAINT fk_events_dealer FOREIGN KEY (dealer_id) REFERENCES dealers(id) ON DELETE SET NULL");
+    } catch (Throwable $e) {
+      // sessizce yut (bazı eski MySQL sürümleri aynı anda FK eklemeyi desteklemeyebilir)
+    }
+  }
   if (!column_exists('events','guest_title'))         pdo()->exec("ALTER TABLE events ADD guest_title VARCHAR(190) NULL");
   if (!column_exists('events','guest_subtitle'))      pdo()->exec("ALTER TABLE events ADD guest_subtitle VARCHAR(255) NULL");
   if (!column_exists('events','allow_guest_view'))    pdo()->exec("ALTER TABLE events ADD allow_guest_view TINYINT(1) NOT NULL DEFAULT 1");

--- a/includes/dealer_auth.php
+++ b/includes/dealer_auth.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * includes/dealer_auth.php — Bayi paneli oturum yardımcıları
+ */
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/db.php';
+require_once __DIR__.'/functions.php';
+require_once __DIR__.'/dealers.php';
+
+function dealer_login(string $email, string $password): bool {
+  $email = trim($email);
+  if ($email === '' || $password === '') return false;
+
+  $st = pdo()->prepare("SELECT * FROM dealers WHERE email=? LIMIT 1");
+  $st->execute([$email]);
+  $dealer = $st->fetch();
+  if (!$dealer) return false;
+  if ($dealer['status'] !== DEALER_STATUS_ACTIVE) return false;
+  if (empty($dealer['password_hash']) || !password_verify($password, $dealer['password_hash'])) {
+    return false;
+  }
+
+  $_SESSION['dealer'] = [
+    'id'    => (int)$dealer['id'],
+    'email' => $dealer['email'],
+    'name'  => $dealer['name'],
+    'since' => time(),
+  ];
+  dealer_update_last_login((int)$dealer['id']);
+  return true;
+}
+
+function dealer_logout(): void {
+  unset($_SESSION['dealer']);
+}
+
+function dealer_user(): ?array {
+  return !empty($_SESSION['dealer']) ? $_SESSION['dealer'] : null;
+}
+
+function dealer_require_login(string $login_url = '/dealer/login.php'): void {
+  if (!dealer_user()) {
+    $back = urlencode($_SERVER['REQUEST_URI'] ?? '/dealer/dashboard.php');
+    redirect($login_url.'?next='.$back);
+  }
+}
+
+function dealer_refresh_session(int $dealer_id): void {
+  $dealer = dealer_get($dealer_id);
+  if (!$dealer) {
+    dealer_logout();
+    return;
+  }
+  $_SESSION['dealer'] = [
+    'id'    => (int)$dealer['id'],
+    'email' => $dealer['email'],
+    'name'  => $dealer['name'],
+    'since' => time(),
+  ];
+}
+
+function dealer_can_manage_events(array $dealer): bool {
+  if ($dealer['status'] !== DEALER_STATUS_ACTIVE) return false;
+  return dealer_has_valid_license($dealer);
+}

--- a/includes/dealers.php
+++ b/includes/dealers.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * includes/dealers.php — Bayi (franchise) yardımcı fonksiyonları
+ */
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/db.php';
+require_once __DIR__.'/functions.php';
+
+const DEALER_STATUS_PENDING = 'pending';
+const DEALER_STATUS_ACTIVE  = 'active';
+const DEALER_STATUS_INACTIVE= 'inactive';
+
+const DEALER_CODE_STATIC = 'static';
+const DEALER_CODE_TRIAL  = 'trial';
+
+/** Benzersiz kod üret (harf + rakam, karışık). */
+function dealer_generate_code_string(int $length = 8): string {
+  $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  $out = '';
+  $max = strlen($alphabet) - 1;
+  for ($i = 0; $i < $length; $i++) {
+    $out .= $alphabet[random_int(0, $max)];
+  }
+  return $out;
+}
+
+function dealer_generate_unique_code(): string {
+  while (true) {
+    $code = dealer_generate_code_string(8);
+    $st = pdo()->prepare("SELECT 1 FROM dealer_codes WHERE code=? LIMIT 1");
+    $st->execute([$code]);
+    if ($st->fetch()) continue;
+    // qr_codes ile çakışmasın
+    $st2 = pdo()->prepare("SELECT 1 FROM qr_codes WHERE code=? LIMIT 1");
+    $st2->execute([$code]);
+    if ($st2->fetch()) continue;
+    return $code;
+  }
+}
+
+function dealer_ensure_codes(int $dealer_id): array {
+  $types = [DEALER_CODE_STATIC, DEALER_CODE_TRIAL];
+  foreach ($types as $type) {
+    $st = pdo()->prepare("SELECT id FROM dealer_codes WHERE dealer_id=? AND type=? LIMIT 1");
+    $st->execute([$dealer_id, $type]);
+    if (!$st->fetch()) {
+      $code = dealer_generate_unique_code();
+      pdo()->prepare("INSERT INTO dealer_codes (dealer_id,type,code,created_at) VALUES (?,?,?,?)")
+          ->execute([$dealer_id, $type, $code, now()]);
+    }
+  }
+  return dealer_get_codes($dealer_id);
+}
+
+function dealer_get_codes(int $dealer_id): array {
+  $st = pdo()->prepare("SELECT * FROM dealer_codes WHERE dealer_id=? ORDER BY type");
+  $st->execute([$dealer_id]);
+  $rows = [];
+  foreach ($st->fetchAll() as $row) {
+    $rows[$row['type']] = $row;
+  }
+  return $rows;
+}
+
+function dealer_regenerate_code(int $dealer_id, string $type): string {
+  $type = $type === DEALER_CODE_TRIAL ? DEALER_CODE_TRIAL : DEALER_CODE_STATIC;
+  $code = dealer_generate_unique_code();
+  pdo()->prepare("UPDATE dealer_codes SET code=?, updated_at=?, target_event_id=NULL WHERE dealer_id=? AND type=?")
+      ->execute([$code, now(), $dealer_id, $type]);
+  return $code;
+}
+
+function dealer_set_code_target(int $dealer_id, string $type, ?int $event_id): void {
+  $type = $type === DEALER_CODE_TRIAL ? DEALER_CODE_TRIAL : DEALER_CODE_STATIC;
+  pdo()->prepare("UPDATE dealer_codes SET target_event_id=?, updated_at=? WHERE dealer_id=? AND type=?")
+      ->execute([$event_id ?: null, now(), $dealer_id, $type]);
+}
+
+function dealer_get(int $dealer_id): ?array {
+  $st = pdo()->prepare("SELECT * FROM dealers WHERE id=? LIMIT 1");
+  $st->execute([$dealer_id]);
+  $row = $st->fetch();
+  return $row ?: null;
+}
+
+function dealer_find_by_email(string $email): ?array {
+  $st = pdo()->prepare("SELECT * FROM dealers WHERE email=? LIMIT 1");
+  $st->execute([$email]);
+  $row = $st->fetch();
+  return $row ?: null;
+}
+
+function dealer_status_badge(string $status): string {
+  return match ($status) {
+    DEALER_STATUS_ACTIVE   => 'Aktif',
+    DEALER_STATUS_INACTIVE => 'Pasif',
+    default                => 'Onay Bekliyor',
+  };
+}
+
+function dealer_has_valid_license(array $dealer): bool {
+  if (empty($dealer['license_expires_at'])) return false;
+  $exp = new DateTime($dealer['license_expires_at']);
+  $now = new DateTime('now');
+  return $exp >= $now;
+}
+
+function dealer_license_label(array $dealer): string {
+  if (empty($dealer['license_expires_at'])) {
+    return 'Tanımlı değil';
+  }
+  $exp = new DateTime($dealer['license_expires_at']);
+  return $exp->format('d.m.Y H:i');
+}
+
+function dealer_assign_venues(int $dealer_id, array $venue_ids): void {
+  $venue_ids = array_map('intval', $venue_ids);
+  $venue_ids = array_values(array_unique(array_filter($venue_ids)));
+  $pdo = pdo();
+  $pdo->beginTransaction();
+  try {
+    if ($venue_ids) {
+      $ph = implode(',', array_fill(0, count($venue_ids), '?'));
+      $params = array_merge([$dealer_id], $venue_ids);
+      $pdo->prepare("DELETE FROM dealer_venues WHERE dealer_id=? AND venue_id NOT IN ($ph)")
+          ->execute($params);
+    } else {
+      $pdo->prepare("DELETE FROM dealer_venues WHERE dealer_id=?")->execute([$dealer_id]);
+    }
+
+    $existing = $pdo->prepare("SELECT venue_id FROM dealer_venues WHERE dealer_id=?");
+    $existing->execute([$dealer_id]);
+    $current = array_map('intval', array_column($existing->fetchAll(), 'venue_id'));
+    foreach ($venue_ids as $vid) {
+      if (!in_array($vid, $current, true)) {
+        $pdo->prepare("INSERT INTO dealer_venues (dealer_id, venue_id, created_at) VALUES (?,?,?)")
+            ->execute([$dealer_id, $vid, now()]);
+      }
+    }
+    $pdo->commit();
+  } catch (Throwable $e) {
+    $pdo->rollBack();
+    throw $e;
+  }
+}
+
+function dealer_fetch_venues(int $dealer_id, bool $onlyActive = false): array {
+  $sql = "SELECT v.* FROM venues v INNER JOIN dealer_venues dv ON dv.venue_id=v.id WHERE dv.dealer_id=?";
+  if ($onlyActive) {
+    $sql .= " AND v.is_active=1";
+  }
+  $sql .= " ORDER BY v.name";
+  $st = pdo()->prepare($sql);
+  $st->execute([$dealer_id]);
+  return $st->fetchAll();
+}
+
+function dealer_event_belongs_to_dealer(int $dealer_id, int $event_id): bool {
+  $st = pdo()->prepare("SELECT 1 FROM events e INNER JOIN dealer_venues dv ON dv.venue_id=e.venue_id WHERE e.id=? AND dv.dealer_id=? LIMIT 1");
+  $st->execute([$event_id, $dealer_id]);
+  return (bool)$st->fetchColumn();
+}
+
+function dealer_allowed_events(int $dealer_id): array {
+  $st = pdo()->prepare("SELECT e.* FROM events e INNER JOIN dealer_venues dv ON dv.venue_id=e.venue_id WHERE dv.dealer_id=? ORDER BY e.event_date DESC, e.id DESC");
+  $st->execute([$dealer_id]);
+  return $st->fetchAll();
+}
+
+function dealer_sync_codes(int $dealer_id): array {
+  dealer_ensure_codes($dealer_id);
+  return dealer_get_codes($dealer_id);
+}
+
+function dealer_notify_new_application(array $dealer): void {
+  $to = defined('MAIL_FROM') && MAIL_FROM ? MAIL_FROM : 'info@localhost';
+  $subject = 'Yeni bayi başvurusu';
+  $html = '<h3>'.h(APP_NAME).' — Yeni Bayi Başvurusu</h3>'
+        . '<p><strong>Ad:</strong> '.h($dealer['name']).'</p>'
+        . '<p><strong>E-posta:</strong> '.h($dealer['email']).'</p>';
+  if (!empty($dealer['phone'])) {
+    $html .= '<p><strong>Telefon:</strong> '.h($dealer['phone']).'</p>';
+  }
+  if (!empty($dealer['company'])) {
+    $html .= '<p><strong>Firma:</strong> '.h($dealer['company']).'</p>';
+  }
+  if (!empty($dealer['notes'])) {
+    $html .= '<p><strong>Not:</strong><br>'.nl2br(h($dealer['notes'])).'</p>';
+  }
+  send_mail_simple($to, $subject, $html);
+}
+
+function dealer_send_application_receipt(array $dealer): void {
+  $html = '<h3>'.h(APP_NAME).' Bayi Başvurusu</h3>'
+        . '<p>Başvurunuz alınmıştır. İnceleme sonrasında size dönüş yapılacaktır.</p>';
+  send_mail_simple($dealer['email'], 'Başvurunuz alındı', $html);
+}
+
+function dealer_random_password(int $length = 10): string {
+  $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789';
+  $out = '';
+  $max = strlen($alphabet) - 1;
+  for ($i=0; $i<$length; $i++) {
+    $out .= $alphabet[random_int(0, $max)];
+  }
+  return $out;
+}
+
+function dealer_send_welcome_mail(array $dealer, string $plain_password): void {
+  $loginUrl = BASE_URL.'/dealer/login.php';
+  $html = '<h3>'.h(APP_NAME).' Bayi Paneli</h3>'
+        . '<p>Bayilik başvurunuz onaylandı.</p>'
+        . '<p><strong>Giriş E-postası:</strong> '.h($dealer['email']).'<br>'
+        . '<strong>Geçici Şifre:</strong> '.h($plain_password).'</p>'
+        . '<p><a href="'.h($loginUrl).'">Panele giriş yapın</a> ve ilk girişte şifrenizi değiştirin.</p>';
+  send_mail_simple($dealer['email'], 'Bayilik paneliniz hazır', $html);
+}
+
+function dealer_update_last_login(int $dealer_id): void {
+  pdo()->prepare("UPDATE dealers SET last_login_at=?, updated_at=? WHERE id=?")
+      ->execute([now(), now(), $dealer_id]);
+}
+
+function dealer_license_warning(array $dealer): ?string {
+  if (empty($dealer['license_expires_at'])) {
+    return 'Lisans süresi tanımlı değil.';
+  }
+  $exp = new DateTime($dealer['license_expires_at']);
+  $now = new DateTime('now');
+  if ($exp < $now) {
+    return 'Lisans süresi dolmuştur.';
+  }
+  $diff = $now->diff($exp);
+  if ($diff->days !== false && $diff->days <= 14) {
+    return 'Lisans süresi yakında ('.max(0, $diff->days).' gün) dolacak.';
+  }
+  return null;
+}
+
+function dealer_fetch_assigned_event_ids(int $dealer_id): array {
+  $st = pdo()->prepare("SELECT e.id FROM events e INNER JOIN dealer_venues dv ON dv.venue_id=e.venue_id WHERE dv.dealer_id=?");
+  $st->execute([$dealer_id]);
+  return array_map('intval', array_column($st->fetchAll(), 'id'));
+}

--- a/qr.php
+++ b/qr.php
@@ -7,8 +7,20 @@ $code=trim($_GET['code']??'');
 if ($code===''){ http_response_code(404); exit('QR yok'); }
 
 $st=pdo()->prepare("SELECT q.*, e.id AS ev_id FROM qr_codes q LEFT JOIN events e ON e.id=q.target_event_id WHERE q.code=?");
-$st->execute([$code]); $q=$st->fetch();
-if (!$q || !$q['ev_id']){ http_response_code(404); exit('Hedef yok'); }
+$st->execute([$code]);
+$q=$st->fetch();
+if ($q && $q['ev_id']){
+  $dest = public_upload_url((int)$q['ev_id']);
+  redirect($dest, 301);
+}
 
-$dest = public_upload_url((int)$q['ev_id']);
-redirect($dest, 301);
+$st2=pdo()->prepare("SELECT dc.*, e.id AS ev_id FROM dealer_codes dc LEFT JOIN events e ON e.id=dc.target_event_id WHERE dc.code=? LIMIT 1");
+$st2->execute([$code]);
+$dc=$st2->fetch();
+if ($dc && $dc['ev_id']){
+  $dest = public_upload_url((int)$dc['ev_id']);
+  redirect($dest, 301);
+}
+
+http_response_code(404);
+exit('Hedef yok');


### PR DESCRIPTION
## Summary
- extend the schema with dealer, dealer_venue, and dealer_code tables plus dealer_id linkage for events
- add reusable dealer helper utilities and authentication plus a full admin dealer management panel
- introduce dealer application, login, dashboard, and venue event management screens with QR code support
- surface dealer navigation in existing admin menus and allow shared QR redirects for dealer codes

## Testing
- php -l includes/dealers.php
- php -l includes/dealer_auth.php
- php -l dealer/login.php
- php -l dealer/dashboard.php
- php -l dealer/venue_events.php
- php -l dealer/apply.php
- php -l admin/dealers.php
- php -l admin/users.php
- php -l admin/venues.php
- php -l admin/dashboard.php
- php -l qr.php
- php -l includes/db.php

------
https://chatgpt.com/codex/tasks/task_e_68e062b7f0088324b0c1289e088aaa22