### PR TITLE
Add superadmin onboarding and refresh admin UI

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -4,6 +4,7 @@ require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
 
 require_admin();
 install_schema();
@@ -257,17 +258,18 @@ function fmt_bytes($b){
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?=h(APP_NAME)?> — Panel (<?=h($VNAME)?>)</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
 <style>
-  :root{ --zs:#0ea5b5; --zs-soft:#e0f7fb; --ink:#111827; --muted:#6b7280; }
-  body{ background:linear-gradient(180deg,var(--zs-soft),#fff) no-repeat }
-  .card-lite{ border:1px solid #eef2f7; border-radius:18px; background:#fff; box-shadow:0 6px 20px rgba(17,24,39,.05) }
-  .btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:12px; padding:.6rem 1rem; font-weight:600 }
-  .btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:12px; font-weight:600 }
-  .link-badge{ padding:.35rem .6rem; border-radius:10px; background:#f3f6fb; display:inline-block; }
-  .muted{ color:var(--muted) }
-  .title-chip{ padding:.35rem .7rem; border-radius:999px; background:#eef5ff; font-weight:600 }
-  .qr-img{ width:96px; height:96px; border-radius:12px; border:1px solid #e5e7eb }
-  .grid-compact .form-control, .grid-compact .form-select{ height:42px }
+  .qr-img{ width:96px; height:96px; border-radius:14px; border:1px solid rgba(148,163,184,.32); background:#fff; object-fit:cover; }
+  .grid-compact .form-control, .grid-compact .form-select{ height:46px; }
+  .section-heading{ display:flex; justify-content:space-between; align-items:center; gap:1rem; margin-bottom:1rem; }
+  .section-heading h5{ margin:0; font-weight:700; }
+  .muted{ color:var(--muted); }
+  .link-badge{ padding:.4rem .75rem; border-radius:12px; background:rgba(14,165,181,.12); font-weight:600; color:var(--brand-dark); display:inline-flex; align-items:center; gap:.4rem; }
+  .btn-zs{ background:var(--brand); border:none; color:#fff; border-radius:12px; font-weight:600; }
+  .btn-zs:hover{ background:var(--brand-dark); color:#fff; }
+  .btn-zs-outline{ background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
+  .btn-zs-outline:hover{ background:rgba(14,165,181,.12); color:var(--brand-dark); }
 </style>
 <script>
 function confirmSoftDelete(){
@@ -276,24 +278,12 @@ function confirmSoftDelete(){
 }
 </script>
 </head>
-<body>
-<nav class="navbar bg-white border-bottom">
+<body class="admin-body">
+<?php render_admin_topnav('dashboard', 'Panel Genel Bakış', 'Salon: '.$VNAME.' • Düğün ve kampanya yönetimi'); ?>
+
+<main class="admin-main">
   <div class="container">
-    <a class="navbar-brand fw-semibold" href="<?=h(BASE_URL)?>"><?=h(APP_NAME)?></a>
-    <div class="d-flex align-items-center gap-3 small">
-      <span class="title-chip">Salon: <?=h($VNAME)?></span>
-      <a class="text-decoration-none" href="<?=h(BASE_URL)?>/admin/venues.php">Salon Değiştir</a>
-      <span>•</span>
-      <span>Admin: <?= h($me['name'] ?? ($_SESSION['uname'] ?? 'Kullanıcı')) ?></span>
-      <span>•</span>
-
-      <a href="<?=h(BASE_URL)?>/admin/login.php?logout=1">Çıkış</a>
-    </div>
-  </div>
-</nav>
-
-<div class="container py-4">
-  <?php flash_box(); ?>
+    <?php flash_box(); ?>
 
   <!-- Kampanyalar -->
   <div id="cmp" class="card-lite p-3 mb-4">
@@ -569,6 +559,7 @@ function confirmSoftDelete(){
     <?php endif; ?>
   </div>
 
-</div>
+  </div>
+</main>
 </body>
 </html>

--- a/admin/dealers.php
+++ b/admin/dealers.php
@@ -1,0 +1,394 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
+
+require_admin();
+install_schema();
+
+function parse_license_input(?string $input): ?string {
+  if (!$input) return null;
+  try {
+    $dt = new DateTime($input);
+    return $dt->format('Y-m-d H:i:s');
+  } catch (Throwable $e) {
+    return null;
+  }
+}
+
+$action = $_POST['do'] ?? '';
+if ($action) {
+  csrf_or_die();
+}
+
+if ($action === 'create') {
+  $name  = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $phone = trim($_POST['phone'] ?? '');
+  $company = trim($_POST['company'] ?? '');
+  $notes = trim($_POST['notes'] ?? '');
+  $status = $_POST['status'] ?? DEALER_STATUS_PENDING;
+  $licenseInput = $_POST['license_expires_at'] ?? '';
+  $license = parse_license_input($licenseInput);
+
+  if ($name === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err', 'Ad ve geçerli e-posta gerekli.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+  if (dealer_find_by_email($email)) {
+    flash('err', 'Bu e-posta zaten kayıtlı.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+
+  $pdo = pdo();
+  $pdo->prepare("INSERT INTO dealers (name,email,phone,company,notes,status,license_expires_at,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?)")
+      ->execute([$name,$email,$phone,$company,$notes,$status,$license, now(), now()]);
+  $dealerId = (int)$pdo->lastInsertId();
+  dealer_ensure_codes($dealerId);
+
+  if ($status === DEALER_STATUS_ACTIVE) {
+    $plain = dealer_random_password();
+    $hash  = password_hash($plain, PASSWORD_DEFAULT);
+    $pdo->prepare("UPDATE dealers SET password_hash=?, approved_at=?, updated_at=? WHERE id=?")
+        ->execute([$hash, now(), now(), $dealerId]);
+    $dealer = dealer_get($dealerId);
+    dealer_send_welcome_mail($dealer, $plain);
+  }
+
+  flash('ok', 'Bayi kaydedildi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'update') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+
+  $name  = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $phone = trim($_POST['phone'] ?? '');
+  $company = trim($_POST['company'] ?? '');
+  $notes = trim($_POST['notes'] ?? '');
+  $status = $_POST['status'] ?? DEALER_STATUS_PENDING;
+  $licenseInput = $_POST['license_expires_at'] ?? '';
+  $license = parse_license_input($licenseInput);
+
+  if ($name === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err','Ad ve geçerli e-posta gerekli.');
+    redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+  }
+  $st = pdo()->prepare("SELECT id FROM dealers WHERE email=? AND id<>? LIMIT 1");
+  $st->execute([$email, $dealerId]);
+  if ($st->fetch()) {
+    flash('err','Bu e-posta başka bir bayide kayıtlı.');
+    redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+  }
+
+  pdo()->prepare("UPDATE dealers SET name=?, email=?, phone=?, company=?, notes=?, status=?, license_expires_at=?, updated_at=? WHERE id=?")
+      ->execute([$name,$email,$phone,$company,$notes,$status,$license, now(), $dealerId]);
+
+  if ($status === DEALER_STATUS_ACTIVE && empty($dealer['password_hash'])) {
+    $plain = dealer_random_password();
+    $hash  = password_hash($plain, PASSWORD_DEFAULT);
+    pdo()->prepare("UPDATE dealers SET password_hash=?, approved_at=?, updated_at=? WHERE id=?")
+        ->execute([$hash, now(), now(), $dealerId]);
+    $dealer = dealer_get($dealerId);
+    dealer_send_welcome_mail($dealer, $plain);
+  }
+
+  flash('ok','Bilgiler güncellendi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'assign_venues') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  $venues = $_POST['venue_ids'] ?? [];
+  dealer_assign_venues($dealerId, $venues);
+  flash('ok','Salon atamaları güncellendi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'regenerate_code') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $type = $_POST['type'] ?? DEALER_CODE_TRIAL;
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  dealer_regenerate_code($dealerId, $type);
+  flash('ok','Kod güncellendi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'set_code_event') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $type = $_POST['type'] ?? DEALER_CODE_STATIC;
+  $eventId = (int)($_POST['event_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  if ($eventId && !dealer_event_belongs_to_dealer($dealerId, $eventId)) {
+    flash('err','Seçilen düğün bu bayiye ait değil.');
+  } else {
+    dealer_set_code_target($dealerId, $type, $eventId ?: null);
+    flash('ok','Kod bağlantısı kaydedildi.');
+  }
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'send_password') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  if ($dealer['status'] !== DEALER_STATUS_ACTIVE) {
+    flash('err','Önce bayiyi aktif hale getirin.');
+    redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+  }
+  $plain = dealer_random_password();
+  $hash = password_hash($plain, PASSWORD_DEFAULT);
+  pdo()->prepare("UPDATE dealers SET password_hash=?, approved_at=COALESCE(approved_at,?), updated_at=? WHERE id=?")
+      ->execute([$hash, now(), now(), $dealerId]);
+  $dealer = dealer_get($dealerId);
+  dealer_send_welcome_mail($dealer, $plain);
+  flash('ok','Yeni şifre e-posta ile gönderildi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+$dealers = pdo()->query("SELECT * FROM dealers ORDER BY created_at DESC")->fetchAll();
+$selectedId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$selectedDealer = $selectedId ? dealer_get($selectedId) : null;
+$selectedCodes = $selectedDealer ? dealer_sync_codes($selectedId) : [];
+$assignedVenues = $selectedDealer ? dealer_fetch_venues($selectedId) : [];
+$assignedVenueIds = array_map(fn($v) => (int)$v['id'], $assignedVenues);
+$allVenues = pdo()->query("SELECT * FROM venues ORDER BY name")->fetchAll();
+$events = $selectedDealer ? dealer_allowed_events($selectedId) : [];
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Yönetimi</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
+<style>
+  .card-lite{ padding:1.5rem; }
+  .badge-status{padding:.35rem .75rem;border-radius:999px;font-size:.75rem;font-weight:600;}
+  .status-active{background:rgba(34,197,94,.15);color:#15803d;}
+  .status-pending{background:rgba(250,204,21,.18);color:#854d0e;}
+  .status-inactive{background:rgba(248,113,113,.16);color:#b91c1c;}
+  .dealer-list .card-lite{padding:1.2rem 1.5rem;}
+  .dealer-meta{color:var(--muted); font-size:.9rem;}
+  .dealer-meta strong{color:var(--ink);}
+  .tab-card{border-radius:18px; background:#fff; border:1px solid rgba(148,163,184,.16); box-shadow:0 22px 45px -28px rgba(15,23,42,.45);}
+</style>
+</head>
+<body class="admin-body">
+<?php render_admin_topnav('dealers', 'Bayi Yönetimi', 'Bayileri yönetin, salon atayın ve lisans durumlarını takip edin.'); ?>
+
+<main class="admin-main">
+  <div class="container">
+  <?php flash_box(); ?>
+  <div class="row g-4">
+    <div class="col-lg-5">
+      <div class="card-lite p-4 mb-4">
+        <h5 class="mb-3">Yeni Bayi Oluştur</h5>
+        <form method="post" class="row g-2">
+          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+          <input type="hidden" name="do" value="create">
+          <div class="col-12">
+            <label class="form-label">Ad Soyad</label>
+            <input class="form-control" name="name" required>
+          </div>
+          <div class="col-12">
+            <label class="form-label">E-posta</label>
+            <input type="email" class="form-control" name="email" required>
+          </div>
+          <div class="col-6">
+            <label class="form-label">Telefon</label>
+            <input class="form-control" name="phone">
+          </div>
+          <div class="col-6">
+            <label class="form-label">Firma</label>
+            <input class="form-control" name="company">
+          </div>
+          <div class="col-12">
+            <label class="form-label">Not</label>
+            <textarea class="form-control" name="notes" rows="2"></textarea>
+          </div>
+          <div class="col-6">
+            <label class="form-label">Durum</label>
+            <select class="form-select" name="status">
+              <option value="pending">Onay Bekliyor</option>
+              <option value="active">Aktif</option>
+              <option value="inactive">Pasif</option>
+            </select>
+          </div>
+          <div class="col-6">
+            <label class="form-label">Lisans Bitişi</label>
+            <input type="datetime-local" class="form-control" name="license_expires_at">
+          </div>
+          <div class="col-12 d-grid">
+            <button class="btn btn-brand" type="submit">Kaydet</button>
+          </div>
+        </form>
+      </div>
+      <div class="card-lite p-0">
+        <div class="p-3 border-bottom"><h5 class="m-0">Bayiler</h5></div>
+        <div class="list-group list-group-flush" style="max-height:420px;overflow:auto;">
+          <?php foreach ($dealers as $d): ?>
+            <?php
+              $badge = dealer_status_badge($d['status']);
+              $activeClass = ($selectedId === (int)$d['id']) ? 'active' : '';
+              $license = $d['license_expires_at'] ? date('d.m.Y', strtotime($d['license_expires_at'])) : '—';
+            ?>
+            <a href="?id=<?= (int)$d['id'] ?>" class="list-group-item list-group-item-action <?= $activeClass ?>">
+              <div class="fw-semibold"><?=h($d['name'])?></div>
+              <div class="d-flex justify-content-between small text-muted">
+                <span><?=h($badge)?></span>
+                <span>Lisans: <?=h($license)?></span>
+              </div>
+            </a>
+          <?php endforeach; ?>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-7">
+      <?php if (!$selectedDealer): ?>
+        <div class="card-lite p-4">
+          <h5 class="mb-2">Bayi seçin</h5>
+          <p class="text-muted">Soldaki listeden bir bayi seçerek detaylarını görüntüleyin.</p>
+        </div>
+      <?php else: ?>
+        <?php
+          $licenseValue = $selectedDealer['license_expires_at'] ? date('Y-m-d\TH:i', strtotime($selectedDealer['license_expires_at'])) : '';
+          $codes = $selectedCodes;
+        ?>
+        <div class="card-lite p-4 mb-4">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h5 class="m-0"><?=h($selectedDealer['name'])?></h5>
+            <form method="post" class="m-0">
+              <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+              <input type="hidden" name="do" value="send_password">
+              <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+              <button class="btn btn-sm btn-outline-primary" type="submit">Yeni Şifre Gönder</button>
+            </form>
+          </div>
+          <form method="post" class="row g-2">
+            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="do" value="update">
+            <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+            <div class="col-md-6">
+              <label class="form-label">Ad Soyad</label>
+              <input class="form-control" name="name" value="<?=h($selectedDealer['name'])?>" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">E-posta</label>
+              <input type="email" class="form-control" name="email" value="<?=h($selectedDealer['email'])?>" required>
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Telefon</label>
+              <input class="form-control" name="phone" value="<?=h($selectedDealer['phone'])?>">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Firma</label>
+              <input class="form-control" name="company" value="<?=h($selectedDealer['company'])?>">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Durum</label>
+              <select class="form-select" name="status">
+                <option value="pending" <?= $selectedDealer['status']==='pending'?'selected':'' ?>>Onay Bekliyor</option>
+                <option value="active" <?= $selectedDealer['status']==='active'?'selected':'' ?>>Aktif</option>
+                <option value="inactive" <?= $selectedDealer['status']==='inactive'?'selected':'' ?>>Pasif</option>
+              </select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Lisans Bitiş</label>
+              <input type="datetime-local" class="form-control" name="license_expires_at" value="<?=h($licenseValue)?>">
+            </div>
+            <div class="col-12">
+              <label class="form-label">Not</label>
+              <textarea class="form-control" name="notes" rows="2"><?=h($selectedDealer['notes'])?></textarea>
+            </div>
+            <div class="col-12 d-grid">
+              <button class="btn btn-brand" type="submit">Bilgileri Güncelle</button>
+            </div>
+          </form>
+        </div>
+
+        <div class="card-lite p-4 mb-4">
+          <h5 class="mb-3">Salon Atamaları</h5>
+          <form method="post" class="row g-3">
+            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="do" value="assign_venues">
+            <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+            <div class="col-12">
+              <select class="form-select" name="venue_ids[]" multiple size="8">
+                <?php foreach ($allVenues as $v): ?>
+                  <option value="<?= (int)$v['id'] ?>" <?= in_array((int)$v['id'], $assignedVenueIds, true) ? 'selected' : '' ?>><?=h($v['name'])?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <div class="col-12 d-grid">
+              <button class="btn btn-outline-primary" type="submit">Atamaları Kaydet</button>
+            </div>
+          </form>
+        </div>
+
+        <div class="card-lite p-4">
+          <h5 class="mb-3">Kodlar</h5>
+          <div class="row g-3">
+            <?php foreach ([DEALER_CODE_STATIC=>'Kalıcı Kod', DEALER_CODE_TRIAL=>'Deneme Kodu'] as $type=>$label):
+              $code = $codes[$type] ?? null;
+              $url = $code ? BASE_URL.'/qr.php?code='.urlencode($code['code']) : '';
+            ?>
+            <div class="col-md-6">
+              <div class="border rounded-3 p-3 h-100">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                  <h6 class="mb-0"><?=h($label)?></h6>
+                  <form method="post" class="m-0">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="regenerate_code">
+                    <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+                    <input type="hidden" name="type" value="<?=h($type)?>">
+                    <button class="btn btn-sm btn-outline-secondary" type="submit">Yenile</button>
+                  </form>
+                </div>
+                <?php if ($code): ?>
+                  <p class="fw-semibold">Kod: <?=h($code['code'])?></p>
+                  <p class="small text-muted"><a href="<?=h($url)?>" target="_blank">QR bağlantısı</a></p>
+                  <form method="post" class="vstack gap-2">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="set_code_event">
+                    <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+                    <input type="hidden" name="type" value="<?=h($type)?>">
+                    <label class="form-label small">Bağlı düğün</label>
+                    <select class="form-select form-select-sm" name="event_id">
+                      <option value="0">— Seçili değil —</option>
+                      <?php foreach ($events as $ev): ?>
+                        <?php
+                          $sel = ($code['target_event_id'] ?? null) == $ev['id'] ? 'selected' : '';
+                          $dateLabel = $ev['event_date'] ? date('d.m.Y', strtotime($ev['event_date'])) : 'Tarihsiz';
+                        ?>
+                        <option value="<?= (int)$ev['id'] ?>" <?=$sel?>><?=h($dateLabel.' • '.$ev['title'])?></option>
+                      <?php endforeach; ?>
+                    </select>
+                    <button class="btn btn-sm btn-brand" type="submit">Kaydet</button>
+                  </form>
+                <?php else: ?>
+                  <p class="text-muted">Kod oluşturulamadı.</p>
+                <?php endif; ?>
+              </div>
+            </div>
+            <?php endforeach; ?>
+          </div>
+        </div>
+      <?php endif; ?>
+    </div>
+  </div>
+  </div>
+</main>
+</body>
+</html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -17,13 +17,41 @@ if (is_admin_logged_in()) {
   redirect($next);
 }
 
-// İlk admin yoksa oluşturmak için (ilk kurulumda 1 kez aktif edin, sonra bu satırı silebilirsiniz)
-// ensure_first_admin('admin@site.com', 'Sifre123', 'Yönetici');
-
+$firstRun = ((int)pdo()->query("SELECT COUNT(*) FROM users")->fetchColumn()) === 0;
+$mode = $firstRun ? 'setup' : 'login';
 $err = null;
 
+if ($mode === 'setup' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+  csrf_or_die();
+
+  $name  = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $pass  = (string)($_POST['password'] ?? '');
+  $pass2 = (string)($_POST['password_confirm'] ?? '');
+
+  if (mb_strlen($name) < 3) {
+    $err = 'Lütfen en az 3 karakterlik bir ad girin.';
+  } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    $err = 'Geçerli bir e-posta adresi girin.';
+  } elseif (mb_strlen($pass) < 8) {
+    $err = 'Şifre en az 8 karakter olmalıdır.';
+  } elseif ($pass !== $pass2) {
+    $err = 'Şifreler eşleşmiyor.';
+  } else {
+    try {
+      pdo()->prepare("INSERT INTO users (email,password_hash,name,role,created_at,updated_at) VALUES (?,?,?,?,?,?)")
+          ->execute([$email, password_hash($pass, PASSWORD_DEFAULT), $name, 'superadmin', now(), now()]);
+      admin_login($email, $pass);
+      flash('ok', 'İlk yönetici hesabı hazır!');
+      redirect('dashboard.php');
+    } catch (Throwable $e) {
+      $err = 'Hesap oluşturulamadı. Lütfen bilgileri kontrol edin.';
+    }
+  }
+}
+
 // Giriş denemesi
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+if ($mode === 'login' && $_SERVER['REQUEST_METHOD'] === 'POST') {
   csrf_or_die(); // CSRF kontrolü
 
   $email = trim($_POST['email'] ?? '');
@@ -34,9 +62,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $err = 'E-posta ve şifre zorunludur.';
   } else {
     if (admin_login($email, $pass)) {
-      // Başarılı → yönlendir
-      // İsteğe bağlı: admin adını session'a yazmak istiyorsanız:
-      // $_SESSION['uname'] = admin_user()['name'] ?? $email;
       redirect($next);
     } else {
       $err = 'E-posta veya şifre hatalı.';
@@ -52,21 +77,31 @@ $next = $_GET['next'] ?? ($_POST['next'] ?? 'dashboard.php');
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Yönetici Girişi — <?=h(APP_NAME)?></title>
+  <title><?= $mode === 'setup' ? 'İlk Yönetici Kurulumu' : 'Yönetici Girişi' ?> — <?=h(APP_NAME)?></title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
-    :root{ --zs:#0ea5b5; }
-    body{ min-height:100vh; display:flex; align-items:center; justify-content:center; background:linear-gradient(180deg,#f0fbfd,#fff) }
-    .cardx{ width:100%; max-width:420px; background:#fff; border:1px solid #e9eef5; border-radius:18px; box-shadow:0 10px 30px rgba(2,6,23,.06) }
-    .btn-zs{ background:var(--zs); color:#fff; border:none; border-radius:12px; padding:.65rem 1rem; font-weight:700 }
-    .brand{ font-weight:800; letter-spacing:.2px; }
+    :root{ --brand:#0ea5b5; --brand-dark:#0b8b98; --ink:#0f172a; --muted:#64748b; }
+    body{ min-height:100vh; margin:0; background:linear-gradient(135deg,rgba(14,165,181,.18),rgba(14,165,181,.04)); font-family:'Inter','Segoe UI',system-ui,-apple-system,sans-serif; display:flex; align-items:center; justify-content:center; padding:2rem; color:var(--ink); }
+    .auth-card{ width:100%; max-width:460px; background:#fff; border-radius:22px; border:1px solid rgba(148,163,184,.18); box-shadow:0 32px 60px -30px rgba(15,23,42,.4); padding:2.8rem 2.4rem; }
+    .brand{ font-weight:800; font-size:1.4rem; letter-spacing:.3px; }
+    .subtitle{ color:var(--muted); font-size:.95rem; }
+    .btn-brand{ background:var(--brand); color:#fff; border:none; border-radius:12px; padding:.7rem 1.1rem; font-weight:600; }
+    .btn-brand:hover{ background:var(--brand-dark); color:#fff; }
+    label{ font-weight:600; color:var(--muted); }
+    .form-control{ border-radius:12px; border:1px solid rgba(148,163,184,.35); padding:.65rem .85rem; }
+    .form-control:focus{ border-color:var(--brand); box-shadow:0 0 0 .2rem rgba(14,165,181,.15); }
+    .alert{ border-radius:12px; }
+    .first-run-badge{ display:inline-flex; align-items:center; gap:.4rem; background:rgba(14,165,181,.12); color:var(--brand-dark); padding:.35rem .85rem; border-radius:999px; font-weight:600; font-size:.82rem; }
   </style>
 </head>
 <body>
-  <div class="cardx p-4">
-    <div class="mb-3 text-center">
-      <div class="brand"><?=h(APP_NAME)?></div>
-      <div class="text-muted small">Yönetici Paneli</div>
+  <div class="auth-card">
+    <div class="mb-4 text-center">
+      <?php if ($mode === 'setup'): ?>
+        <span class="first-run-badge">🚀 İlk Kurulum</span>
+      <?php endif; ?>
+      <div class="brand mt-2"><?=h(APP_NAME)?></div>
+      <div class="subtitle">Yönetim Paneli</div>
     </div>
 
     <?php if ($m = flash('ok')): ?>
@@ -76,18 +111,46 @@ $next = $_GET['next'] ?? ($_POST['next'] ?? 'dashboard.php');
       <div class="alert alert-danger"><?=$err?></div>
     <?php endif; ?>
 
-    <form method="post" class="vstack gap-2">
-      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-      <input type="hidden" name="next" value="<?=h($next)?>">
-      <label class="form-label">E-posta</label>
-      <input class="form-control" type="email" name="email" required autofocus>
-      <label class="form-label mt-2">Şifre</label>
-      <input class="form-control" type="password" name="password" required>
-      <button class="btn btn-zs mt-3 w-100">Giriş Yap</button>
-    </form>
+    <?php if ($mode === 'setup'): ?>
+      <form method="post" class="vstack gap-3">
+        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+        <div>
+          <label class="form-label">Ad Soyad</label>
+          <input class="form-control" type="text" name="name" required autofocus placeholder="Örn. Ayşe Yılmaz">
+        </div>
+        <div>
+          <label class="form-label">E-posta</label>
+          <input class="form-control" type="email" name="email" required placeholder="ornek@firma.com">
+        </div>
+        <div>
+          <label class="form-label">Şifre</label>
+          <input class="form-control" type="password" name="password" required placeholder="En az 8 karakter">
+        </div>
+        <div>
+          <label class="form-label">Şifre (Tekrar)</label>
+          <input class="form-control" type="password" name="password_confirm" required>
+        </div>
+        <button class="btn btn-brand mt-2 w-100">İlk Süperadmini Oluştur</button>
+      </form>
+      <p class="subtitle text-center mt-3">Bu hesap süperadmin yetkisine sahip olacak ve diğer yöneticileri davet edebilecek.</p>
+    <?php else: ?>
+      <form method="post" class="vstack gap-3">
+        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+        <input type="hidden" name="next" value="<?=h($next)?>">
+        <div>
+          <label class="form-label">E-posta</label>
+          <input class="form-control" type="email" name="email" required autofocus>
+        </div>
+        <div>
+          <label class="form-label">Şifre</label>
+          <input class="form-control" type="password" name="password" required>
+        </div>
+        <button class="btn btn-brand mt-2 w-100">Giriş Yap</button>
+      </form>
+    <?php endif; ?>
 
-    <div class="mt-3 text-center">
-      <a class="small" href="../index.php">Ana sayfa</a>
+    <div class="mt-4 text-center">
+      <a class="text-decoration-none" href="../index.php">← Ana sayfaya dön</a>
     </div>
   </div>
 </body>

--- a/admin/partials/ui.php
+++ b/admin/partials/ui.php
@@ -1,0 +1,98 @@
+<?php
+if (!function_exists('admin_base_styles')) {
+  function admin_base_styles(): string {
+    return <<<'CSS'
+    <style>
+      :root{
+        --brand:#0ea5b5;
+        --brand-dark:#0b8b98;
+        --ink:#0f172a;
+        --muted:#64748b;
+        --surface:#ffffff;
+        --soft:#f1f7fb;
+      }
+      body.admin-body{background:var(--soft);color:var(--ink);min-height:100vh;font-family:'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;}
+      .admin-topnav{background:var(--surface);border-bottom:1px solid rgba(148,163,184,.22);box-shadow:0 10px 30px rgba(15,23,42,.05);position:sticky;top:0;z-index:1030;}
+      .admin-topnav .navbar-brand{font-weight:700;letter-spacing:.2px;color:var(--ink);}
+      .admin-topnav .navbar-toggler{border-color:rgba(148,163,184,.45);}
+      .admin-topnav .navbar-toggler:focus{box-shadow:0 0 0 .2rem rgba(14,165,181,.25);}
+      .admin-topnav .navbar-toggler-icon{background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(15,23,42,0.7)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");}
+      .admin-topnav .nav-link{font-weight:600;color:var(--muted);border-radius:12px;padding:.45rem .95rem;}
+      .admin-topnav .nav-link:hover{color:var(--brand-dark);background:rgba(14,165,181,.08);}
+      .admin-topnav .nav-link.active{color:var(--brand);background:rgba(14,165,181,.14);}
+      .admin-topnav .user-chip{background:rgba(14,165,181,.12);border-radius:999px;padding:.35rem .85rem;font-size:.85rem;color:var(--brand-dark);font-weight:600;}
+      .admin-hero{background:linear-gradient(120deg,rgba(14,165,181,.18),rgba(14,165,181,.04));padding:2.4rem 0 1.9rem;margin-bottom:2rem;}
+      .admin-hero h1{font-weight:700;margin-bottom:.35rem;}
+      .admin-hero p{margin:0;color:var(--muted);font-size:.97rem;max-width:720px;}
+      .admin-main{padding-bottom:4rem;}
+      .card-lite{border-radius:20px;background:var(--surface);border:1px solid rgba(148,163,184,.18);box-shadow:0 28px 50px -32px rgba(15,23,42,.55);}
+      .card-section{padding:1.7rem 1.5rem;}
+      .btn-brand{background:var(--brand);border:none;color:#fff;border-radius:12px;font-weight:600;padding:.58rem 1.3rem;}
+      .btn-brand:hover{background:var(--brand-dark);color:#fff;}
+      .btn-brand-outline{background:#fff;border:1px solid rgba(14,165,181,.6);color:var(--brand);border-radius:12px;font-weight:600;padding:.55rem 1.2rem;}
+      .badge-soft{background:rgba(14,165,181,.12);color:var(--brand-dark);border-radius:999px;padding:.35rem .75rem;font-size:.75rem;font-weight:600;}
+      .table thead th{color:var(--muted);font-weight:600;text-transform:uppercase;font-size:.75rem;letter-spacing:.04em;border-bottom:1px solid rgba(148,163,184,.25);}
+      .table tbody td{vertical-align:middle;}
+      .form-control, .form-select{border-radius:12px;border:1px solid rgba(148,163,184,.45);padding:.6rem .75rem;}
+      .form-control:focus, .form-select:focus{border-color:var(--brand);box-shadow:0 0 0 .2rem rgba(14,165,181,.15);}
+      @media (max-width: 991px){
+        .admin-topnav{position:static;}
+        .admin-hero{padding:1.7rem 0 1.2rem;margin-bottom:1.2rem;}
+      }
+      @media print{
+        .admin-header, .admin-hero{display:none !important;}
+        body.admin-body{background:#fff;}
+        .admin-main{padding:0;}
+      }
+    </style>
+CSS;
+  }
+
+  function render_admin_topnav(string $active = '', string $title = '', string $subtitle = ''): void {
+    $me = admin_user();
+    $links = [
+      'dashboard' => ['href' => BASE_URL.'/admin/dashboard.php', 'label' => 'Genel Bakış'],
+      'venues'    => ['href' => BASE_URL.'/admin/venues.php',    'label' => 'Salonlar'],
+      'users'     => ['href' => BASE_URL.'/admin/users.php',     'label' => 'Çiftler'],
+      'dealers'   => ['href' => BASE_URL.'/admin/dealers.php',   'label' => 'Bayiler'],
+    ];
+    if (is_superadmin()) {
+      $links['team'] = ['href' => BASE_URL.'/admin/team.php', 'label' => 'Yönetim'];
+    }
+    echo '<header class="admin-header">';
+    echo '<nav class="admin-topnav navbar navbar-expand-lg">';
+    echo '<div class="container">';
+    echo '<a class="navbar-brand" href="'.h(BASE_URL.'/admin/dashboard.php').'">'.h(APP_NAME).'</a>';
+    echo '<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false" aria-label="Menü">';
+    echo '<span class="navbar-toggler-icon"></span>';
+    echo '</button>';
+    echo '<div class="collapse navbar-collapse" id="adminNav">';
+    echo '<ul class="navbar-nav me-auto mb-2 mb-lg-0">';
+    foreach ($links as $key => $link) {
+      $cls = 'nav-link'.($active === $key ? ' active' : '');
+      echo '<li class="nav-item"><a class="'.$cls.'" href="'.h($link['href']).'">'.h($link['label']).'</a></li>';
+    }
+    echo '</ul>';
+    echo '<div class="d-flex align-items-center gap-3 mb-2 mb-lg-0">';
+    if ($me) {
+      $roleLabel = is_superadmin() ? 'Süperadmin' : 'Admin';
+      echo '<span class="user-chip">'.h($me['name'] ?? $me['email']).' • '.h($roleLabel).'</span>';
+    }
+    echo '<a class="text-decoration-none fw-semibold" href="'.h(BASE_URL.'/admin/login.php?logout=1').'">Çıkış</a>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
+    echo '</nav>';
+    if ($title !== '') {
+      echo '<div class="admin-hero">';
+      echo '<div class="container">';
+      echo '<h1>'.h($title).'</h1>';
+      if ($subtitle !== '') {
+        echo '<p>'.h($subtitle).'</p>';
+      }
+      echo '</div>';
+      echo '</div>';
+    }
+    echo '</header>';
+  }
+}

--- a/admin/team.php
+++ b/admin/team.php
@@ -1,0 +1,240 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
+
+require_admin();
+require_superadmin();
+install_schema();
+
+function superadmin_count(): int {
+  return (int)pdo()->query("SELECT COUNT(*) FROM users WHERE role='superadmin'")->fetchColumn();
+}
+
+$me = admin_user();
+$action = $_POST['do'] ?? '';
+if ($action) {
+  csrf_or_die();
+}
+
+if ($action === 'create') {
+  $name  = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $role  = $_POST['role'] ?? 'admin';
+  $pass  = (string)($_POST['password'] ?? '');
+  $pass2 = (string)($_POST['password_confirm'] ?? '');
+
+  if (mb_strlen($name) < 3) {
+    flash('err', 'Ad en az 3 karakter olmalıdır.');
+  } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err', 'Geçerli bir e-posta girin.');
+  } elseif (!in_array($role, ['admin','superadmin'], true)) {
+    flash('err', 'Geçersiz rol seçimi.');
+  } elseif (mb_strlen($pass) < 8) {
+    flash('err', 'Şifre en az 8 karakter olmalıdır.');
+  } elseif ($pass !== $pass2) {
+    flash('err', 'Şifreler eşleşmiyor.');
+  } else {
+    $st = pdo()->prepare("SELECT id FROM users WHERE email=? LIMIT 1");
+    $st->execute([$email]);
+    if ($st->fetch()) {
+      flash('err', 'Bu e-posta ile kayıtlı bir yönetici zaten var.');
+    } else {
+      pdo()->prepare("INSERT INTO users (email,password_hash,name,role,created_at,updated_at) VALUES (?,?,?,?,?,?)")
+          ->execute([$email, password_hash($pass, PASSWORD_DEFAULT), $name, $role, now(), now()]);
+      flash('ok', 'Yeni yönetici hesabı oluşturuldu.');
+    }
+  }
+  redirect($_SERVER['REQUEST_URI']);
+}
+
+if ($action === 'update_role') {
+  $userId = (int)($_POST['user_id'] ?? 0);
+  $role   = $_POST['role'] ?? 'admin';
+  if (!in_array($role, ['admin','superadmin'], true)) {
+    flash('err', 'Geçersiz rol seçimi.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  $st = pdo()->prepare("SELECT id, role FROM users WHERE id=? LIMIT 1");
+  $st->execute([$userId]);
+  $target = $st->fetch();
+  if (!$target) {
+    flash('err', 'Kullanıcı bulunamadı.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  if ($target['role'] === 'superadmin' && $role !== 'superadmin' && superadmin_count() <= 1) {
+    flash('err', 'Sistemde en az bir süperadmin kalmalıdır.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  pdo()->prepare("UPDATE users SET role=?, updated_at=? WHERE id=?")
+      ->execute([$role, now(), $userId]);
+  if ($userId === ($me['id'] ?? 0)) {
+    $_SESSION['admin']['role'] = $role;
+  }
+  flash('ok', 'Rol güncellendi.');
+  redirect($_SERVER['REQUEST_URI']);
+}
+
+if ($action === 'reset_password') {
+  $userId = (int)($_POST['user_id'] ?? 0);
+  $pass   = (string)($_POST['password'] ?? '');
+  $pass2  = (string)($_POST['password_confirm'] ?? '');
+  if (mb_strlen($pass) < 8) {
+    flash('err', 'Yeni şifre en az 8 karakter olmalıdır.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  if ($pass !== $pass2) {
+    flash('err', 'Yeni şifreler eşleşmiyor.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  $st = pdo()->prepare("SELECT id FROM users WHERE id=? LIMIT 1");
+  $st->execute([$userId]);
+  if (!$st->fetch()) {
+    flash('err', 'Kullanıcı bulunamadı.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  pdo()->prepare("UPDATE users SET password_hash=?, updated_at=? WHERE id=?")
+      ->execute([password_hash($pass, PASSWORD_DEFAULT), now(), $userId]);
+  if ($userId === ($me['id'] ?? 0)) {
+    flash('ok', 'Şifreniz güncellendi.');
+  } else {
+    flash('ok', 'Şifre başarıyla sıfırlandı.');
+  }
+  redirect($_SERVER['REQUEST_URI']);
+}
+
+$admins = pdo()->query("SELECT id, name, email, role, created_at, last_login_at FROM users ORDER BY created_at DESC")->fetchAll();
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title><?=h(APP_NAME)?> — Yönetici Ekibi</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <?=admin_base_styles()?>
+  <style>
+    .team-card{ border-radius:20px; border:1px solid rgba(148,163,184,.16); box-shadow:0 22px 45px -30px rgba(15,23,42,.45); }
+    .role-chip{ display:inline-flex; align-items:center; gap:.35rem; padding:.35rem .8rem; border-radius:999px; font-weight:600; }
+    .role-chip.admin{ background:rgba(148,163,184,.2); color:#475569; }
+    .role-chip.superadmin{ background:rgba(14,165,181,.16); color:#0b8b98; }
+    details summary{ cursor:pointer; font-weight:600; color:var(--brand); }
+    details summary::-webkit-details-marker{ display:none; }
+    details[open] summary{ color:var(--brand-dark); }
+  </style>
+</head>
+<body class="admin-body">
+<?php render_admin_topnav('team', 'Yönetici Ekibi', 'Süperadmin ve admin rollerini yönetin, ekip arkadaşlarınızı davet edin.'); ?>
+
+<main class="admin-main">
+  <div class="container">
+    <?php flash_box(); ?>
+
+    <div class="row g-4">
+      <div class="col-lg-4">
+        <div class="card-lite p-4 team-card">
+          <h5 class="mb-3">Yeni Yönetici Davet Et</h5>
+          <form method="post" class="vstack gap-3">
+            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="do" value="create">
+            <div>
+              <label class="form-label">Ad Soyad</label>
+              <input class="form-control" name="name" required placeholder="Örn. Mehmet Kara">
+            </div>
+            <div>
+              <label class="form-label">E-posta</label>
+              <input class="form-control" type="email" name="email" required placeholder="ornek@firma.com">
+            </div>
+            <div>
+              <label class="form-label">Rol</label>
+              <select class="form-select" name="role">
+                <option value="admin">Admin</option>
+                <option value="superadmin">Süperadmin</option>
+              </select>
+            </div>
+            <div>
+              <label class="form-label">Geçici Şifre</label>
+              <input class="form-control" type="password" name="password" required placeholder="En az 8 karakter">
+            </div>
+            <div>
+              <label class="form-label">Şifre (Tekrar)</label>
+              <input class="form-control" type="password" name="password_confirm" required>
+            </div>
+            <button class="btn btn-brand mt-2">Yöneticiyi Oluştur</button>
+            <p class="text-muted small mb-0">Hesap oluşturulduktan sonra parolayı paylaşmayı unutmayın. Girişte değiştirilebilir.</p>
+          </form>
+        </div>
+      </div>
+
+      <div class="col-lg-8">
+        <div class="card-lite p-4 team-card">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h5 class="mb-0">Mevcut Yöneticiler</h5>
+            <span class="text-muted small">Toplam <?=count($admins)?> yönetici</span>
+          </div>
+          <div class="table-responsive">
+            <table class="table align-middle">
+              <thead>
+                <tr>
+                  <th>Adı</th>
+                  <th>E-posta</th>
+                  <th>Rol</th>
+                  <th>Son Giriş</th>
+                  <th class="text-end">İşlemler</th>
+                </tr>
+              </thead>
+              <tbody>
+                <?php foreach ($admins as $admin): ?>
+                  <tr>
+                    <td>
+                      <div class="fw-semibold"><?=h($admin['name'] ?: '—')?><?= $admin['id'] === ($me['id'] ?? 0) ? ' <span class="badge bg-info">Siz</span>' : '' ?></div>
+                      <div class="text-muted small">Oluşturulma: <?=h($admin['created_at'])?></div>
+                    </td>
+                    <td><?=h($admin['email'])?></td>
+                    <td>
+                      <span class="role-chip <?=h($admin['role'])?>"><?= $admin['role'] === 'superadmin' ? 'Süperadmin' : 'Admin' ?></span>
+                    </td>
+                    <td>
+                      <?php if ($admin['last_login_at']): ?>
+                        <span class="text-muted small"><?=h($admin['last_login_at'])?></span>
+                      <?php else: ?>
+                        <span class="text-muted small">Henüz giriş yapmadı</span>
+                      <?php endif; ?>
+                    </td>
+                    <td class="text-end">
+                      <form method="post" class="d-inline-flex gap-2 align-items-center flex-wrap justify-content-end">
+                        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                        <input type="hidden" name="do" value="update_role">
+                        <input type="hidden" name="user_id" value="<?=$admin['id']?>">
+                        <select class="form-select form-select-sm" name="role">
+                          <option value="admin" <?=$admin['role']==='admin'?'selected':''?>>Admin</option>
+                          <option value="superadmin" <?=$admin['role']==='superadmin'?'selected':''?>>Süperadmin</option>
+                        </select>
+                        <button class="btn btn-sm btn-brand-outline" type="submit">Rolü Kaydet</button>
+                      </form>
+                      <details class="mt-2">
+                        <summary>Parola Sıfırla</summary>
+                        <form method="post" class="vstack gap-2 mt-2">
+                          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                          <input type="hidden" name="do" value="reset_password">
+                          <input type="hidden" name="user_id" value="<?=$admin['id']?>">
+                          <input class="form-control form-control-sm" type="password" name="password" placeholder="Yeni şifre" required>
+                          <input class="form-control form-control-sm" type="password" name="password_confirm" placeholder="Şifre tekrar" required>
+                          <button class="btn btn-sm btn-brand" type="submit">Parolayı Güncelle</button>
+                        </form>
+                      </details>
+                    </td>
+                  </tr>
+                <?php endforeach; ?>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/admin/users.php
+++ b/admin/users.php
@@ -4,6 +4,7 @@ require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
 
 require_admin();
 install_schema();
@@ -141,35 +142,28 @@ if ($detail_id) {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?=h(APP_NAME)?> — Kullanıcılar & Ödemeler</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
 <style>
-  :root{ --zs:#0ea5b5; --ink:#0f172a; --muted:#64748b; --soft:#f6fbfd; }
-  body{ background:linear-gradient(180deg,#eef8fb,#fff) no-repeat; color:var(--ink) }
-  .card-lite{ border:1px solid #e8eff5; border-radius:18px; background:#fff; box-shadow:0 6px 20px rgba(2,6,23,.05) }
-  .btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600 }
-  .btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:12px; font-weight:600 }
-  .muted{ color:var(--muted) }
-  .badge-soft{ background:#eef5ff; color:#334155 }
+  .card-lite{ border-radius:20px; border:1px solid rgba(148,163,184,.16); box-shadow:0 18px 45px -28px rgba(15,23,42,.4); }
+  .btn-zs{ background:var(--brand); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600; }
+  .btn-zs:hover{ background:var(--brand-dark); color:#fff; }
+  .btn-zs-outline{ background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
+  .btn-zs-outline:hover{ background:rgba(14,165,181,.12); color:var(--brand-dark); }
+  .muted{ color:var(--muted); }
+  .badge-soft{ background:rgba(14,165,181,.14); color:var(--brand-dark); border-radius:999px; padding:.3rem .7rem; font-weight:600; }
   @media print{
-    .no-print{ display:none !important }
-    body{ background:#fff }
-    .card-lite{ border:none; box-shadow:none }
-    table{ font-size:12px }
+    .admin-header, .admin-hero, .no-print{ display:none !important; }
+    body.admin-body{ background:#fff; }
+    .card-lite{ border:none; box-shadow:none; }
+    table{ font-size:12px; }
   }
 </style>
 </head>
-<body>
-<nav class="navbar bg-white border-bottom no-print">
-  <div class="container">
-    <a class="navbar-brand fw-semibold" href="<?=h(BASE_URL)?>"><?=h(APP_NAME)?></a>
-    <div class="small">
-      <a href="<?=h(BASE_URL)?>/admin/dashboard.php" class="text-decoration-none">Panel</a>
-      <span class="mx-2">•</span>
-      <a href="<?=h(BASE_URL)?>/admin/login.php?logout=1" class="text-decoration-none">Çıkış</a>
-    </div>
-  </div>
-</nav>
+<body class="admin-body">
+<?php render_admin_topnav('users', 'Çiftler & Ödemeler', 'Etkinlik hesaplarını, lisans sürelerini ve ödeme durumlarını inceleyin.'); ?>
 
-<div class="container py-4">
+<main class="admin-main">
+  <div class="container">
   <?php flash_box(); ?>
 
   <!-- Filtreler -->
@@ -360,6 +354,7 @@ if ($detail_id) {
       </div>
     <?php endif; ?>
   </div>
-</div>
+  </div>
+</main>
 </body>
 </html>

--- a/admin/venue_events.php
+++ b/admin/venue_events.php
@@ -4,6 +4,7 @@ require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
 
 require_admin();
 install_schema();
@@ -200,34 +201,23 @@ if (isset($_GET['export']) && $_GET['export']==='pdf') {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?=h(APP_NAME)?> — <?=h($VNAME)?> / Düğünler</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
 <style>
-  :root{ --zs:#0ea5b5; --zs-soft:#e0f7fb; --ink:#0f172a; --muted:#6b7280; }
-  body{ background:linear-gradient(180deg,var(--zs-soft),#fff) no-repeat }
-  .card-lite{ border:1px solid #eef2f7; border-radius:18px; background:#fff; box-shadow:0 6px 20px rgba(17,24,39,.05) }
-  .btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600 }
-  .btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:12px; font-weight:600 }
-  .muted{ color:var(--muted) }
-  .group-title{ font-weight:800; color:#0f172a; margin:8px 0 6px }
-  .badge-soft{ background:#eef5ff; color:#334155; border-radius:999px; padding:.25rem .55rem; font-weight:600 }
+  .btn-zs{ background:var(--brand); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600; }
+  .btn-zs:hover{ background:var(--brand-dark); color:#fff; }
+  .btn-zs-outline{ background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
+  .btn-zs-outline:hover{ background:rgba(14,165,181,.12); color:var(--brand-dark); }
+  .muted{ color:var(--muted); }
+  .group-title{ font-weight:800; color:var(--ink); margin:8px 0 6px; }
+  .badge-soft{ background:rgba(14,165,181,.14); color:var(--brand-dark); border-radius:999px; padding:.25rem .55rem; font-weight:600; }
   .table td, .table th { vertical-align: middle; }
 </style>
 </head>
-<body>
-<nav class="navbar bg-white border-bottom">
-  <div class="container">
-    <a class="navbar-brand fw-semibold" href="<?=h(BASE_URL)?>"><?=h(APP_NAME)?></a>
-    <div class="small d-flex align-items-center gap-3">
-      <span class="badge-soft">Salon: <?=h($VNAME)?></span>
-      <a class="text-decoration-none" href="venues.php">Salon Değiştir</a>
-      <span>•</span>
-      <a class="text-decoration-none" href="dashboard.php">Panel</a>
-      <span>•</span>
-      <a class="text-decoration-none" href="login.php?logout=1">Çıkış</a>
-    </div>
-  </div>
-</nav>
+<body class="admin-body">
+<?php render_admin_topnav('venues', 'Salon Düğünleri', 'Salon: '.$VNAME.' için etkinlik listesi'); ?>
 
-<div class="container py-4">
+<main class="admin-main">
+  <div class="container">
   <?php flash_box(); ?>
 
   <!-- Filtre + PDF -->
@@ -315,6 +305,7 @@ if (isset($_GET['export']) && $_GET['export']==='pdf') {
       </div>
     <?php endforeach; ?>
   <?php endif; ?>
-</div>
+  </div>
+</main>
 </body>
 </html>

--- a/admin/venues.php
+++ b/admin/venues.php
@@ -4,6 +4,7 @@ require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
 
 require_admin();
 install_schema();
@@ -146,14 +147,14 @@ $venues = $st->fetchAll();
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?=h(APP_NAME)?> — Düğün Salonları</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
 <style>
-  :root{ --zs:#0ea5b5; --zs-soft:#e0f7fb; --muted:#6b7280; }
-  body{ background:linear-gradient(180deg,var(--zs-soft),#fff) no-repeat }
-  .card-lite{ border:1px solid #eef2f7; border-radius:18px; background:#fff; box-shadow:0 6px 20px rgba(17,24,39,.05) }
-  .btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600 }
-  .btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:12px; font-weight:600 }
-  .grid-compact .form-control, .grid-compact .form-select{ height:42px }
-  .muted{ color:var(--muted) }
+  .grid-compact .form-control, .grid-compact .form-select{ height:46px; }
+  .muted{ color:var(--muted); }
+  .btn-zs{ background:var(--brand); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600; }
+  .btn-zs:hover{ background:var(--brand-dark); color:#fff; }
+  .btn-zs-outline{ background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
+  .btn-zs-outline:hover{ background:rgba(14,165,181,.12); color:var(--brand-dark); }
 </style>
 <script>
 function askToggle(){
@@ -162,28 +163,11 @@ function askToggle(){
 }
 </script>
 </head>
-<body>
-<nav class="navbar bg-white border-bottom zs-topbar">
+<body class="admin-body">
+<?php render_admin_topnav('venues', 'Düğün Salonları', 'Salon portföyünüzü yönetin ve etkinliklerinizi organize edin.'); ?>
+
+<main class="admin-main">
   <div class="container">
-    <!-- Sol: Marka -->
-    <a class="navbar-brand fw-semibold d-flex align-items-center gap-2" href="<?=h(BASE_URL)?>">
-      <?=h(APP_NAME)?>
-    </a>
-
-    <!-- Sağ: Aksiyonlar (buton görünümleri senin mevcut stillerle) -->
-    <div class="d-flex align-items-center gap-2">
-      <a href="<?=h(BASE_URL)?>/admin/dashboard.php" class="btn btn-sm btn-zs-outline">Panel</a>
-
-      <!-- Yeni: Kullanıcılar (liste sayfasına gider) -->
-      <a href="<?=h(BASE_URL)?>/admin/users.php" class="btn btn-sm btn-zs">Kullanıcılar</a>
-
-      <span class="text-muted px-1">•</span>
-
-      <a href="<?=h(BASE_URL)?>/admin/login.php?logout=1" class="btn btn-sm btn-outline-secondary">Çıkış</a>
-    </div>
-  </div>
-</nav>
-<div class="container py-4">
   <?php flash_box(); ?>
 
   <!-- Yeni Salon -->
@@ -331,6 +315,7 @@ function askToggle(){
       </div>
     <?php endif; ?>
   </div>
-</div>
+  </div>
+</main>
 </body>
 </html>

--- a/dealer/apply.php
+++ b/dealer/apply.php
@@ -1,0 +1,93 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+
+install_schema();
+
+$submitted = isset($_GET['done']);
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  csrf_or_die();
+  $name = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $phone = trim($_POST['phone'] ?? '');
+  $company = trim($_POST['company'] ?? '');
+  $notes = trim($_POST['notes'] ?? '');
+
+  if ($name === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err', 'Lütfen adınızı ve geçerli bir e-posta adresini girin.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+
+  if (dealer_find_by_email($email)) {
+    flash('err', 'Bu e-posta ile kayıtlı bir bayi başvurusu bulunuyor.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+
+  $st = pdo()->prepare("INSERT INTO dealers (name,email,phone,company,notes,status,created_at) VALUES (?,?,?,?,?,'pending',?)");
+  $st->execute([$name,$email,$phone,$company,$notes, now()]);
+  $dealerId = (int)pdo()->lastInsertId();
+  dealer_ensure_codes($dealerId);
+
+  $dealer = dealer_get($dealerId);
+  dealer_notify_new_application($dealer);
+  dealer_send_application_receipt($dealer);
+
+  flash('ok', 'Başvurunuz alınmıştır. En kısa sürede sizinle iletişime geçeceğiz.');
+  redirect($_SERVER['PHP_SELF'].'?done=1');
+}
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Başvurusu</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:linear-gradient(180deg,#fff5f7,#ffffff);}
+  .hero{max-width:640px;margin:40px auto;padding:32px;border-radius:18px;background:#fff;box-shadow:0 12px 40px rgba(15,23,42,.08);}
+</style>
+</head>
+<body>
+<div class="hero">
+  <h1 class="h3 mb-3">Bayi Başvuru Formu</h1>
+  <p class="text-muted">Düğün salonunuz veya organizasyon şirketiniz için başvuru yapın, yönetici onayıyla bayilik paneliniz açılsın.</p>
+  <?php if ($submitted): ?>
+    <?php flash_box(); ?>
+  <?php else: ?>
+    <?php flash_box(); ?>
+    <form method="post" class="row g-3">
+      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+      <div class="col-md-6">
+        <label class="form-label">Ad Soyad</label>
+        <input class="form-control" name="name" required>
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Firma Adı</label>
+        <input class="form-control" name="company">
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">E-posta</label>
+        <input type="email" class="form-control" name="email" required>
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Telefon</label>
+        <input class="form-control" name="phone">
+      </div>
+      <div class="col-12">
+        <label class="form-label">Notlar</label>
+        <textarea class="form-control" name="notes" rows="4" placeholder="Salon sayısı, bulunduğunuz şehir vb."></textarea>
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary" type="submit">Başvuruyu Gönder</button>
+      </div>
+    </form>
+  <?php endif; ?>
+  <div class="mt-4 text-center">
+    <a href="login.php" class="small text-decoration-none">Zaten bayimiz misiniz? Giriş yapın.</a>
+  </div>
+</div>
+</body>
+</html>

--- a/dealer/dashboard.php
+++ b/dealer/dashboard.php
@@ -1,0 +1,167 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+
+install_schema();
+
+dealer_require_login();
+$sessionDealer = dealer_user();
+$dealer = dealer_get((int)$sessionDealer['id']);
+if (!$dealer) {
+  dealer_logout();
+  redirect('login.php');
+}
+
+dealer_refresh_session((int)$dealer['id']);
+
+$action = $_POST['do'] ?? '';
+if ($action) {
+  csrf_or_die();
+  if ($action === 'set_code') {
+    $type = $_POST['type'] ?? DEALER_CODE_STATIC;
+    $eventId = (int)($_POST['event_id'] ?? 0);
+    if ($eventId > 0 && !dealer_event_belongs_to_dealer((int)$dealer['id'], $eventId)) {
+      flash('err', 'Bu etkinliği yönetme yetkiniz yok.');
+    } else {
+      dealer_set_code_target((int)$dealer['id'], $type, $eventId > 0 ? $eventId : null);
+      flash('ok', 'Kod bağlantısı güncellendi.');
+    }
+    redirect($_SERVER['PHP_SELF']);
+  }
+  if ($action === 'refresh_trial') {
+    dealer_regenerate_code((int)$dealer['id'], DEALER_CODE_TRIAL);
+    flash('ok', 'Deneme kodu yenilendi.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+}
+
+$codes   = dealer_sync_codes((int)$dealer['id']);
+$venues  = dealer_fetch_venues((int)$dealer['id']);
+$events  = dealer_allowed_events((int)$dealer['id']);
+$warning = dealer_license_warning($dealer);
+$canCreate = dealer_can_manage_events($dealer);
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Paneli</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:linear-gradient(180deg,#f4f9fb,#fff) no-repeat;font-family:'Inter',sans-serif;}
+  .topbar{background:#fff;border-bottom:1px solid #e5e7eb;}
+  .card-lite{border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.08);}
+  .code-pill{font-family:'Fira Code',monospace;font-size:1.1rem;padding:.35rem .8rem;border-radius:10px;background:#f1f5f9;display:inline-block;}
+</style>
+</head>
+<body>
+<nav class="topbar py-3">
+  <div class="container d-flex justify-content-between align-items-center">
+    <span class="fw-semibold"><?=h(APP_NAME)?> — Bayi Paneli</span>
+    <div class="d-flex align-items-center gap-3 small">
+      <span><?=h($dealer['name'])?></span>
+      <span>•</span>
+      <a class="text-decoration-none" href="login.php?logout=1">Çıkış</a>
+    </div>
+  </div>
+</nav>
+<div class="container py-4">
+  <?php flash_box(); ?>
+  <div class="row g-4">
+    <div class="col-lg-4">
+      <div class="card-lite p-4 h-100">
+        <h5 class="mb-3">Lisans Durumu</h5>
+        <p class="mb-1"><strong>Bitiş:</strong> <?=h(dealer_license_label($dealer))?></p>
+        <p class="text-muted small">Durum: <?= dealer_has_valid_license($dealer) ? 'Geçerli' : 'Geçersiz' ?></p>
+        <?php if ($warning): ?>
+          <div class="alert alert-warning small mb-0"><?=h($warning)?></div>
+        <?php endif; ?>
+      </div>
+    </div>
+    <div class="col-lg-8">
+      <div class="card-lite p-4">
+        <h5 class="mb-3">Kalıcı & Deneme Kodları</h5>
+        <div class="row g-4">
+          <?php foreach ([DEALER_CODE_STATIC=>'Kalıcı Kod', DEALER_CODE_TRIAL=>'Deneme Kodu'] as $type=>$label):
+            $code = $codes[$type] ?? null;
+            $url = $code ? BASE_URL.'/qr.php?code='.urlencode($code['code']) : '';
+          ?>
+          <div class="col-md-6">
+            <div class="border rounded-3 p-3 h-100">
+              <div class="d-flex justify-content-between align-items-center mb-2">
+                <h6 class="mb-0"><?=h($label)?></h6>
+                <?php if ($type === DEALER_CODE_TRIAL): ?>
+                  <form method="post" class="m-0">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="refresh_trial">
+                    <button class="btn btn-sm btn-outline-secondary">Yenile</button>
+                  </form>
+                <?php endif; ?>
+              </div>
+              <?php if ($code): ?>
+                <div class="code-pill mb-2"><?=h($code['code'])?></div>
+                <p class="small text-muted mb-2"><a href="<?=h($url)?>" target="_blank">QR bağlantısı</a></p>
+                <form method="post" class="vstack gap-2">
+                  <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                  <input type="hidden" name="do" value="set_code">
+                  <input type="hidden" name="type" value="<?=h($type)?>">
+                  <label class="form-label small mb-1">Bağlı düğün</label>
+                  <select class="form-select form-select-sm" name="event_id">
+                    <option value="0">— Seçili değil —</option>
+                    <?php foreach ($events as $ev): ?>
+                      <?php
+                        $selected = ($code['target_event_id'] ?? null) == $ev['id'] ? 'selected' : '';
+                        $dateLabel = $ev['event_date'] ? date('d.m.Y', strtotime($ev['event_date'])) : 'Tarihsiz';
+                      ?>
+                      <option value="<?= (int)$ev['id'] ?>" <?=$selected?>><?=h($dateLabel.' • '.$ev['title'])?></option>
+                    <?php endforeach; ?>
+                  </select>
+                  <button class="btn btn-sm btn-primary" type="submit">Kaydet</button>
+                </form>
+              <?php else: ?>
+                <p class="text-muted small">Kod oluşturulamadı.</p>
+              <?php endif; ?>
+            </div>
+          </div>
+          <?php endforeach; ?>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card-lite p-4 mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h5 class="mb-0">Salonlarınız</h5>
+      <a class="btn btn-sm btn-outline-primary" href="mailto:<?=h(MAIL_FROM ?? 'info@localhost')?>?subject=Bayi%20Salon%20Talebi">Yeni salon talep et</a>
+    </div>
+    <?php if (!$venues): ?>
+      <p class="text-muted">Henüz size atanmış salon bulunmuyor. Lütfen yönetici ile iletişime geçin.</p>
+    <?php else: ?>
+      <div class="table-responsive">
+        <table class="table align-middle">
+          <thead><tr><th>Salon</th><th>Durum</th><th></th></tr></thead>
+          <tbody>
+            <?php foreach ($venues as $v): ?>
+              <tr>
+                <td>
+                  <div class="fw-semibold"><?=h($v['name'])?></div>
+                  <div class="small text-muted">Slug: <?=h($v['slug'])?></div>
+                </td>
+                <td><?= $v['is_active'] ? 'Aktif' : 'Pasif' ?></td>
+                <td class="text-end">
+                  <a class="btn btn-sm btn-primary" href="venue_events.php?venue_id=<?= (int)$v['id'] ?>">Düğünleri Yönet</a>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php endif; ?>
+  </div>
+</div>
+</body>
+</html>

--- a/dealer/login.php
+++ b/dealer/login.php
@@ -1,0 +1,63 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+require_once __DIR__.'/../includes/dealers.php';
+
+install_schema();
+
+if (isset($_GET['logout'])) {
+  dealer_logout();
+  flash('ok', 'Oturum kapatıldı.');
+}
+
+if (dealer_user()) {
+  redirect('dashboard.php');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $email = trim($_POST['email'] ?? '');
+  $pass  = (string)($_POST['password'] ?? '');
+  if (dealer_login($email, $pass)) {
+    $next = $_GET['next'] ?? 'dashboard.php';
+    redirect($next);
+  } else {
+    flash('err', 'Giriş başarısız. Bilgilerinizi kontrol edin.');
+  }
+}
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Girişi</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:#f4f6fb;}
+  .login-card{max-width:420px;margin:80px auto;padding:32px;border-radius:16px;background:#fff;box-shadow:0 12px 40px rgba(15,23,42,.12);}
+</style>
+</head>
+<body>
+<div class="login-card">
+  <h2 class="h4 mb-3 text-center">Bayi Paneli</h2>
+  <p class="text-muted small text-center mb-4">Bayi kodlarınızı ve düğünlerinizi buradan yönetin.</p>
+  <?php flash_box(); ?>
+  <form method="post" class="vstack gap-3">
+    <div>
+      <label class="form-label">E-posta</label>
+      <input type="email" name="email" class="form-control" required>
+    </div>
+    <div>
+      <label class="form-label">Şifre</label>
+      <input type="password" name="password" class="form-control" required>
+    </div>
+    <button class="btn btn-primary w-100" type="submit">Giriş Yap</button>
+  </form>
+  <div class="text-center mt-3">
+    <a class="small" href="apply.php">Bayi olmak için başvurun</a>
+  </div>
+</div>
+</body>
+</html>

--- a/dealer/venue_events.php
+++ b/dealer/venue_events.php
@@ -1,0 +1,219 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+
+install_schema();
+
+dealer_require_login();
+$sessionDealer = dealer_user();
+$dealer = dealer_get((int)$sessionDealer['id']);
+if (!$dealer) {
+  dealer_logout();
+  redirect('login.php');
+}
+
+$venueId = (int)($_GET['venue_id'] ?? 0);
+if ($venueId <= 0) {
+  flash('err', 'Salon seçilmedi.');
+  redirect('dashboard.php');
+}
+
+$st = pdo()->prepare("SELECT v.* FROM venues v INNER JOIN dealer_venues dv ON dv.venue_id=v.id WHERE dv.dealer_id=? AND v.id=? LIMIT 1");
+$st->execute([(int)$dealer['id'], $venueId]);
+$venue = $st->fetch();
+if (!$venue) {
+  flash('err', 'Bu salona erişiminiz yok.');
+  redirect('dashboard.php');
+}
+
+$canManage = dealer_can_manage_events($dealer);
+
+$action = $_POST['do'] ?? '';
+if ($action === 'create_event') {
+  csrf_or_die();
+  if (!$canManage) {
+    flash('err', 'Lisans süreniz dolduğu için yeni düğün oluşturamazsınız.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+
+  $title = trim($_POST['title'] ?? '');
+  $date  = trim($_POST['event_date'] ?? '');
+  $email = trim($_POST['couple_email'] ?? '');
+  $pass  = (string)($_POST['couple_pass'] ?? '');
+
+  if ($title === '' || $email === '' || $pass === '') {
+    flash('err', 'Başlık, e-posta ve şifre alanları zorunlu.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+  if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err', 'Geçerli bir e-posta girin.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+  if (strlen($pass) < 6) {
+    flash('err', 'Geçici şifre en az 6 karakter olmalı.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+
+  $slug = slugify($title);
+  if ($slug === '') $slug = 'event-'.bin2hex(random_bytes(3));
+  $base = $slug; $i = 1;
+  while (true) {
+    $chk = pdo()->prepare("SELECT id FROM events WHERE venue_id=? AND slug=? LIMIT 1");
+    $chk->execute([$venueId, $slug]);
+    if (!$chk->fetch()) break;
+    $slug = $base.'-'.$i++;
+  }
+
+  $same = pdo()->prepare("SELECT id FROM events WHERE couple_username=? LIMIT 1");
+  $same->execute([$email]);
+  if ($same->fetch()) {
+    flash('err', 'Bu e-posta farklı bir düğün için kullanılıyor.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+
+  $key  = bin2hex(random_bytes(16));
+  $hash = password_hash($pass, PASSWORD_DEFAULT);
+  $primary = '#0ea5b5';
+  $accent  = '#e0f7fb';
+
+  $sql = "INSERT INTO events (venue_id,dealer_id,user_id,title,slug,couple_panel_key,theme_primary,theme_accent,event_date,created_at,couple_username,couple_password_hash,couple_force_reset,contact_email) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+  pdo()->prepare($sql)->execute([
+    $venueId,
+    (int)$dealer['id'],
+    null,
+    $title,
+    $slug,
+    $key,
+    $primary,
+    $accent,
+    $date ?: null,
+    now(),
+    $email,
+    $hash,
+    1,
+    $email,
+  ]);
+
+  $eventId = (int)pdo()->lastInsertId();
+  $loginUrl = BASE_URL.'/couple/login.php?event='.$eventId;
+  $html = '<h3>'.h(APP_NAME).' Çift Paneli</h3>'
+        . '<p>Düğün paneliniz oluşturuldu.</p>'
+        . '<p><strong>Kullanıcı adı:</strong> '.h($email).'<br>'
+        . '<strong>Geçici şifre:</strong> '.h($pass).'</p>'
+        . '<p><a href="'.h($loginUrl).'">Panele giriş yapın</a> ve ilk girişte şifrenizi değiştirin.</p>';
+  send_mail_simple($email, 'Çift paneliniz hazır', $html);
+
+  flash('ok', 'Düğün oluşturuldu ve bilgiler çifte e-posta ile gönderildi.');
+  redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+}
+
+if ($action === 'toggle' && isset($_POST['event_id'])) {
+  csrf_or_die();
+  $eventId = (int)$_POST['event_id'];
+  if (!dealer_event_belongs_to_dealer((int)$dealer['id'], $eventId)) {
+    flash('err', 'Bu düğünü yönetme yetkiniz yok.');
+  } else {
+    pdo()->prepare("UPDATE events SET is_active=1-is_active WHERE id=? AND venue_id=?")
+        ->execute([$eventId, $venueId]);
+    flash('ok', 'Durum güncellendi.');
+  }
+  redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+}
+
+$events = [];
+$st = pdo()->prepare("SELECT * FROM events WHERE venue_id=? ORDER BY event_date DESC, id DESC");
+$st->execute([$venueId]);
+$events = $st->fetchAll();
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h($venue['name'])?> — Düğünler</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:#f4f6fb;}
+  .card-lite{border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.06);}
+</style>
+</head>
+<body>
+<nav class="navbar bg-white border-bottom mb-4">
+  <div class="container d-flex justify-content-between align-items-center py-2">
+    <div>
+      <a class="navbar-brand fw-semibold" href="dashboard.php">← Bayi Paneli</a>
+      <span class="ms-2 text-muted">Salon: <?=h($venue['name'])?></span>
+    </div>
+    <a class="text-decoration-none" href="login.php?logout=1">Çıkış</a>
+  </div>
+</nav>
+<div class="container pb-5">
+  <?php flash_box(); ?>
+  <div class="card-lite p-4 mb-4">
+    <h5 class="mb-3">Yeni Düğün Oluştur</h5>
+    <?php if (!$canManage): ?>
+      <div class="alert alert-warning">Lisans süreniz geçersiz olduğu için yeni düğün oluşturamazsınız. Lütfen yönetici ile iletişime geçin.</div>
+    <?php endif; ?>
+    <form method="post" class="row g-3" autocomplete="off">
+      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+      <input type="hidden" name="do" value="create_event">
+      <div class="col-md-6">
+        <label class="form-label">Düğün Başlığı</label>
+        <input class="form-control" name="title" required <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Düğün Tarihi</label>
+        <input type="date" class="form-control" name="event_date" <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Çift E-postası</label>
+        <input type="email" class="form-control" name="couple_email" required <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Geçici Şifre</label>
+        <input type="text" class="form-control" name="couple_pass" minlength="6" required <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-9 d-flex align-items-end">
+        <button class="btn btn-primary" type="submit" <?= $canManage ? '' : 'disabled' ?>>Düğünü Oluştur</button>
+      </div>
+    </form>
+  </div>
+
+  <div class="card-lite p-4">
+    <h5 class="mb-3">Düğün Listesi</h5>
+    <?php if (!$events): ?>
+      <p class="text-muted">Bu salona ait düğün bulunmuyor.</p>
+    <?php else: ?>
+      <div class="table-responsive">
+        <table class="table align-middle">
+          <thead><tr><th>Başlık</th><th>Tarih</th><th>Durum</th><th></th></tr></thead>
+          <tbody>
+            <?php foreach ($events as $ev): ?>
+              <tr>
+                <td>
+                  <div class="fw-semibold"><?=h($ev['title'])?></div>
+                  <div class="small text-muted">Çift e-postası: <?=h($ev['couple_username'] ?? $ev['contact_email'])?></div>
+                </td>
+                <td><?= $ev['event_date'] ? h(date('d.m.Y', strtotime($ev['event_date']))) : '—' ?></td>
+                <td><?= $ev['is_active'] ? 'Aktif' : 'Pasif' ?></td>
+                <td class="text-end">
+                  <form method="post" class="d-inline">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="toggle">
+                    <input type="hidden" name="event_id" value="<?= (int)$ev['id'] ?>">
+                    <button class="btn btn-sm btn-outline-secondary" type="submit">Durumu Değiştir</button>
+                  </form>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php endif; ?>
+  </div>
+</div>
+</body>
+</html>

--- a/includes/dealer_auth.php
+++ b/includes/dealer_auth.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * includes/dealer_auth.php — Bayi paneli oturum yardımcıları
+ */
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/db.php';
+require_once __DIR__.'/functions.php';
+require_once __DIR__.'/dealers.php';
+
+function dealer_login(string $email, string $password): bool {
+  $email = trim($email);
+  if ($email === '' || $password === '') return false;
+
+  $st = pdo()->prepare("SELECT * FROM dealers WHERE email=? LIMIT 1");
+  $st->execute([$email]);
+  $dealer = $st->fetch();
+  if (!$dealer) return false;
+  if ($dealer['status'] !== DEALER_STATUS_ACTIVE) return false;
+  if (empty($dealer['password_hash']) || !password_verify($password, $dealer['password_hash'])) {
+    return false;
+  }
+
+  $_SESSION['dealer'] = [
+    'id'    => (int)$dealer['id'],
+    'email' => $dealer['email'],
+    'name'  => $dealer['name'],
+    'since' => time(),
+  ];
+  dealer_update_last_login((int)$dealer['id']);
+  return true;
+}
+
+function dealer_logout(): void {
+  unset($_SESSION['dealer']);
+}
+
+function dealer_user(): ?array {
+  return !empty($_SESSION['dealer']) ? $_SESSION['dealer'] : null;
+}
+
+function dealer_require_login(string $login_url = '/dealer/login.php'): void {
+  if (!dealer_user()) {
+    $back = urlencode($_SERVER['REQUEST_URI'] ?? '/dealer/dashboard.php');
+    redirect($login_url.'?next='.$back);
+  }
+}
+
+function dealer_refresh_session(int $dealer_id): void {
+  $dealer = dealer_get($dealer_id);
+  if (!$dealer) {
+    dealer_logout();
+    return;
+  }
+  $_SESSION['dealer'] = [
+    'id'    => (int)$dealer['id'],
+    'email' => $dealer['email'],
+    'name'  => $dealer['name'],
+    'since' => time(),
+  ];
+}
+
+function dealer_can_manage_events(array $dealer): bool {
+  if ($dealer['status'] !== DEALER_STATUS_ACTIVE) return false;
+  return dealer_has_valid_license($dealer);
+}

--- a/includes/dealers.php
+++ b/includes/dealers.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * includes/dealers.php — Bayi (franchise) yardımcı fonksiyonları
+ */
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/db.php';
+require_once __DIR__.'/functions.php';
+
+const DEALER_STATUS_PENDING = 'pending';
+const DEALER_STATUS_ACTIVE  = 'active';
+const DEALER_STATUS_INACTIVE= 'inactive';
+
+const DEALER_CODE_STATIC = 'static';
+const DEALER_CODE_TRIAL  = 'trial';
+
+/** Benzersiz kod üret (harf + rakam, karışık). */
+function dealer_generate_code_string(int $length = 8): string {
+  $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  $out = '';
+  $max = strlen($alphabet) - 1;
+  for ($i = 0; $i < $length; $i++) {
+    $out .= $alphabet[random_int(0, $max)];
+  }
+  return $out;
+}
+
+function dealer_generate_unique_code(): string {
+  while (true) {
+    $code = dealer_generate_code_string(8);
+    $st = pdo()->prepare("SELECT 1 FROM dealer_codes WHERE code=? LIMIT 1");
+    $st->execute([$code]);
+    if ($st->fetch()) continue;
+    // qr_codes ile çakışmasın
+    $st2 = pdo()->prepare("SELECT 1 FROM qr_codes WHERE code=? LIMIT 1");
+    $st2->execute([$code]);
+    if ($st2->fetch()) continue;
+    return $code;
+  }
+}
+
+function dealer_ensure_codes(int $dealer_id): array {
+  $types = [DEALER_CODE_STATIC, DEALER_CODE_TRIAL];
+  foreach ($types as $type) {
+    $st = pdo()->prepare("SELECT id FROM dealer_codes WHERE dealer_id=? AND type=? LIMIT 1");
+    $st->execute([$dealer_id, $type]);
+    if (!$st->fetch()) {
+      $code = dealer_generate_unique_code();
+      pdo()->prepare("INSERT INTO dealer_codes (dealer_id,type,code,created_at) VALUES (?,?,?,?)")
+          ->execute([$dealer_id, $type, $code, now()]);
+    }
+  }
+  return dealer_get_codes($dealer_id);
+}
+
+function dealer_get_codes(int $dealer_id): array {
+  $st = pdo()->prepare("SELECT * FROM dealer_codes WHERE dealer_id=? ORDER BY type");
+  $st->execute([$dealer_id]);
+  $rows = [];
+  foreach ($st->fetchAll() as $row) {
+    $rows[$row['type']] = $row;
+  }
+  return $rows;
+}
+
+function dealer_regenerate_code(int $dealer_id, string $type): string {
+  $type = $type === DEALER_CODE_TRIAL ? DEALER_CODE_TRIAL : DEALER_CODE_STATIC;
+  $code = dealer_generate_unique_code();
+  pdo()->prepare("UPDATE dealer_codes SET code=?, updated_at=?, target_event_id=NULL WHERE dealer_id=? AND type=?")
+      ->execute([$code, now(), $dealer_id, $type]);
+  return $code;
+}
+
+function dealer_set_code_target(int $dealer_id, string $type, ?int $event_id): void {
+  $type = $type === DEALER_CODE_TRIAL ? DEALER_CODE_TRIAL : DEALER_CODE_STATIC;
+  pdo()->prepare("UPDATE dealer_codes SET target_event_id=?, updated_at=? WHERE dealer_id=? AND type=?")
+      ->execute([$event_id ?: null, now(), $dealer_id, $type]);
+}
+
+function dealer_get(int $dealer_id): ?array {
+  $st = pdo()->prepare("SELECT * FROM dealers WHERE id=? LIMIT 1");
+  $st->execute([$dealer_id]);
+  $row = $st->fetch();
+  return $row ?: null;
+}
+
+function dealer_find_by_email(string $email): ?array {
+  $st = pdo()->prepare("SELECT * FROM dealers WHERE email=? LIMIT 1");
+  $st->execute([$email]);
+  $row = $st->fetch();
+  return $row ?: null;
+}
+
+function dealer_status_badge(string $status): string {
+  return match ($status) {
+    DEALER_STATUS_ACTIVE   => 'Aktif',
+    DEALER_STATUS_INACTIVE => 'Pasif',
+    default                => 'Onay Bekliyor',
+  };
+}
+
+function dealer_has_valid_license(array $dealer): bool {
+  if (empty($dealer['license_expires_at'])) return false;
+  $exp = new DateTime($dealer['license_expires_at']);
+  $now = new DateTime('now');
+  return $exp >= $now;
+}
+
+function dealer_license_label(array $dealer): string {
+  if (empty($dealer['license_expires_at'])) {
+    return 'Tanımlı değil';
+  }
+  $exp = new DateTime($dealer['license_expires_at']);
+  return $exp->format('d.m.Y H:i');
+}
+
+function dealer_assign_venues(int $dealer_id, array $venue_ids): void {
+  $venue_ids = array_map('intval', $venue_ids);
+  $venue_ids = array_values(array_unique(array_filter($venue_ids)));
+  $pdo = pdo();
+  $pdo->beginTransaction();
+  try {
+    if ($venue_ids) {
+      $ph = implode(',', array_fill(0, count($venue_ids), '?'));
+      $params = array_merge([$dealer_id], $venue_ids);
+      $pdo->prepare("DELETE FROM dealer_venues WHERE dealer_id=? AND venue_id NOT IN ($ph)")
+          ->execute($params);
+    } else {
+      $pdo->prepare("DELETE FROM dealer_venues WHERE dealer_id=?")->execute([$dealer_id]);
+    }
+
+    $existing = $pdo->prepare("SELECT venue_id FROM dealer_venues WHERE dealer_id=?");
+    $existing->execute([$dealer_id]);
+    $current = array_map('intval', array_column($existing->fetchAll(), 'venue_id'));
+    foreach ($venue_ids as $vid) {
+      if (!in_array($vid, $current, true)) {
+        $pdo->prepare("INSERT INTO dealer_venues (dealer_id, venue_id, created_at) VALUES (?,?,?)")
+            ->execute([$dealer_id, $vid, now()]);
+      }
+    }
+    $pdo->commit();
+  } catch (Throwable $e) {
+    $pdo->rollBack();
+    throw $e;
+  }
+}
+
+function dealer_fetch_venues(int $dealer_id, bool $onlyActive = false): array {
+  $sql = "SELECT v.* FROM venues v INNER JOIN dealer_venues dv ON dv.venue_id=v.id WHERE dv.dealer_id=?";
+  if ($onlyActive) {
+    $sql .= " AND v.is_active=1";
+  }
+  $sql .= " ORDER BY v.name";
+  $st = pdo()->prepare($sql);
+  $st->execute([$dealer_id]);
+  return $st->fetchAll();
+}
+
+function dealer_event_belongs_to_dealer(int $dealer_id, int $event_id): bool {
+  $st = pdo()->prepare("SELECT 1 FROM events e INNER JOIN dealer_venues dv ON dv.venue_id=e.venue_id WHERE e.id=? AND dv.dealer_id=? LIMIT 1");
+  $st->execute([$event_id, $dealer_id]);
+  return (bool)$st->fetchColumn();
+}
+
+function dealer_allowed_events(int $dealer_id): array {
+  $st = pdo()->prepare("SELECT e.* FROM events e INNER JOIN dealer_venues dv ON dv.venue_id=e.venue_id WHERE dv.dealer_id=? ORDER BY e.event_date DESC, e.id DESC");
+  $st->execute([$dealer_id]);
+  return $st->fetchAll();
+}
+
+function dealer_sync_codes(int $dealer_id): array {
+  dealer_ensure_codes($dealer_id);
+  return dealer_get_codes($dealer_id);
+}
+
+function dealer_notify_new_application(array $dealer): void {
+  $to = defined('MAIL_FROM') && MAIL_FROM ? MAIL_FROM : 'info@localhost';
+  $subject = 'Yeni bayi başvurusu';
+  $html = '<h3>'.h(APP_NAME).' — Yeni Bayi Başvurusu</h3>'
+        . '<p><strong>Ad:</strong> '.h($dealer['name']).'</p>'
+        . '<p><strong>E-posta:</strong> '.h($dealer['email']).'</p>';
+  if (!empty($dealer['phone'])) {
+    $html .= '<p><strong>Telefon:</strong> '.h($dealer['phone']).'</p>';
+  }
+  if (!empty($dealer['company'])) {
+    $html .= '<p><strong>Firma:</strong> '.h($dealer['company']).'</p>';
+  }
+  if (!empty($dealer['notes'])) {
+    $html .= '<p><strong>Not:</strong><br>'.nl2br(h($dealer['notes'])).'</p>';
+  }
+  send_mail_simple($to, $subject, $html);
+}
+
+function dealer_send_application_receipt(array $dealer): void {
+  $html = '<h3>'.h(APP_NAME).' Bayi Başvurusu</h3>'
+        . '<p>Başvurunuz alınmıştır. İnceleme sonrasında size dönüş yapılacaktır.</p>';
+  send_mail_simple($dealer['email'], 'Başvurunuz alındı', $html);
+}
+
+function dealer_random_password(int $length = 10): string {
+  $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789';
+  $out = '';
+  $max = strlen($alphabet) - 1;
+  for ($i=0; $i<$length; $i++) {
+    $out .= $alphabet[random_int(0, $max)];
+  }
+  return $out;
+}
+
+function dealer_send_welcome_mail(array $dealer, string $plain_password): void {
+  $loginUrl = BASE_URL.'/dealer/login.php';
+  $html = '<h3>'.h(APP_NAME).' Bayi Paneli</h3>'
+        . '<p>Bayilik başvurunuz onaylandı.</p>'
+        . '<p><strong>Giriş E-postası:</strong> '.h($dealer['email']).'<br>'
+        . '<strong>Geçici Şifre:</strong> '.h($plain_password).'</p>'
+        . '<p><a href="'.h($loginUrl).'">Panele giriş yapın</a> ve ilk girişte şifrenizi değiştirin.</p>';
+  send_mail_simple($dealer['email'], 'Bayilik paneliniz hazır', $html);
+}
+
+function dealer_update_last_login(int $dealer_id): void {
+  pdo()->prepare("UPDATE dealers SET last_login_at=?, updated_at=? WHERE id=?")
+      ->execute([now(), now(), $dealer_id]);
+}
+
+function dealer_license_warning(array $dealer): ?string {
+  if (empty($dealer['license_expires_at'])) {
+    return 'Lisans süresi tanımlı değil.';
+  }
+  $exp = new DateTime($dealer['license_expires_at']);
+  $now = new DateTime('now');
+  if ($exp < $now) {
+    return 'Lisans süresi dolmuştur.';
+  }
+  $diff = $now->diff($exp);
+  if ($diff->days !== false && $diff->days <= 14) {
+    return 'Lisans süresi yakında ('.max(0, $diff->days).' gün) dolacak.';
+  }
+  return null;
+}
+
+function dealer_fetch_assigned_event_ids(int $dealer_id): array {
+  $st = pdo()->prepare("SELECT e.id FROM events e INNER JOIN dealer_venues dv ON dv.venue_id=e.venue_id WHERE dv.dealer_id=?");
+  $st->execute([$dealer_id]);
+  return array_map('intval', array_column($st->fetchAll(), 'id'));
+}

--- a/qr.php
+++ b/qr.php
@@ -7,8 +7,20 @@ $code=trim($_GET['code']??'');
 if ($code===''){ http_response_code(404); exit('QR yok'); }
 
 $st=pdo()->prepare("SELECT q.*, e.id AS ev_id FROM qr_codes q LEFT JOIN events e ON e.id=q.target_event_id WHERE q.code=?");
-$st->execute([$code]); $q=$st->fetch();
-if (!$q || !$q['ev_id']){ http_response_code(404); exit('Hedef yok'); }
+$st->execute([$code]);
+$q=$st->fetch();
+if ($q && $q['ev_id']){
+  $dest = public_upload_url((int)$q['ev_id']);
+  redirect($dest, 301);
+}
 
-$dest = public_upload_url((int)$q['ev_id']);
-redirect($dest, 301);
+$st2=pdo()->prepare("SELECT dc.*, e.id AS ev_id FROM dealer_codes dc LEFT JOIN events e ON e.id=dc.target_event_id WHERE dc.code=? LIMIT 1");
+$st2->execute([$code]);
+$dc=$st2->fetch();
+if ($dc && $dc['ev_id']){
+  $dest = public_upload_url((int)$dc['ev_id']);
+  redirect($dest, 301);
+}
+
+http_response_code(404);
+exit('Hedef yok');


### PR DESCRIPTION
## Summary
- extend the users schema with role and last_login fields plus backfill to guarantee at least one superadmin
- update authentication, first-run login, and shared admin layout helpers to create the first superadmin and surface role-aware navigation
- restyle the admin area with the new layout and add a management screen for inviting admins, changing roles, and resetting passwords

## Testing
- php -l includes/db.php
- php -l includes/auth.php
- php -l admin/login.php
- php -l admin/dashboard.php
- php -l admin/dealers.php
- php -l admin/users.php
- php -l admin/venues.php
- php -l admin/venue_events.php
- php -l admin/partials/ui.php
- php -l admin/team.php

------
https://chatgpt.com/codex/tasks/task_e_68e062b7f0088324b0c1289e088aaa22