### PR TITLE
Add superadmin onboarding and refresh admin UI

### DIFF
--- a/admin/campaigns.php
+++ b/admin/campaigns.php
@@ -9,17 +9,10 @@ require_once __DIR__.'/partials/ui.php';
 require_admin();
 install_schema();
 
-if (function_exists('require_current_venue_or_redirect')) {
-  $venue = require_current_venue_or_redirect();
-  $VID   = (int)$venue['id'];
-  $VNAME = $venue['name'];
-  $VSLUG = $venue['slug'];
-} else {
-    if (empty($_SESSION['venue_id'])) { redirect(BASE_URL.'/admin/venues.php'); }
-    $VID   = (int)$_SESSION['venue_id'];
-    $VNAME = $_SESSION['venue_name'] ?? 'Salon';
-    $VSLUG = $_SESSION['venue_slug'] ?? '';
-}
+$venue = require_current_venue_or_redirect();
+$VID   = (int)$venue['id'];
+$VNAME = $venue['name'];
+$VSLUG = $venue['slug'];
 
 try {
   pdo()->query("SELECT 1 FROM campaigns LIMIT 1");

--- a/admin/campaigns.php
+++ b/admin/campaigns.php
@@ -1,0 +1,201 @@
+<?php
+// admin/campaigns.php — kampanyalar artık ayrı sayfada yönetilir
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
+
+require_admin();
+install_schema();
+
+if (function_exists('require_current_venue_or_redirect')) {
+  $venue = require_current_venue_or_redirect();
+  $VID   = (int)$venue['id'];
+  $VNAME = $venue['name'];
+  $VSLUG = $venue['slug'];
+} else {
+    if (empty($_SESSION['venue_id'])) { redirect(BASE_URL.'/admin/venues.php'); }
+    $VID   = (int)$_SESSION['venue_id'];
+    $VNAME = $_SESSION['venue_name'] ?? 'Salon';
+    $VSLUG = $_SESSION['venue_slug'] ?? '';
+}
+
+try {
+  pdo()->query("SELECT 1 FROM campaigns LIMIT 1");
+} catch (Throwable $e) {
+  try {
+    pdo()->exec("
+      CREATE TABLE campaigns (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        venue_id INT NOT NULL,
+        name VARCHAR(190) NOT NULL,
+        type VARCHAR(120) NOT NULL,
+        description TEXT NULL,
+        price INT NOT NULL DEFAULT 0,
+        is_active TINYINT(1) NOT NULL DEFAULT 1,
+        created_at DATETIME NOT NULL,
+        updated_at DATETIME NULL,
+        FOREIGN KEY (venue_id) REFERENCES venues(id) ON DELETE CASCADE,
+        INDEX (venue_id, is_active)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+    ");
+  } catch (Throwable $e2) {}
+}
+
+if (($_POST['do'] ?? '') === 'camp_create') {
+  csrf_or_die();
+  $name = trim($_POST['name'] ?? '');
+  $type = trim($_POST['type'] ?? '');
+  $desc = trim($_POST['description'] ?? '');
+  $price = max(0,(int)($_POST['price'] ?? 0));
+  if (!$name || !$type) {
+    flash('err','Kampanya adı ve türü gerekli.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+  pdo()->prepare("INSERT INTO campaigns (venue_id,name,type,description,price,is_active,created_at) VALUES (?,?,?,?,?,1,?)")
+      ->execute([$VID,$name,$type,$desc,$price, now()]);
+  flash('ok','Kampanya eklendi.');
+  redirect($_SERVER['PHP_SELF']);
+}
+
+if (($_POST['do'] ?? '') === 'camp_update') {
+  csrf_or_die();
+  $id    = (int)($_POST['id'] ?? 0);
+  $name  = trim($_POST['name'] ?? '');
+  $type  = trim($_POST['type'] ?? '');
+  $desc  = trim($_POST['description'] ?? '');
+  $price = max(0,(int)($_POST['price'] ?? 0));
+  $act   = isset($_POST['is_active']) ? 1 : 0;
+  pdo()->prepare("UPDATE campaigns SET name=?, type=?, description=?, price=?, is_active=?, updated_at=? WHERE id=? AND venue_id=?")
+      ->execute([$name,$type,$desc,$price,$act, now(), $id, $VID]);
+  flash('ok','Kampanya güncellendi.');
+  redirect($_SERVER['PHP_SELF']);
+}
+
+if (($_POST['do'] ?? '') === 'camp_toggle') {
+  csrf_or_die();
+  $id=(int)($_POST['id'] ?? 0);
+  pdo()->prepare("UPDATE campaigns SET is_active=1-is_active, updated_at=? WHERE id=? AND venue_id=?")
+      ->execute([now(), $id, $VID]);
+  redirect($_SERVER['PHP_SELF']);
+}
+
+$campaigns = pdo()->prepare("SELECT * FROM campaigns WHERE venue_id=? ORDER BY is_active DESC, id DESC");
+$campaigns->execute([$VID]);
+$campaigns=$campaigns->fetchAll();
+
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Kampanyalar (<?=h($VNAME)?>)</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
+<style>
+  .grid-compact .form-control, .grid-compact .form-select{ height:46px; }
+  .muted{ color:var(--muted); }
+  .btn-zs{ background:var(--brand); border:none; color:#fff; border-radius:12px; font-weight:600; }
+  .btn-zs:hover{ background:var(--brand-dark); color:#fff; }
+  .btn-zs-outline{ background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
+  .btn-zs-outline:hover{ background:rgba(14,165,181,.12); color:var(--brand-dark); }
+</style>
+</head>
+<body class="admin-body">
+<?php render_admin_topnav('campaigns', 'Kampanya Yönetimi', 'Salon: '.$VNAME.' • Kampanyalar tüm etkinlik panellerinde gösterilir.'); ?>
+<main class="admin-main">
+  <div class="container">
+    <?php flash_box(); ?>
+
+    <div class="card-lite p-3 mb-4">
+      <div class="d-flex justify-content-between align-items-center mb-2">
+        <h5 class="m-0">Yeni Kampanya</h5>
+        <span class="muted small">Eklediğiniz kampanyalar salonunuzdaki tüm etkinlik panellerine yansır.</span>
+      </div>
+      <form method="post" class="row g-3 grid-compact">
+        <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+        <input type="hidden" name="do" value="camp_create">
+        <div class="col-md-4">
+          <label class="form-label">Kampanya Adı</label>
+          <input class="form-control" name="name" placeholder="Örn: Gold Paket">
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Tür / Etiket</label>
+          <input class="form-control" name="type" placeholder="Örn: video, premium">
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Fiyat (TL)</label>
+          <input class="form-control" type="number" min="0" step="100" name="price" placeholder="0">
+        </div>
+        <div class="col-12">
+          <label class="form-label">Açıklama</label>
+          <textarea class="form-control" name="description" rows="3" placeholder="Kampanyanın detaylarını yazın."></textarea>
+        </div>
+        <div class="col-12 col-md-3">
+          <button class="btn btn-zs w-100">Kampanyayı Kaydet</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="card-lite p-3">
+      <h5 class="mb-3">Aktif Kampanyalar</h5>
+      <?php if (!$campaigns): ?>
+        <div class="muted">Henüz kampanya eklenmedi.</div>
+      <?php else: ?>
+        <div class="table-responsive">
+          <table class="table align-middle">
+            <thead>
+              <tr>
+                <th>Ad</th>
+                <th>Tür</th>
+                <th>Fiyat</th>
+                <th>Durum</th>
+                <th style="width:220px">İşlemler</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach($campaigns as $c): ?>
+                <form id="camp-form-<?=$c['id']?>" method="post" class="d-none">
+                  <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+                  <input type="hidden" name="id" value="<?=$c['id']?>">
+                </form>
+                <tr>
+                  <td>
+                    <input form="camp-form-<?=$c['id']?>" class="form-control mb-2" name="name" value="<?=h($c['name'])?>">
+                    <textarea form="camp-form-<?=$c['id']?>" class="form-control" name="description" rows="2" placeholder="Açıklama"><?=h($c['description'])?></textarea>
+                  </td>
+                  <td>
+                    <input form="camp-form-<?=$c['id']?>" class="form-control" name="type" value="<?=h($c['type'])?>">
+                  </td>
+                  <td>
+                    <div class="input-group">
+                      <input form="camp-form-<?=$c['id']?>" type="number" class="form-control" name="price" min="0" step="100" value="<?= (int)$c['price'] ?>">
+                      <span class="input-group-text">TL</span>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="form-check form-switch">
+                      <input form="camp-form-<?=$c['id']?>" class="form-check-input" type="checkbox" value="1" name="is_active" id="camp-active-<?=$c['id']?>" <?= $c['is_active'] ? 'checked' : '' ?>>
+                      <label class="form-check-label" for="camp-active-<?=$c['id']?>">Aktif</label>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="d-flex gap-2">
+                      <button form="camp-form-<?=$c['id']?>" class="btn btn-zs" type="submit" name="do" value="camp_update">Güncelle</button>
+                      <button form="camp-form-<?=$c['id']?>" class="btn btn-zs-outline" type="submit" name="do" value="camp_toggle">Durumu Değiştir</button>
+                    </div>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php endif; ?>
+    </div>
+  </div>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/admin/campaigns.php
+++ b/admin/campaigns.php
@@ -104,12 +104,10 @@ $campaigns=$campaigns->fetchAll();
 </style>
 </head>
 <body class="admin-body">
-<?php render_admin_topnav('campaigns', 'Kampanya Yönetimi', 'Salon: '.$VNAME.' • Kampanyalar tüm etkinlik panellerinde gösterilir.'); ?>
-<main class="admin-main">
-  <div class="container">
+<?php admin_layout_start('campaigns', 'Kampanya Yönetimi', 'Salon: '.$VNAME.' • Kampanyalar tüm etkinlik panellerinde gösterilir.'); ?>
     <?php flash_box(); ?>
 
-    <div class="card-lite p-3 mb-4">
+    <div class="card-lite mb-4">
       <div class="d-flex justify-content-between align-items-center mb-2">
         <h5 class="m-0">Yeni Kampanya</h5>
         <span class="muted small">Eklediğiniz kampanyalar salonunuzdaki tüm etkinlik panellerine yansır.</span>
@@ -139,7 +137,7 @@ $campaigns=$campaigns->fetchAll();
       </form>
     </div>
 
-    <div class="card-lite p-3">
+    <div class="card-lite">
       <h5 class="mb-3">Aktif Kampanyalar</h5>
       <?php if (!$campaigns): ?>
         <div class="muted">Henüz kampanya eklenmedi.</div>
@@ -194,8 +192,7 @@ $campaigns=$campaigns->fetchAll();
         </div>
       <?php endif; ?>
     </div>
-  </div>
-</main>
+<?php admin_layout_end(); ?>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,9 +1,10 @@
 <?php
-// admin/dashboard.php — kampanya input, arama/filtre, soft-delete, QR PDF, çift hesabı
+// admin/dashboard.php — yönetim genel bakış ekranı
 require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/../includes/dealers.php';
 require_once __DIR__.'/partials/ui.php';
 
 require_admin();
@@ -11,244 +12,98 @@ install_schema();
 
 $me    = admin_user();
 $venue = require_current_venue_or_redirect();
-$VID   = (int)$venue['id'];
 $VNAME = $venue['name'];
-$VSLUG = $venue['slug'];
 $today = date('Y-m-d');
 
-$stats = [
-  'total_events'    => 0,
-  'active_events'   => 0,
-  'upcoming_events' => 0,
-  'upload_count'    => 0,
-  'storage_bytes'   => 0,
-  'active_campaigns'=> 0,
-  'qr_codes'        => 0,
+$dealerCounts = dealer_status_counts();
+$topupStats = [
+  DEALER_TOPUP_STATUS_PENDING         => ['count' => 0, 'amount' => 0],
+  DEALER_TOPUP_STATUS_AWAITING_REVIEW => ['count' => 0, 'amount' => 0],
+  DEALER_TOPUP_STATUS_COMPLETED       => ['count' => 0, 'amount' => 0],
+];
+$cashbackSummary = ['count' => 0, 'amount' => 0];
+$campaignCount   = 0;
+$eventStats      = [
+  'total'     => 0,
+  'active'    => 0,
+  'upcoming'  => 0,
+  'completed' => 0,
 ];
 
 try {
-  $eventAgg = pdo()->prepare("SELECT COUNT(*) AS total_events, SUM(CASE WHEN is_active=1 THEN 1 ELSE 0 END) AS active_events, SUM(CASE WHEN is_active=1 AND event_date IS NOT NULL AND event_date >= ? THEN 1 ELSE 0 END) AS upcoming_events FROM events WHERE venue_id = ?");
-  $eventAgg->execute([$today, $VID]);
+  $st = pdo()->query("SELECT status, COUNT(*) AS c, COALESCE(SUM(amount_cents),0) AS total FROM dealer_topups GROUP BY status");
+  foreach ($st->fetchAll() as $row) {
+    $status = $row['status'] ?? '';
+    if (!isset($topupStats[$status])) {
+      continue;
+    }
+    $topupStats[$status]['count']  = (int)$row['c'];
+    $topupStats[$status]['amount'] = (int)$row['total'];
+  }
+} catch (Throwable $e) {}
+
+try {
+  $st = pdo()->prepare("SELECT COUNT(*) AS c, COALESCE(SUM(cashback_amount),0) AS total FROM dealer_package_purchases WHERE cashback_status=?");
+  $st->execute([DEALER_CASHBACK_PENDING]);
+  if ($row = $st->fetch()) {
+    $cashbackSummary['count']  = (int)$row['c'];
+    $cashbackSummary['amount'] = (int)$row['total'];
+  }
+} catch (Throwable $e) {}
+
+try {
+  $campaignCount = (int)pdo()->query("SELECT COUNT(*) FROM campaigns WHERE is_active=1")->fetchColumn();
+} catch (Throwable $e) {}
+
+try {
+  $eventAgg = pdo()->prepare(
+    "SELECT COUNT(*) AS total,
+            SUM(CASE WHEN is_active=1 THEN 1 ELSE 0 END) AS active,
+            SUM(CASE WHEN event_date IS NOT NULL AND event_date >= ? THEN 1 ELSE 0 END) AS upcoming,
+            SUM(CASE WHEN event_date IS NOT NULL AND event_date < ? THEN 1 ELSE 0 END) AS completed
+       FROM events"
+  );
+  $eventAgg->execute([$today, $today]);
   if ($row = $eventAgg->fetch()) {
-    $stats['total_events']    = (int)$row['total_events'];
-    $stats['active_events']   = (int)($row['active_events'] ?? 0);
-    $stats['upcoming_events'] = (int)($row['upcoming_events'] ?? 0);
+    $eventStats['total']     = (int)$row['total'];
+    $eventStats['active']    = (int)($row['active'] ?? 0);
+    $eventStats['upcoming']  = (int)($row['upcoming'] ?? 0);
+    $eventStats['completed'] = (int)($row['completed'] ?? 0);
   }
 } catch (Throwable $e) {}
 
+$pendingTopups = [];
 try {
-  $uploadAgg = pdo()->prepare("SELECT COUNT(*) AS upload_count, COALESCE(SUM(file_size),0) AS total_bytes FROM uploads WHERE venue_id = ?");
-  $uploadAgg->execute([$VID]);
-  if ($row = $uploadAgg->fetch()) {
-    $stats['upload_count']  = (int)($row['upload_count'] ?? 0);
-    $stats['storage_bytes'] = (int)($row['total_bytes'] ?? 0);
-  }
+  $st = pdo()->prepare(
+    "SELECT dt.*, d.name AS dealer_name, d.code AS dealer_code
+       FROM dealer_topups dt
+       INNER JOIN dealers d ON d.id = dt.dealer_id
+       WHERE dt.status IN (?, ?)
+       ORDER BY dt.created_at DESC
+       LIMIT 6"
+  );
+  $st->execute([DEALER_TOPUP_STATUS_PENDING, DEALER_TOPUP_STATUS_AWAITING_REVIEW]);
+  $pendingTopups = $st->fetchAll();
 } catch (Throwable $e) {}
 
+$pendingDealers = [];
 try {
-  $campaignAgg = pdo()->prepare("SELECT COUNT(*) FROM campaigns WHERE venue_id = ? AND is_active = 1");
-  $campaignAgg->execute([$VID]);
-  $stats['active_campaigns'] = (int)$campaignAgg->fetchColumn();
+  $st = pdo()->query("SELECT id, name, email, phone, created_at, code FROM dealers WHERE status='pending' ORDER BY created_at ASC LIMIT 6");
+  $pendingDealers = $st->fetchAll();
 } catch (Throwable $e) {}
 
-$upcomingEvents = [];
-try {
-  $upcomingStmt = pdo()->prepare("SELECT id, title, event_date FROM events WHERE venue_id = ? AND is_active = 1 AND event_date IS NOT NULL AND event_date >= ? ORDER BY event_date ASC LIMIT 5");
-  $upcomingStmt->execute([$VID, $today]);
-  $upcomingEvents = $upcomingStmt->fetchAll();
-} catch (Throwable $e) {}
-
-/* ---- Migrasyonlar (gerekirse) ---- */
-try { pdo()->query("SELECT event_date FROM events LIMIT 1"); }
-catch(Throwable $e){ try{ pdo()->exec("ALTER TABLE events ADD COLUMN event_date DATE NULL"); }catch(Throwable $e2){} }
-
-try { pdo()->query("SELECT 1 FROM campaigns LIMIT 1"); }
-catch(Throwable $e){
-  try{
-    pdo()->exec("
-      CREATE TABLE campaigns (
-        id INT AUTO_INCREMENT PRIMARY KEY,
-        venue_id INT NOT NULL,
-        name VARCHAR(190) NOT NULL,
-        type VARCHAR(120) NOT NULL,
-        description TEXT NULL,
-        price INT NOT NULL DEFAULT 0,
-        is_active TINYINT(1) NOT NULL DEFAULT 1,
-        created_at DATETIME NOT NULL,
-        updated_at DATETIME NULL,
-        FOREIGN KEY (venue_id) REFERENCES venues(id) ON DELETE CASCADE,
-        INDEX (venue_id, is_active)
-      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-    ");
-  }catch(Throwable $e2){}
+function fmt_count($n) {
+  return number_format((int)$n, 0, ',', '.');
 }
 
-/* ---- Etkinlik işlemleri (ÇİFT HESABI İLE) ---- */
-if (($_POST['do'] ?? '') === 'create_event') {
-  csrf_or_die();
+$pendingTopupAmount   = $topupStats[DEALER_TOPUP_STATUS_PENDING]['amount'] ?? 0;
+$pendingTopupCount    = $topupStats[DEALER_TOPUP_STATUS_PENDING]['count'] ?? 0;
+$reviewTopupAmount    = $topupStats[DEALER_TOPUP_STATUS_AWAITING_REVIEW]['amount'] ?? 0;
+$reviewTopupCount     = $topupStats[DEALER_TOPUP_STATUS_AWAITING_REVIEW]['count'] ?? 0;
+$completedTopupAmount = $topupStats[DEALER_TOPUP_STATUS_COMPLETED]['amount'] ?? 0;
+$completedTopupCount  = $topupStats[DEALER_TOPUP_STATUS_COMPLETED]['count'] ?? 0;
 
-  $title = trim($_POST['title'] ?? '');
-  $date  = trim($_POST['event_date'] ?? '');
-  $email = trim($_POST['couple_email'] ?? '');
-  $force_reset = 1;
-
-  if(!$title){ flash('err','Başlık gerekli.'); redirect($_SERVER['PHP_SELF'].'#ev'); }
-  if(!filter_var($email, FILTER_VALIDATE_EMAIL)){ flash('err','Geçerli bir e-posta girin.'); redirect($_SERVER['PHP_SELF'].'#ev'); }
-
-  // salon gerçekten var mı (aktif)?
-  $st = pdo()->prepare("SELECT id FROM venues WHERE id=? AND is_active=1");
-  $st->execute([$VID]);
-  if(!$st->fetch()){
-    flash('err','Geçersiz veya pasif salon. Lütfen salon seçin.');
-    redirect(BASE_URL.'/admin/venues.php');
-  }
-
-  // slug benzersizliği
-  $slug = slugify($title); if ($slug==='') $slug = 'event-'.bin2hex(random_bytes(3));
-  $base=$slug; $i=1;
-  while(true){
-    $chk=pdo()->prepare("SELECT id FROM events WHERE venue_id=? AND slug=?"); $chk->execute([$VID,$slug]);
-    if(!$chk->fetch()) break; $slug=$base.'-'.$i++;
-  }
-
-  $key   = bin2hex(random_bytes(16));
-  $pcol  = defined('THEME_PRIMARY_DEFAULT') ? THEME_PRIMARY_DEFAULT : '#0ea5b5';
-  $acol  = defined('THEME_ACCENT_DEFAULT')  ? THEME_ACCENT_DEFAULT  : '#e0f7fb';
-  $plain_pass = substr(bin2hex(random_bytes(8)),0,12);
-  $hash  = password_hash($plain_pass, PASSWORD_DEFAULT);
-
-  // insert
-  try {
-    $sql="
-      INSERT INTO events
-        (venue_id,user_id,title,slug,couple_panel_key,theme_primary,theme_accent,event_date,created_at,
-         couple_username,couple_password_hash,couple_force_reset,contact_email)
-      VALUES
-        (?,?,?,?,?,?,?,?,?,
-         ?,?,?,?)
-    ";
-    pdo()->prepare($sql)->execute([
-      $VID, ($me['id'] ?? null), $title, $slug, $key, $pcol, $acol, ($date?:null), now(),
-      $email, $hash, $force_reset, $email
-    ]);
-  } catch(Throwable $e){
-    // eski şema desteği (user_id yoksa)
-    $sql="
-      INSERT INTO events
-        (venue_id,title,slug,couple_panel_key,theme_primary,theme_accent,event_date,created_at,
-         couple_username,couple_password_hash,couple_force_reset,contact_email)
-      VALUES
-        (?,?,?,?,?,?,?,?,
-         ?,?,?,?)
-    ";
-    pdo()->prepare($sql)->execute([
-      $VID, $title, $slug, $key, $pcol, $acol, ($date?:null), now(),
-      $email, $hash, $force_reset, $email
-    ]);
-  }
-
-  $eventId = (int)pdo()->lastInsertId();
-  if ($eventId) {
-    couple_set_account($eventId, $email, $plain_pass);
-  }
-
-  flash('ok','Etkinlik oluşturuldu ve giriş bilgileri e-posta ile gönderildi.');
-  redirect($_SERVER['PHP_SELF'].'#ev');
-}
-
-/* Aktif-pasif (toggle) */
-if (($_GET['do'] ?? '')==='toggle' && isset($_GET['id'])) {
-  $eid=(int)$_GET['id'];
-  pdo()->prepare("UPDATE events SET is_active=1-is_active WHERE id=? AND venue_id=?")->execute([$eid,$VID]);
-  redirect($_SERVER['PHP_SELF'].'#ev');
-}
-
-/* Soft-delete (Sil görünür ama pasife alır) — iki kez onay JS ile */
-if (($_POST['do'] ?? '')==='soft_delete' && isset($_POST['event_id'])) {
-  csrf_or_die();
-  $eid = (int)$_POST['event_id'];
-  pdo()->prepare("UPDATE events SET is_active=0 WHERE id=? AND venue_id=?")->execute([$eid,$VID]);
-  flash('ok','Etkinlik pasife alındı (silindi olarak işaretlendi).');
-  redirect($_SERVER['PHP_SELF'].'#ev');
-}
-
-/* ---- QR işlemleri ---- */
-if (($_POST['do'] ?? '')==='create_qr'){
-  csrf_or_die();
-  $code=trim($_POST['code'] ?? ''); if ($code==='') $code='qr-'.bin2hex(random_bytes(3));
-  $code=preg_replace('~[^a-zA-Z0-9_-]+~','',$code);
-  try{
-    pdo()->prepare("INSERT INTO qr_codes (venue_id,code,created_at) VALUES (?,?,?)")->execute([$VID,$code,now()]);
-    flash('ok','Kalıcı QR oluşturuldu.');
-  }catch(Throwable $e){
-    flash('err','Kod zaten var.');
-  }
-  redirect($_SERVER['PHP_SELF'].'#qr');
-}
-if (($_POST['do'] ?? '')==='bind_qr'){
-  csrf_or_die();
-  $qid=(int)($_POST['qr_id'] ?? 0); $eid=(int)($_POST['event_id'] ?? 0);
-  pdo()->prepare("UPDATE qr_codes SET target_event_id=?, updated_at=? WHERE id=? AND venue_id=?")
-      ->execute([$eid,now(),$qid,$VID]);
-  flash('ok','QR hedefi güncellendi.');
-  redirect($_SERVER['PHP_SELF'].'#qr');
-}
-
-/* ---- Filtreler (etkinlik listesi) ---- */
-$q  = trim($_GET['q'] ?? '');
-$df = trim($_GET['date_from'] ?? '');
-$dt = trim($_GET['date_to'] ?? '');
-$where = ["e.venue_id = ?"];
-$args  = [$VID];
-if ($q!==''){ $where[]="(e.title LIKE ? OR e.slug LIKE ?)"; $args[]='%'.$q.'%'; $args[]='%'.$q.'%'; }
-if ($df!==''){ $where[]="(e.event_date IS NOT NULL AND e.event_date >= ?)"; $args[]=$df; }
-if ($dt!==''){ $where[]="(e.event_date IS NOT NULL AND e.event_date <= ?)"; $args[]=$dt; }
-// Sadece aktifleri göster
-$where[] = "e.is_active = 1";
-$W = implode(' AND ',$where);
-
-$sql = "
-  SELECT e.*,
-         (SELECT COUNT(*) FROM uploads u WHERE u.venue_id=e.venue_id AND u.event_id=e.id) AS file_count,
-         (SELECT COALESCE(SUM(u.file_size),0) FROM uploads u WHERE u.venue_id=e.venue_id AND u.event_id=e.id) AS total_bytes
-  FROM events e
-  WHERE $W
-  ORDER BY e.id DESC
-";
-$st = pdo()->prepare($sql); $st->execute($args); $events=$st->fetchAll();
-
-$qr = pdo()->prepare("
-  SELECT q.*, e.title AS ev_title
-  FROM qr_codes q
-  LEFT JOIN events e ON e.id=q.target_event_id
-  WHERE q.venue_id=? ORDER BY q.id DESC
-");
-$qr->execute([$VID]); $qr=$qr->fetchAll();
-$stats['qr_codes'] = count($qr);
-
-function fmt_bytes($b){
-  if ($b<=0) return '0 MB';
-  $mb=$b/1048576; if ($mb<1024) return number_format($mb,1).' MB';
-  return number_format($mb/1024,2).' GB';
-}
-
-function fmt_count($n){
-  return number_format((int)$n,0,',','.');
-}
-
-function days_until_label(?string $date): string {
-  if (!$date) return '';
-  try {
-    $event = new DateTime($date);
-    $today = new DateTime('today');
-  } catch (Throwable $e) {
-    return '';
-  }
-  $diff = (int)$today->diff($event)->format('%r%a');
-  if ($diff === 0) return 'Bugün';
-  if ($diff > 0) return $diff.' gün kaldı';
-  return abs($diff).' gün önce';
-}
+$subtitle = 'Salon: '.$VNAME.' • BİKARE platform göstergeleri';
 ?>
 <!doctype html>
 <html lang="tr">
@@ -259,332 +114,241 @@ function days_until_label(?string $date): string {
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <?=admin_base_styles()?>
 <style>
-  .qr-img{ width:96px; height:96px; border-radius:14px; border:1px solid rgba(148,163,184,.32); background:#fff; object-fit:cover; }
-  .grid-compact .form-control, .grid-compact .form-select{ height:46px; }
-  .section-heading{ display:flex; justify-content:space-between; align-items:center; gap:1rem; margin-bottom:1rem; }
-  .section-heading h5{ margin:0; font-weight:700; }
-  .muted{ color:var(--muted); }
-  .link-badge{ padding:.4rem .75rem; border-radius:12px; background:rgba(14,165,181,.12); font-weight:600; color:var(--brand-dark); display:inline-flex; align-items:center; gap:.4rem; }
-  .btn-zs{ background:var(--brand); border:none; color:#fff; border-radius:12px; font-weight:600; }
-  .btn-zs:hover{ background:var(--brand-dark); color:#fff; }
-  .btn-zs-outline{ background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
-  .btn-zs-outline:hover{ background:rgba(14,165,181,.12); color:var(--brand-dark); }
-  .stats-row .stat-card{ display:flex; align-items:flex-start; gap:16px; position:relative; overflow:hidden; }
-  .stat-icon{ width:56px; height:56px; border-radius:18px; display:flex; align-items:center; justify-content:center; font-size:1.4rem; background:rgba(14,165,181,.12); color:var(--brand); }
-  .stat-meta{ flex:1; }
-  .stat-value{ font-size:1.9rem; font-weight:700; margin-bottom:2px; }
-  .stat-title{ text-transform:uppercase; font-size:.72rem; letter-spacing:.12em; color:var(--muted); font-weight:600; }
-  .stat-sub{ font-size:.85rem; color:var(--admin-muted); }
-  .stat-card::after{ content:''; position:absolute; inset:auto -60px -60px auto; width:160px; height:160px; border-radius:50%; background:rgba(14,165,181,.08); }
-  .quick-links .quick-link{ display:flex; align-items:center; gap:14px; padding:12px 14px; border-radius:14px; border:1px solid rgba(14,165,181,.18); text-decoration:none; color:var(--ink); transition:all .2s ease; }
-  .quick-links .quick-link:hover{ background:rgba(14,165,181,.08); text-decoration:none; color:var(--ink); }
-  .quick-links .quick-link i{ width:42px; height:42px; border-radius:14px; display:flex; align-items:center; justify-content:center; background:rgba(14,165,181,.14); color:var(--brand); font-size:1.2rem; }
-  .quick-links .quick-link strong{ display:block; font-weight:600; }
-  .quick-links .quick-link span{ display:block; font-size:.85rem; color:var(--muted); }
-  .quick-links ul{ list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:12px; }
-  .upcoming-card .upcoming-item{ display:flex; align-items:center; justify-content:space-between; gap:12px; padding:12px 0; border-bottom:1px solid rgba(15,23,42,.08); }
-  .upcoming-card .upcoming-item:last-child{ border-bottom:none; }
-  .upcoming-card .upcoming-item strong{ display:block; font-weight:600; }
-  .upcoming-card .upcoming-item small{ color:var(--muted); }
-  .badge-soon{ background:rgba(14,165,181,.12); color:var(--brand-dark); border-radius:999px; padding:.35rem .9rem; font-size:.75rem; font-weight:600; }
-  .upcoming-card .empty{ color:var(--muted); font-size:.9rem; padding:8px 0; }
-  @media (max-width: 575px){
-    .stat-card{ flex-direction:row; }
-  }
+  .stat-grid .stat-card{ display:flex; gap:18px; align-items:flex-start; background:var(--surface); border-radius:22px; padding:22px; box-shadow:0 24px 60px -38px rgba(14,165,181,.55); position:relative; overflow:hidden; }
+  .stat-grid .stat-card::after{ content:''; position:absolute; inset:auto -70px -70px auto; width:160px; height:160px; border-radius:50%; background:rgba(14,165,181,.1); }
+  .stat-icon{ width:58px; height:58px; border-radius:18px; display:flex; align-items:center; justify-content:center; background:rgba(14,165,181,.15); color:var(--brand); font-size:1.5rem; flex-shrink:0; }
+  .stat-meta{ position:relative; z-index:1; }
+  .stat-title{ font-size:.78rem; letter-spacing:.16em; text-transform:uppercase; color:var(--admin-muted); font-weight:600; margin-bottom:6px; }
+  .stat-value{ font-size:2.1rem; font-weight:700; color:var(--ink); margin-bottom:4px; }
+  .stat-sub{ font-size:.9rem; color:var(--admin-muted); }
+  .quick-actions{ display:grid; gap:16px; }
+  .quick-actions a{ display:flex; align-items:center; justify-content:space-between; background:var(--surface); border-radius:18px; padding:18px 20px; text-decoration:none; color:var(--ink); box-shadow:0 22px 60px -40px rgba(15,23,42,.55); transition:transform .2s ease, box-shadow .2s ease; }
+  .quick-actions a:hover{ transform:translateY(-2px); box-shadow:0 30px 62px -42px rgba(14,165,181,.45); }
+  .quick-actions .info{ display:flex; gap:14px; align-items:center; }
+  .quick-actions .info i{ width:44px; height:44px; border-radius:14px; display:flex; align-items:center; justify-content:center; background:rgba(14,165,181,.15); color:var(--brand); font-size:1.2rem; }
+  .quick-actions .info span{ display:block; font-weight:600; }
+  .quick-actions small{ display:block; font-size:.86rem; color:var(--admin-muted); margin-top:2px; }
+  .status-table{ background:var(--surface); border-radius:22px; padding:22px; box-shadow:0 24px 60px -40px rgba(15,23,42,.48); }
+  .status-table h5{ font-weight:700; margin-bottom:12px; }
+  .status-table table{ font-size:.92rem; margin-bottom:0; }
+  .status-table .empty{ color:var(--admin-muted); font-size:.9rem; }
 </style>
-<script>
-function confirmSoftDelete(){
-  if(!confirm('Bu etkinliği silmek istiyor musunuz?')) return false;
-  return confirm('Emin misiniz? Silinirse panelden kaldırılacak (veriler silinmez).');
-}
-</script>
 </head>
 <body class="admin-body">
-<?php admin_layout_start('dashboard', 'Panel Genel Bakış', 'Salon: '.$VNAME.' • Etkinlik ve QR yönetimi'); ?>
+<?php admin_layout_start('dashboard', 'Genel Bakış', $subtitle); ?>
 
-    <?php flash_box(); ?>
+  <?php flash_box(); ?>
 
-  <div class="stats-row row g-3 mb-4">
-    <div class="col-xl-3 col-md-6">
-      <div class="card-lite stat-card">
-        <div class="stat-icon"><i class="bi bi-lightning-charge"></i></div>
-        <div class="stat-meta">
-          <div class="stat-title">Aktif Etkinlik</div>
-          <div class="stat-value"><?=fmt_count($stats['active_events'])?></div>
-          <div class="stat-sub">Toplam <?=fmt_count($stats['total_events'])?> etkinliğin <strong><?=fmt_count($stats['active_events'])?></strong>'i yayında.</div>
-        </div>
+  <div class="stat-grid row row-cols-1 row-cols-md-2 row-cols-xl-4 g-3 mb-4">
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-shop"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">Toplam Bayi</div>
+        <div class="stat-value"><?=fmt_count($dealerCounts['all'] ?? 0)?></div>
+        <div class="stat-sub">Aktif: <?=fmt_count($dealerCounts['active'] ?? 0)?> • Pasif: <?=fmt_count($dealerCounts['inactive'] ?? 0)?></div>
+      </div>
+    </div></div>
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-person-check"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">Onay Bekleyen Bayi</div>
+        <div class="stat-value"><?=fmt_count($dealerCounts['pending'] ?? 0)?></div>
+        <div class="stat-sub">Yeni başvuruları Bayiler sayfasından inceleyin.</div>
+      </div>
+    </div></div>
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-megaphone"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">Aktif Kampanyalar</div>
+        <div class="stat-value"><?=fmt_count($campaignCount)?></div>
+        <div class="stat-sub">Tüm etkinlik panellerinde yayında.</div>
+      </div>
+    </div></div>
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-calendar-event"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">Aktif Etkinlik</div>
+        <div class="stat-value"><?=fmt_count($eventStats['active'])?></div>
+        <div class="stat-sub">Toplam etkinlik: <?=fmt_count($eventStats['total'])?>.</div>
+      </div>
+    </div></div>
+  </div>
+
+  <div class="stat-grid row row-cols-1 row-cols-md-2 row-cols-xl-4 g-3 mb-4">
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-credit-card"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">Ödeme Bekleyen</div>
+        <div class="stat-value"><?=fmt_count($pendingTopupCount)?></div>
+        <div class="stat-sub">Toplam tutar <?=format_currency($pendingTopupAmount)?>.</div>
+      </div>
+    </div></div>
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-clipboard-check"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">İnceleme Bekleyen</div>
+        <div class="stat-value"><?=fmt_count($reviewTopupCount)?></div>
+        <div class="stat-sub">Doğrulanmayı bekleyen tutar <?=format_currency($reviewTopupAmount)?>.</div>
+      </div>
+    </div></div>
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-cash-coin"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">Tamamlanan Ödemeler</div>
+        <div class="stat-value"><?=fmt_count($completedTopupCount)?></div>
+        <div class="stat-sub">Toplam tahsilat <?=format_currency($completedTopupAmount)?>.</div>
+      </div>
+    </div></div>
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-gift"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">Bekleyen Cashback</div>
+        <div class="stat-value"><?=fmt_count($cashbackSummary['count'])?></div>
+        <div class="stat-sub">Ödenecek tutar <?=format_currency($cashbackSummary['amount'])?>.</div>
+      </div>
+    </div></div>
+  </div>
+
+  <div class="stat-grid row row-cols-1 row-cols-md-2 row-cols-xl-4 g-3 mb-5">
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-flag"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">Yaklaşan Etkinlik</div>
+        <div class="stat-value"><?=fmt_count($eventStats['upcoming'])?></div>
+        <div class="stat-sub">Önümüzdeki tarihler için hazır.</div>
+      </div>
+    </div></div>
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-check2-circle"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">Tamamlanan Etkinlik</div>
+        <div class="stat-value"><?=fmt_count($eventStats['completed'])?></div>
+        <div class="stat-sub">Arşivde güvenli şekilde saklanıyor.</div>
+      </div>
+    </div></div>
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-people"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">Aktif Çiftler</div>
+        <div class="stat-value"><?=fmt_count($eventStats['active'])?></div>
+        <div class="stat-sub">Panel erişimi açık çift sayısı.</div>
+      </div>
+    </div></div>
+    <div class="col"><div class="stat-card">
+      <div class="stat-icon"><i class="bi bi-arrow-repeat"></i></div>
+      <div class="stat-meta">
+        <div class="stat-title">Günlük Güncelleme</div>
+        <div class="stat-value"><?=date('d.m')?></div>
+        <div class="stat-sub">Raporlar güncel verilerden oluşturuldu.</div>
+      </div>
+    </div></div>
+  </div>
+
+  <div class="row g-4 mb-5">
+    <div class="col-xl-6">
+      <div class="status-table h-100">
+        <h5>Bekleyen Ödeme Talepleri</h5>
+        <?php if (!$pendingTopups): ?>
+          <div class="empty">Şu anda bekleyen ödeme talebi bulunmuyor.</div>
+        <?php else: ?>
+          <div class="table-responsive">
+            <table class="table align-middle">
+              <thead><tr><th>Bayi</th><th>Tutar</th><th>Durum</th><th>Tarih</th></tr></thead>
+              <tbody>
+                <?php foreach ($pendingTopups as $req): ?>
+                  <tr>
+                    <td>
+                      <strong><?=h($req['dealer_name'] ?? 'Bayi')?></strong>
+                      <?php if (!empty($req['dealer_code'])): ?>
+                        <div class="text-muted small">Kod: <?=h($req['dealer_code'])?></div>
+                      <?php endif; ?>
+                    </td>
+                    <td><?=format_currency((int)$req['amount_cents'])?></td>
+                    <td><?=h(dealer_topup_status_label($req['status']))?></td>
+                    <td class="text-muted small"><?=h(date('d.m.Y H:i', strtotime($req['created_at'] ?? 'now')))?></td>
+                  </tr>
+                <?php endforeach; ?>
+              </tbody>
+            </table>
+          </div>
+        <?php endif; ?>
+        <a class="btn btn-link px-0 mt-2" href="<?=h(BASE_URL)?>/admin/dealers.php">Bayi faturalandırmasını yönet</a>
       </div>
     </div>
-    <div class="col-xl-3 col-md-6">
-      <div class="card-lite stat-card">
-        <div class="stat-icon"><i class="bi bi-calendar-event"></i></div>
-        <div class="stat-meta">
-          <div class="stat-title">Yaklaşan</div>
-          <div class="stat-value"><?=fmt_count($stats['upcoming_events'])?></div>
-          <div class="stat-sub">Takvimde planlanan etkinlikler arasında.</div>
-        </div>
-      </div>
-    </div>
-    <div class="col-xl-3 col-md-6">
-      <div class="card-lite stat-card">
-        <div class="stat-icon"><i class="bi bi-people"></i></div>
-        <div class="stat-meta">
-          <div class="stat-title">Misafir Yüklemeleri</div>
-          <div class="stat-value"><?=fmt_count($stats['upload_count'])?></div>
-          <div class="stat-sub">Galeri alanında <?=fmt_bytes($stats['storage_bytes'])?> yer kullanılıyor.</div>
-        </div>
-      </div>
-    </div>
-    <div class="col-xl-3 col-md-6">
-      <div class="card-lite stat-card">
-        <div class="stat-icon"><i class="bi bi-megaphone"></i></div>
-        <div class="stat-meta">
-          <div class="stat-title">Kampanyalar & QR</div>
-          <div class="stat-value"><?=fmt_count($stats['active_campaigns'])?></div>
-          <div class="stat-sub">Aktif kampanya · <?=fmt_count($stats['qr_codes'])?> kalıcı QR kodu hazır.</div>
-        </div>
+    <div class="col-xl-6">
+      <div class="status-table h-100">
+        <h5>Onay Bekleyen Bayiler</h5>
+        <?php if (!$pendingDealers): ?>
+          <div class="empty">Bekleyen bayi başvurusu bulunmuyor.</div>
+        <?php else: ?>
+          <div class="table-responsive">
+            <table class="table align-middle">
+              <thead><tr><th>Bayi</th><th>İletişim</th><th>Başvuru</th></tr></thead>
+              <tbody>
+                <?php foreach ($pendingDealers as $dealer): ?>
+                  <tr>
+                    <td>
+                      <strong><?=h($dealer['name'] ?? 'Bayi')?></strong>
+                      <?php if (!empty($dealer['code'])): ?>
+                        <div class="text-muted small">Kod: <?=h($dealer['code'])?></div>
+                      <?php endif; ?>
+                    </td>
+                    <td class="small">
+                      <?php if (!empty($dealer['email'])): ?>
+                        <div><?=h($dealer['email'])?></div>
+                      <?php endif; ?>
+                      <?php if (!empty($dealer['phone'])): ?>
+                        <div><?=h($dealer['phone'])?></div>
+                      <?php endif; ?>
+                    </td>
+                    <td class="text-muted small"><?=h(date('d.m.Y H:i', strtotime($dealer['created_at'] ?? 'now')))?></td>
+                  </tr>
+                <?php endforeach; ?>
+              </tbody>
+            </table>
+          </div>
+        <?php endif; ?>
+        <a class="btn btn-link px-0 mt-2" href="<?=h(BASE_URL)?>/admin/dealers.php?filter=pending">Başvuruları incele</a>
       </div>
     </div>
   </div>
 
-  <div class="row g-3 mb-4">
-    <div class="col-xxl-5 col-xl-6">
-      <div class="card-lite quick-links h-100">
-        <div class="section-heading">
-          <h5>Kolay Erişim</h5>
-          <a class="btn btn-zs-outline" href="<?=h(BASE_URL)?>/admin/venues.php">Salon Seç</a>
+  <div class="row g-4 mb-5">
+    <div class="col-12 col-xl-6">
+      <div class="status-table h-100">
+        <h5>Kolay Erişim</h5>
+        <div class="quick-actions">
+          <a href="<?=h(BASE_URL)?>/admin/venues.php">
+            <div class="info"><i class="bi bi-building"></i><div><span>Salon Yönetimi</span><small>Salonlarınızı ve etkinliklerini düzenleyin.</small></div></div>
+            <i class="bi bi-chevron-right"></i>
+          </a>
+          <a href="<?=h(BASE_URL)?>/admin/campaigns.php">
+            <div class="info"><i class="bi bi-megaphone"></i><div><span>Kampanyalar</span><small>Tüm çift panellerinde yayınlanacak kampanyaları güncelleyin.</small></div></div>
+            <i class="bi bi-chevron-right"></i>
+          </a>
+          <a href="<?=h(BASE_URL)?>/admin/dealers.php">
+            <div class="info"><i class="bi bi-shop"></i><div><span>Bayi Yönetimi</span><small>Başvuruları onaylayın, bakiye ve paketlerini takip edin.</small></div></div>
+            <i class="bi bi-chevron-right"></i>
+          </a>
+          <?php if (is_superadmin()): ?>
+          <a href="<?=h(BASE_URL)?>/admin/dealer_packages.php">
+            <div class="info"><i class="bi bi-box"></i><div><span>Paketler</span><small>Bayi paketleri ve fiyatlandırmasını yönetin.</small></div></div>
+            <i class="bi bi-chevron-right"></i>
+          </a>
+          <?php endif; ?>
         </div>
-        <p class="muted small mb-3">Sık kullandığınız işlemler için kısayollar:</p>
-        <ul>
-          <li>
-            <a class="quick-link" href="<?=h(BASE_URL)?>/admin/venue_events.php">
-              <i class="bi bi-calendar-check"></i>
-              <div>
-                <strong>Etkinlikleri Yönet</strong>
-                <span><?=fmt_count($stats['active_events'])?> aktif etkinlik listeleniyor.</span>
-              </div>
-            </a>
-          </li>
-          <li>
-            <a class="quick-link" href="#ev">
-              <i class="bi bi-plus-circle"></i>
-              <div>
-                <strong>Yeni Etkinlik Oluştur</strong>
-                <span>Çifte e-posta ile giriş bilgileri gönderilir.</span>
-              </div>
-            </a>
-          </li>
-          <li>
-            <a class="quick-link" href="<?=h(BASE_URL)?>/admin/campaigns.php">
-              <i class="bi bi-megaphone"></i>
-              <div>
-                <strong>Kampanyaları Yönet</strong>
-                <span><?=fmt_count($stats['active_campaigns'])?> kampanya yayında.</span>
-              </div>
-            </a>
-          </li>
-          <li>
-            <a class="quick-link" href="#qr">
-              <i class="bi bi-qr-code"></i>
-              <div>
-                <strong>Kalıcı QR Kodlar</strong>
-                <span><?=fmt_count($stats['qr_codes'])?> kod hazır, etkinlik ataması yapabilirsiniz.</span>
-              </div>
-            </a>
-          </li>
+      </div>
+    </div>
+    <div class="col-12 col-xl-6">
+      <div class="status-table h-100">
+        <h5>Notlar</h5>
+        <ul class="mb-0 ps-3">
+          <li>Bayi bakiyeleri PayTR test modunda otomatik olarak onaylanır; canlıya alırken PayTR ayarlarını güncellemeyi unutmayın.</li>
+          <li>Cashback işlemleri onaylandıktan sonra bayi ve müşteri e-postalarına otomatik bilgilendirme gönderilir.</li>
+          <li>Kampanya sayfasından yayınlanan içerikler tüm çift panellerinde eş zamanlı olarak görünür.</li>
         </ul>
       </div>
     </div>
-    <div class="col-xxl-7 col-xl-6">
-      <div class="card-lite upcoming-card h-100">
-        <div class="section-heading">
-          <h5>Yaklaşan Etkinlikler</h5>
-          <a class="btn btn-zs-outline" href="<?=h(BASE_URL)?>/admin/venue_events.php">Tümünü Gör</a>
-        </div>
-        <?php if($upcomingEvents): ?>
-          <?php foreach($upcomingEvents as $ev): ?>
-            <?php $dateLabel = $ev['event_date'] ? date('d.m.Y', strtotime($ev['event_date'])) : 'Tarih Belirsiz'; ?>
-            <div class="upcoming-item">
-              <div>
-                <strong><?=h($ev['title'])?></strong>
-                <small><?=h($dateLabel)?></small>
-              </div>
-              <div class="d-flex align-items-center gap-2">
-                <?php $badge = days_until_label($ev['event_date']); if ($badge): ?>
-                  <span class="badge-soon"><?=h($badge)?></span>
-                <?php endif; ?>
-                <a class="btn btn-zs-outline btn-sm" href="<?=h(BASE_URL)?>/admin/venue_events.php?highlight=<?=$ev['id']?>">Detay</a>
-              </div>
-            </div>
-          <?php endforeach; ?>
-        <?php else: ?>
-          <div class="empty">Yakın tarihte planlanmış etkinlik bulunmuyor. Yeni etkinlikler oluşturduğunuzda burada listelenecek.</div>
-        <?php endif; ?>
-      </div>
-    </div>
-  </div>
-
-  <!-- Yeni Etkinlik -->
-  <div id="ev" class="card-lite mb-4">
-    <div class="section-heading">
-      <h5>Yeni Etkinlik Oluştur</h5>
-      <a class="btn btn-zs-outline" href="<?=h(BASE_URL)?>/admin/campaigns.php">Kampanyaları Yönet</a>
-    </div>
-    <p class="muted small mb-4">E-posta alanına yazdığınız kullanıcıya otomatik olarak geçici şifre gönderilir ve ilk girişte şifre yenilemesi istenir.</p>
-    <form method="post" class="row g-3 grid-compact">
-      <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-      <input type="hidden" name="do" value="create_event">
-      <div class="col-md-4">
-        <label class="form-label">Etkinlik Başlığı</label>
-        <input class="form-control" name="title" placeholder="Örn: Bahar Daveti" required>
-      </div>
-      <div class="col-md-4">
-        <label class="form-label">Çift E-posta Adresi</label>
-        <input class="form-control" name="couple_email" type="email" placeholder="ornek@eposta.com" required>
-      </div>
-      <div class="col-md-4">
-        <label class="form-label">Etkinlik Tarihi</label>
-        <input class="form-control" name="event_date" type="date" value="<?=h(date('Y-m-d'))?>">
-      </div>
-      <div class="col-12">
-        <button class="btn btn-zs" type="submit">Etkinliği Oluştur ve Davet Gönder</button>
-      </div>
-    </form>
-  </div>
-
-  <!-- Etkinlik Listesi -->
-  <div class="card-lite mb-4">
-    <div class="section-heading">
-      <h5>Etkinliklerim</h5>
-      <form class="d-flex align-items-center gap-2" method="get">
-        <input type="date" class="form-control" name="date_from" value="<?=h($df)?>" placeholder="Başlangıç">
-        <input type="date" class="form-control" name="date_to" value="<?=h($dt)?>" placeholder="Bitiş">
-        <input type="search" class="form-control" name="q" value="<?=h($q)?>" placeholder="Başlık veya kısa adres">
-        <button class="btn btn-zs-outline" type="submit">Filtrele</button>
-      </form>
-    </div>
-    <?php if(!$events): ?>
-      <div class="muted">Henüz etkinlik oluşturulmadı.</div>
-    <?php else: ?>
-      <div class="table-responsive">
-        <table class="table align-middle">
-          <thead>
-            <tr>
-              <th>Başlık</th>
-              <th>Tarih</th>
-              <th>Linkler</th>
-              <th class="text-center">Dosya</th>
-              <th class="text-center">Toplam Boyut</th>
-              <th>Durum</th>
-              <th style="width:90px">Sil</th>
-            </tr>
-          </thead>
-          <tbody>
-            <?php foreach($events as $e):
-              $pub = public_upload_url($e['id']);
-              $couple_link = BASE_URL.'/couple/index.php?event='.$e['id'].'&key='.$e['couple_panel_key'];
-            ?>
-              <tr>
-                <td class="fw-semibold">
-                  <?=h($e['title'])?>
-                  <div class="small muted"><?=h($e['slug'])?></div>
-                </td>
-                <td class="small"><?= $e['event_date'] ? h($e['event_date']) : '—' ?></td>
-                <td class="small">
-                  <a class="link-badge text-decoration-none" target="_blank" href="<?=h($pub)?>">Misafir Yükleme</a>
-                  <a class="link-badge text-decoration-none" target="_blank" href="<?=h($couple_link)?>">Etkinlik Paneli</a>
-                </td>
-                <td class="text-center"><span class="badge bg-secondary"><?= (int)$e['file_count'] ?></span></td>
-                <td class="text-center"><?= fmt_bytes((int)$e['total_bytes']) ?></td>
-                <td>
-                  <a class="btn btn-sm <?= $e['is_active']?'btn-success':'btn-outline-secondary' ?>" href="?do=toggle&id=<?=$e['id']?>#ev">
-                    <?= $e['is_active']?'Aktif':'Pasif' ?>
-                  </a>
-                </td>
-                <td>
-                  <form method="post" onsubmit="return confirmSoftDelete()">
-                    <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-                    <input type="hidden" name="do" value="soft_delete">
-                    <input type="hidden" name="event_id" value="<?=$e['id']?>">
-                    <button class="btn btn-sm btn-outline-danger w-100">Sil</button>
-                  </form>
-                </td>
-              </tr>
-            <?php endforeach; ?>
-          </tbody>
-        </table>
-      </div>
-    <?php endif; ?>
-  </div>
-
-  <!-- Kalıcı QR Yönetimi -->
-  <div id="qr" class="card-lite mb-4">
-    <h5 class="mb-3">Kalıcı QR Kodlar</h5>
-    <form method="post" class="row g-2 align-items-end mb-3 grid-compact">
-      <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-      <input type="hidden" name="do" value="create_qr">
-      <div class="col-md-5">
-        <label class="form-label">Kod (opsiyonel)</label>
-        <input name="code" class="form-control" placeholder="salon-brosur-2025">
-      </div>
-      <div class="col-md-3 d-grid">
-        <button class="btn btn-zs-outline">QR Oluştur</button>
-      </div>
-      <div class="col-md-4 small muted">
-        Broşür URL: <code>/qr.php?code=&lt;KOD&gt;&amp;v=<?=h($VSLUG)?></code>
-      </div>
-    </form>
-
-    <?php if(!$qr): ?>
-      <div class="muted">QR kod yok.</div>
-    <?php else: ?>
-      <div class="table-responsive">
-        <table class="table align-middle">
-          <thead><tr><th>Kod</th><th>Önizleme</th><th>Bağlı Etkinlik</th><th style="width:420px">Hedefi Değiştir</th><th style="width:160px">PDF</th></tr></thead>
-          <tbody>
-            <?php foreach($qr as $q):
-              $qrLink = BASE_URL.'/qr.php?code='.rawurlencode($q['code']).'&v='.rawurlencode($VSLUG);
-              $img    = 'https://api.qrserver.com/v1/create-qr-code/?size=240x240&data='.rawurlencode($qrLink);
-            ?>
-              <tr>
-                <td>
-                  <div class="fw-semibold"><?=h($q['code'])?></div>
-                  <div class="small"><a target="_blank" href="<?=h($qrLink)?>">Kalıcı URL</a></div>
-                </td>
-                <td><img class="qr-img" src="<?=h($img)?>" alt="qr"></td>
-                <td><?= $q['ev_title'] ? h($q['ev_title']) : '<span class="muted">—</span>' ?></td>
-                <td>
-                  <form method="post" class="row g-2 grid-compact">
-                    <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-                    <input type="hidden" name="do" value="bind_qr">
-                    <input type="hidden" name="qr_id" value="<?=$q['id']?>">
-                    <div class="col-md-8">
-                      <select name="event_id" class="form-select" required>
-                        <option value="">Seçiniz…</option>
-                        <?php foreach($events as $ev): ?>
-                          <option value="<?=$ev['id']?>" <?= $q['target_event_id']==$ev['id']?'selected':'' ?>>
-                            <?=h($ev['title'])?> <?= $ev['event_date']?'('.h($ev['event_date']).')':'' ?>
-                          </option>
-                        <?php endforeach; ?>
-                      </select>
-                    </div>
-                    <div class="col-md-4 d-grid">
-                      <button class="btn btn-zs">Kaydet</button>
-                    </div>
-                  </form>
-                </td>
-                <td>
-                  <a class="btn btn-sm btn-zs-outline w-100" target="_blank"
-                     href="<?=h(BASE_URL)?>/qr_pdf.php?code=<?=rawurlencode($q['code'])?>&v=<?=rawurlencode($VSLUG)?>">
-                     QR PDF İndir
-                  </a>
-                </td>
-              </tr>
-            <?php endforeach; ?>
-          </tbody>
-        </table>
-      </div>
-    <?php endif; ?>
   </div>
 
 <?php admin_layout_end(); ?>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -9,20 +9,11 @@ require_once __DIR__.'/partials/ui.php';
 require_admin();
 install_schema();
 
-$me = admin_user();
-
-/* Salon doğrulaması */
-if (function_exists('require_current_venue_or_redirect')) {
-  $venue = require_current_venue_or_redirect();
-  $VID   = (int)$venue['id'];
-  $VNAME = $venue['name'];
-  $VSLUG = $venue['slug'];
-} else {
-  if (empty($_SESSION['venue_id'])) { redirect(BASE_URL.'/admin/venues.php'); }
-  $VID   = (int)$_SESSION['venue_id'];
-  $VNAME = $_SESSION['venue_name'] ?? 'Salon';
-  $VSLUG = $_SESSION['venue_slug'] ?? '';
-}
+$me    = admin_user();
+$venue = require_current_venue_or_redirect();
+$VID   = (int)$venue['id'];
+$VNAME = $venue['name'];
+$VSLUG = $venue['slug'];
 
 /* ---- Migrasyonlar (gerekirse) ---- */
 try { pdo()->query("SELECT event_date FROM events LIMIT 1"); }

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -77,14 +77,6 @@ if (($_POST['do'] ?? '') === 'create_event') {
     if(!$chk->fetch()) break; $slug=$base.'-'.$i++;
   }
 
-  // aynı e-posta başka etkinlikte kullanılmış mı? (isteğe bağlı engel)
-  $same = pdo()->prepare("SELECT id FROM events WHERE couple_username=? LIMIT 1");
-  $same->execute([$email]);
-  if($same->fetch()){
-    flash('err','Bu e-posta başka bir etkinlik için tanımlı. Lütfen farklı bir e-posta kullanın.');
-    redirect($_SERVER['PHP_SELF'].'#ev');
-  }
-
   $key   = bin2hex(random_bytes(16));
   $pcol  = defined('THEME_PRIMARY_DEFAULT') ? THEME_PRIMARY_DEFAULT : '#0ea5b5';
   $acol  = defined('THEME_ACCENT_DEFAULT')  ? THEME_ACCENT_DEFAULT  : '#e0f7fb';

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -225,14 +225,12 @@ function confirmSoftDelete(){
 </script>
 </head>
 <body class="admin-body">
-<?php render_admin_topnav('dashboard', 'Panel Genel Bakış', 'Salon: '.$VNAME.' • Etkinlik ve QR yönetimi'); ?>
+<?php admin_layout_start('dashboard', 'Panel Genel Bakış', 'Salon: '.$VNAME.' • Etkinlik ve QR yönetimi'); ?>
 
-<main class="admin-main">
-  <div class="container">
     <?php flash_box(); ?>
 
   <!-- Yeni Etkinlik -->
-  <div id="ev" class="card-lite p-3 mb-4">
+  <div id="ev" class="card-lite mb-4">
     <div class="section-heading">
       <h5>Yeni Etkinlik Oluştur</h5>
       <a class="btn btn-zs-outline" href="<?=h(BASE_URL)?>/admin/campaigns.php">Kampanyaları Yönet</a>
@@ -260,7 +258,7 @@ function confirmSoftDelete(){
   </div>
 
   <!-- Etkinlik Listesi -->
-  <div class="card-lite p-3 mb-4">
+  <div class="card-lite mb-4">
     <div class="section-heading">
       <h5>Etkinliklerim</h5>
       <form class="d-flex align-items-center gap-2" method="get">
@@ -325,7 +323,7 @@ function confirmSoftDelete(){
   </div>
 
   <!-- Kalıcı QR Yönetimi -->
-  <div id="qr" class="card-lite p-3 mb-4">
+  <div id="qr" class="card-lite mb-4">
     <h5 class="mb-3">Kalıcı QR Kodlar</h5>
     <form method="post" class="row g-2 align-items-end mb-3 grid-compact">
       <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
@@ -394,7 +392,6 @@ function confirmSoftDelete(){
     <?php endif; ?>
   </div>
 
-  </div>
-</main>
+<?php admin_layout_end(); ?>
 </body>
 </html>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -4,6 +4,7 @@ require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
 
 require_admin();
 install_schema();
@@ -257,17 +258,18 @@ function fmt_bytes($b){
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?=h(APP_NAME)?> — Panel (<?=h($VNAME)?>)</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
 <style>
-  :root{ --zs:#0ea5b5; --zs-soft:#e0f7fb; --ink:#111827; --muted:#6b7280; }
-  body{ background:linear-gradient(180deg,var(--zs-soft),#fff) no-repeat }
-  .card-lite{ border:1px solid #eef2f7; border-radius:18px; background:#fff; box-shadow:0 6px 20px rgba(17,24,39,.05) }
-  .btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:12px; padding:.6rem 1rem; font-weight:600 }
-  .btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:12px; font-weight:600 }
-  .link-badge{ padding:.35rem .6rem; border-radius:10px; background:#f3f6fb; display:inline-block; }
-  .muted{ color:var(--muted) }
-  .title-chip{ padding:.35rem .7rem; border-radius:999px; background:#eef5ff; font-weight:600 }
-  .qr-img{ width:96px; height:96px; border-radius:12px; border:1px solid #e5e7eb }
-  .grid-compact .form-control, .grid-compact .form-select{ height:42px }
+  .qr-img{ width:96px; height:96px; border-radius:14px; border:1px solid rgba(148,163,184,.32); background:#fff; object-fit:cover; }
+  .grid-compact .form-control, .grid-compact .form-select{ height:46px; }
+  .section-heading{ display:flex; justify-content:space-between; align-items:center; gap:1rem; margin-bottom:1rem; }
+  .section-heading h5{ margin:0; font-weight:700; }
+  .muted{ color:var(--muted); }
+  .link-badge{ padding:.4rem .75rem; border-radius:12px; background:rgba(14,165,181,.12); font-weight:600; color:var(--brand-dark); display:inline-flex; align-items:center; gap:.4rem; }
+  .btn-zs{ background:var(--brand); border:none; color:#fff; border-radius:12px; font-weight:600; }
+  .btn-zs:hover{ background:var(--brand-dark); color:#fff; }
+  .btn-zs-outline{ background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
+  .btn-zs-outline:hover{ background:rgba(14,165,181,.12); color:var(--brand-dark); }
 </style>
 <script>
 function confirmSoftDelete(){
@@ -276,24 +278,12 @@ function confirmSoftDelete(){
 }
 </script>
 </head>
-<body>
-<nav class="navbar bg-white border-bottom">
+<body class="admin-body">
+<?php render_admin_topnav('dashboard', 'Panel Genel Bakış', 'Salon: '.$VNAME.' • Düğün ve kampanya yönetimi'); ?>
+
+<main class="admin-main">
   <div class="container">
-    <a class="navbar-brand fw-semibold" href="<?=h(BASE_URL)?>"><?=h(APP_NAME)?></a>
-    <div class="d-flex align-items-center gap-3 small">
-      <span class="title-chip">Salon: <?=h($VNAME)?></span>
-      <a class="text-decoration-none" href="<?=h(BASE_URL)?>/admin/venues.php">Salon Değiştir</a>
-      <span>•</span>
-      <span>Admin: <?= h($me['name'] ?? ($_SESSION['uname'] ?? 'Kullanıcı')) ?></span>
-      <span>•</span>
-
-      <a href="<?=h(BASE_URL)?>/admin/login.php?logout=1">Çıkış</a>
-    </div>
-  </div>
-</nav>
-
-<div class="container py-4">
-  <?php flash_box(); ?>
+    <?php flash_box(); ?>
 
   <!-- Kampanyalar -->
   <div id="cmp" class="card-lite p-3 mb-4">
@@ -569,6 +559,7 @@ function confirmSoftDelete(){
     <?php endif; ?>
   </div>
 
-</div>
+  </div>
+</main>
 </body>
 </html>

--- a/admin/dealer_packages.php
+++ b/admin/dealer_packages.php
@@ -106,9 +106,7 @@ $editPackage = $editId ? dealer_package_get($editId) : null;
 </style>
 </head>
 <body class="admin-body">
-<?php render_admin_topnav('packages', 'Paket Yönetimi', 'Bayi paketlerini oluşturun, fiyatlarını güncelleyin ve satış durumlarını yönetin.'); ?>
-<main class="admin-main">
-  <div class="container">
+<?php admin_layout_start('packages', 'Paket Yönetimi', 'Bayi paketlerini oluşturun, fiyatlarını güncelleyin ve satış durumlarını yönetin.'); ?>
     <?php flash_box(); ?>
     <div class="row g-4">
       <div class="col-lg-5">
@@ -204,7 +202,6 @@ $editPackage = $editId ? dealer_package_get($editId) : null;
         </div>
       </div>
     </div>
-  </div>
-</main>
+<?php admin_layout_end(); ?>
 </body>
 </html>

--- a/admin/dealer_packages.php
+++ b/admin/dealer_packages.php
@@ -88,6 +88,20 @@ $packages = dealer_packages_all(false);
 $editId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $editPackage = $editId ? dealer_package_get($editId) : null;
 
+$packageTotals = [
+  'all'    => count($packages),
+  'active' => 0,
+  'public' => 0,
+];
+foreach ($packages as $pkg) {
+  if (!empty($pkg['is_active'])) {
+    $packageTotals['active']++;
+  }
+  if (!empty($pkg['is_public'])) {
+    $packageTotals['public']++;
+  }
+}
+
 ?>
 <!doctype html>
 <html lang="tr">
@@ -98,20 +112,71 @@ $editPackage = $editId ? dealer_package_get($editId) : null;
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <?=admin_base_styles()?>
 <style>
-  .card-lite form .form-label{font-weight:600;}
-  .table thead th{vertical-align:middle;}
-  .badge-status{padding:.35rem .75rem;border-radius:999px;font-size:.75rem;font-weight:600;}
-  .status-active{background:rgba(34,197,94,.15);color:#15803d;}
-  .status-passive{background:rgba(248,113,113,.16);color:#b91c1c;}
+  .card-lite form .form-label { font-weight:600; }
+  .stats-row .stat-card {
+    border-radius:18px;
+    background:#fff;
+    border:1px solid rgba(14,165,181,.12);
+    padding:22px 24px;
+    box-shadow:0 28px 52px -38px rgba(14,165,181,.6);
+    display:flex;
+    flex-direction:column;
+    gap:6px;
+  }
+  .stats-row .stat-label { font-size:.78rem; color:var(--admin-muted); letter-spacing:.08em; text-transform:uppercase; }
+  .stats-row .stat-value { font-size:1.9rem; font-weight:700; color:var(--admin-ink); }
+  .stats-row .stat-chip { display:inline-flex; align-items:center; gap:6px; padding:.28rem .9rem; border-radius:999px; background:rgba(14,165,181,.12); color:var(--admin-brand-dark); font-size:.75rem; font-weight:600; }
+
+  .package-table thead th { vertical-align:middle; white-space:nowrap; }
+  .package-table .badge-status { padding:.35rem .85rem; border-radius:999px; font-size:.75rem; font-weight:600; }
+  .package-table .status-active { background:rgba(34,197,94,.18); color:#15803d; }
+  .package-table .status-passive { background:rgba(248,113,113,.18); color:#b91c1c; }
+  .package-table .status-public { background:rgba(14,165,181,.18); color:var(--admin-brand-dark); }
+  .package-table .action-group { display:flex; gap:8px; flex-wrap:wrap; }
+
+  .package-summary { border-radius:16px; background:rgba(14,165,181,.08); padding:18px; }
 </style>
 </head>
 <body class="admin-body">
 <?php admin_layout_start('packages', 'Paket Yönetimi', 'Bayi paketlerini oluşturun, fiyatlarını güncelleyin ve satış durumlarını yönetin.'); ?>
     <?php flash_box(); ?>
+
+    <div class="row g-3 stats-row mb-4">
+      <div class="col-md-4">
+        <div class="stat-card">
+          <span class="stat-label">Toplam Paket</span>
+          <span class="stat-value"><?=$packageTotals['all']?></span>
+          <span class="stat-chip"><i class="bi bi-boxes me-1"></i>Portföy</span>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="stat-card">
+          <span class="stat-label">Satışta</span>
+          <span class="stat-value text-success"><?=$packageTotals['active']?></span>
+          <span class="stat-chip"><i class="bi bi-graph-up-arrow me-1"></i>Aktif</span>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="stat-card">
+          <span class="stat-label">Web'de Yayında</span>
+          <span class="stat-value text-primary"><?=$packageTotals['public']?></span>
+          <span class="stat-chip"><i class="bi bi-globe2 me-1"></i>Site</span>
+        </div>
+      </div>
+    </div>
+
     <div class="row g-4">
       <div class="col-lg-5">
-        <div class="card-lite p-4">
-          <h5 class="mb-3"><?= $editPackage ? 'Paketi Güncelle' : 'Yeni Paket Oluştur' ?></h5>
+        <div class="card-lite p-4 h-100">
+          <div class="d-flex justify-content-between align-items-start mb-3">
+            <div>
+              <h5 class="mb-1"><?= $editPackage ? 'Paketi Güncelle' : 'Yeni Paket Oluştur' ?></h5>
+              <p class="small text-muted mb-0">Bayi paketlerinizi fiyat, hak ve cashback kurallarına göre düzenleyin.</p>
+            </div>
+            <?php if ($editPackage): ?>
+              <a href="<?=h($_SERVER['PHP_SELF'])?>" class="btn btn-light border btn-sm"><i class="bi bi-x-lg"></i></a>
+            <?php endif; ?>
+          </div>
           <form method="post" class="row g-3">
             <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
             <input type="hidden" name="do" value="save">
@@ -122,7 +187,7 @@ $editPackage = $editId ? dealer_package_get($editId) : null;
             </div>
             <div class="col-12">
               <label class="form-label">Fiyat (TL)</label>
-              <input class="form-control" name="price" value="<?= $editPackage ? number_format($editPackage['price_cents']/100, 2, ',', '') : ''?>" placeholder="Örn. 3000" required>
+              <input class="form-control" name="price" value="<?= $editPackage ? number_format($editPackage['price_cents']/100,2, ',', '') : ''?>" placeholder="Örn. 3000" required>
             </div>
             <div class="col-md-6">
               <label class="form-label">Etkinlik Hakkı</label>
@@ -155,11 +220,27 @@ $editPackage = $editId ? dealer_package_get($editId) : null;
         </div>
       </div>
       <div class="col-lg-7">
-        <div class="card-lite p-4">
-          <h5 class="mb-3">Paket Listesi</h5>
+        <div class="card-lite p-4 h-100">
+          <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-2 mb-3">
+            <h5 class="mb-0">Paket Listesi</h5>
+            <div class="package-summary small">
+              <strong><?=$packageTotals['active']?> paket</strong> satışta • <?=$packageTotals['public']?> paket web sitesinde yayınlanıyor.
+            </div>
+          </div>
           <div class="table-responsive">
-            <table class="table align-middle mb-0">
-              <thead><tr><th>Ad</th><th>Fiyat</th><th>Etkinlik</th><th>Süre</th><th>Cashback</th><th>Web</th><th>Durum</th><th></th></tr></thead>
+            <table class="table align-middle mb-0 package-table">
+              <thead>
+                <tr>
+                  <th>Paket</th>
+                  <th>Fiyat</th>
+                  <th>Etkinlik</th>
+                  <th>Süre</th>
+                  <th>Cashback</th>
+                  <th>Web</th>
+                  <th>Durum</th>
+                  <th style="width:200px">İşlemler</th>
+                </tr>
+              </thead>
               <tbody>
                 <?php if (!$packages): ?>
                   <tr><td colspan="8" class="text-center text-muted">Tanımlı paket bulunmuyor.</td></tr>
@@ -171,27 +252,30 @@ $editPackage = $editId ? dealer_package_get($editId) : null;
                       $quotaLabel = $pkg['event_quota'] === null ? 'Sınırsız' : $pkg['event_quota'];
                       $durationLabel = $pkg['duration_days'] === null ? 'Süre yok' : $pkg['duration_days'].' gün';
                       $cashbackLabel = $pkg['cashback_rate'] > 0 ? number_format($pkg['cashback_rate'] * 100, 1).'%' : '—';
-                      $publicLabel = $pkg['is_public'] ? 'Evet' : 'Hayır';
                     ?>
                     <tr>
                       <td>
-                        <div class="fw-semibold"><?=h($pkg['name'])?></div>
+                        <div class="fw-semibold mb-1"><?=h($pkg['name'])?></div>
                         <?php if (!empty($pkg['description'])): ?><div class="small text-muted"><?=h($pkg['description'])?></div><?php endif; ?>
                       </td>
                       <td><?=h(format_currency($pkg['price_cents']))?></td>
                       <td><?=h($quotaLabel)?></td>
                       <td><?=h($durationLabel)?></td>
                       <td><?=h($cashbackLabel)?></td>
-                      <td><?=h($publicLabel)?></td>
+                      <td>
+                        <span class="badge-status <?= $pkg['is_public'] ? 'status-public' : 'status-passive' ?>"><?= $pkg['is_public'] ? 'Yayında' : 'Gizli' ?></span>
+                      </td>
                       <td><span class="badge-status <?=$statusClass?>"><?=h($statusLabel)?></span></td>
-                      <td class="text-end">
-                        <a class="btn btn-sm btn-outline-primary" href="?id=<?= (int)$pkg['id'] ?>">Düzenle</a>
-                        <form method="post" class="d-inline">
-                          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-                          <input type="hidden" name="do" value="toggle">
-                          <input type="hidden" name="package_id" value="<?= (int)$pkg['id'] ?>">
-                          <button class="btn btn-sm btn-outline-secondary" type="submit"><?= $pkg['is_active'] ? 'Pasifleştir' : 'Aktifleştir' ?></button>
-                        </form>
+                      <td>
+                        <div class="action-group justify-content-end">
+                          <a class="btn btn-sm btn-brand-outline" href="?id=<?= (int)$pkg['id'] ?>"><i class="bi bi-pencil me-1"></i>Düzenle</a>
+                          <form method="post">
+                            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                            <input type="hidden" name="do" value="toggle">
+                            <input type="hidden" name="package_id" value="<?= (int)$pkg['id'] ?>">
+                            <button class="btn btn-sm btn-light border" type="submit"><i class="bi bi-shuffle me-1"></i><?= $pkg['is_active'] ? 'Pasifleştir' : 'Aktifleştir' ?></button>
+                          </form>
+                        </div>
                       </td>
                     </tr>
                   <?php endforeach; ?>

--- a/admin/dealer_packages.php
+++ b/admin/dealer_packages.php
@@ -1,0 +1,203 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
+
+require_admin();
+require_superadmin();
+install_schema();
+
+$action = $_POST['do'] ?? '';
+if ($action) {
+  csrf_or_die();
+}
+
+if ($action === 'save') {
+  $packageId = (int)($_POST['package_id'] ?? 0);
+  $name = trim($_POST['name'] ?? '');
+  $priceInput = $_POST['price'] ?? '';
+  $quotaInput = trim($_POST['event_quota'] ?? '');
+  $durationInput = trim($_POST['duration_days'] ?? '');
+  $cashbackInput = trim($_POST['cashback_rate'] ?? '0');
+  $description = trim($_POST['description'] ?? '');
+  $isActive = isset($_POST['is_active']) ? 1 : 0;
+
+  if ($name === '') {
+    flash('err', 'Paket adı zorunludur.');
+    redirect($_SERVER['PHP_SELF'].($packageId ? '?id='.$packageId : ''));
+  }
+
+  $priceCents = money_to_cents($priceInput);
+  if ($priceCents <= 0) {
+    flash('err', 'Geçerli bir fiyat girin.');
+    redirect($_SERVER['PHP_SELF'].($packageId ? '?id='.$packageId : ''));
+  }
+
+  $eventQuota = ($quotaInput === '' ? null : max(0, (int)$quotaInput));
+  if ($eventQuota === 0) {
+    $eventQuota = null;
+  }
+  $durationDays = ($durationInput === '' ? null : max(0, (int)$durationInput));
+  if ($durationDays === 0) {
+    $durationDays = null;
+  }
+
+  $cashbackPercent = (float)str_replace(',', '.', $cashbackInput);
+  if ($cashbackPercent < 0) $cashbackPercent = 0;
+  if ($cashbackPercent > 100) $cashbackPercent = 100;
+  $cashbackRate = $cashbackPercent / 100;
+
+  if ($eventQuota !== null && $eventQuota < 1) {
+    flash('err', 'Etkinlik hakkı en az 1 olmalıdır.');
+    redirect($_SERVER['PHP_SELF'].($packageId ? '?id='.$packageId : ''));
+  }
+
+  $now = now();
+  if ($packageId > 0) {
+    $st = pdo()->prepare("UPDATE dealer_packages SET name=?, description=?, price_cents=?, event_quota=?, duration_days=?, cashback_rate=?, is_active=?, updated_at=? WHERE id=?");
+    $st->execute([$name, $description ?: null, $priceCents, $eventQuota, $durationDays, $cashbackRate, $isActive, $now, $packageId]);
+    flash('ok', 'Paket güncellendi.');
+    redirect($_SERVER['PHP_SELF'].'?id='.$packageId);
+  } else {
+    $st = pdo()->prepare("INSERT INTO dealer_packages (name, description, price_cents, event_quota, duration_days, cashback_rate, is_active, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?)");
+    $st->execute([$name, $description ?: null, $priceCents, $eventQuota, $durationDays, $cashbackRate, $isActive, $now, $now]);
+    flash('ok', 'Yeni paket oluşturuldu.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+}
+
+if ($action === 'toggle') {
+  $packageId = (int)($_POST['package_id'] ?? 0);
+  $pkg = dealer_package_get($packageId);
+  if (!$pkg) {
+    flash('err', 'Paket bulunamadı.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+  $newStatus = $pkg['is_active'] ? 0 : 1;
+  pdo()->prepare("UPDATE dealer_packages SET is_active=?, updated_at=? WHERE id=?")
+      ->execute([$newStatus, now(), $packageId]);
+  flash('ok', 'Paket durumu güncellendi.');
+  redirect($_SERVER['PHP_SELF']);
+}
+
+$packages = dealer_packages_all(false);
+$editId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$editPackage = $editId ? dealer_package_get($editId) : null;
+
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Paketleri</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
+<style>
+  .card-lite form .form-label{font-weight:600;}
+  .table thead th{vertical-align:middle;}
+  .badge-status{padding:.35rem .75rem;border-radius:999px;font-size:.75rem;font-weight:600;}
+  .status-active{background:rgba(34,197,94,.15);color:#15803d;}
+  .status-passive{background:rgba(248,113,113,.16);color:#b91c1c;}
+</style>
+</head>
+<body class="admin-body">
+<?php render_admin_topnav('packages', 'Paket Yönetimi', 'Bayi paketlerini oluşturun, fiyatlarını güncelleyin ve satış durumlarını yönetin.'); ?>
+<main class="admin-main">
+  <div class="container">
+    <?php flash_box(); ?>
+    <div class="row g-4">
+      <div class="col-lg-5">
+        <div class="card-lite p-4">
+          <h5 class="mb-3"><?= $editPackage ? 'Paketi Güncelle' : 'Yeni Paket Oluştur' ?></h5>
+          <form method="post" class="row g-3">
+            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="do" value="save">
+            <input type="hidden" name="package_id" value="<?= $editPackage ? (int)$editPackage['id'] : 0 ?>">
+            <div class="col-12">
+              <label class="form-label">Paket Adı</label>
+              <input class="form-control" name="name" value="<?=h($editPackage['name'] ?? '')?>" required>
+            </div>
+            <div class="col-12">
+              <label class="form-label">Fiyat (TL)</label>
+              <input class="form-control" name="price" value="<?= $editPackage ? number_format($editPackage['price_cents']/100, 2, ',', '') : ''?>" placeholder="Örn. 3000" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Etkinlik Hakkı</label>
+              <input type="number" min="1" class="form-control" name="event_quota" value="<?= $editPackage && $editPackage['event_quota'] !== null ? (int)$editPackage['event_quota'] : '' ?>" placeholder="Sınırsız için boş bırakın">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Süre (gün)</label>
+              <input type="number" min="0" class="form-control" name="duration_days" value="<?= $editPackage && $editPackage['duration_days'] !== null ? (int)$editPackage['duration_days'] : '' ?>" placeholder="Süre yoksa boş">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Cashback (%)</label>
+              <input type="number" step="0.1" min="0" max="100" class="form-control" name="cashback_rate" value="<?= $editPackage ? number_format($editPackage['cashback_rate'] * 100, 1, ',', '') : '0' ?>">
+            </div>
+            <div class="col-12">
+              <label class="form-label">Açıklama</label>
+              <textarea class="form-control" name="description" rows="3"><?=h($editPackage['description'] ?? '')?></textarea>
+            </div>
+            <div class="col-12 form-check ms-2">
+              <input class="form-check-input" type="checkbox" name="is_active" id="is_active" <?= !$editPackage || !empty($editPackage['is_active']) ? 'checked' : '' ?>>
+              <label class="form-check-label" for="is_active">Paket satışta</label>
+            </div>
+            <div class="col-12 d-grid">
+              <button class="btn btn-brand" type="submit"><?= $editPackage ? 'Paketi Güncelle' : 'Paketi Kaydet' ?></button>
+            </div>
+          </form>
+        </div>
+      </div>
+      <div class="col-lg-7">
+        <div class="card-lite p-4">
+          <h5 class="mb-3">Paket Listesi</h5>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0">
+              <thead><tr><th>Ad</th><th>Fiyat</th><th>Etkinlik</th><th>Süre</th><th>Cashback</th><th>Durum</th><th></th></tr></thead>
+              <tbody>
+                <?php if (!$packages): ?>
+                  <tr><td colspan="7" class="text-center text-muted">Tanımlı paket bulunmuyor.</td></tr>
+                <?php else: ?>
+                  <?php foreach ($packages as $pkg): ?>
+                    <?php
+                      $statusClass = $pkg['is_active'] ? 'status-active' : 'status-passive';
+                      $statusLabel = $pkg['is_active'] ? 'Satışta' : 'Pasif';
+                      $quotaLabel = $pkg['event_quota'] === null ? 'Sınırsız' : $pkg['event_quota'];
+                      $durationLabel = $pkg['duration_days'] === null ? 'Süre yok' : $pkg['duration_days'].' gün';
+                      $cashbackLabel = $pkg['cashback_rate'] > 0 ? number_format($pkg['cashback_rate'] * 100, 1).'%' : '—';
+                    ?>
+                    <tr>
+                      <td>
+                        <div class="fw-semibold"><?=h($pkg['name'])?></div>
+                        <?php if (!empty($pkg['description'])): ?><div class="small text-muted"><?=h($pkg['description'])?></div><?php endif; ?>
+                      </td>
+                      <td><?=h(format_currency($pkg['price_cents']))?></td>
+                      <td><?=h($quotaLabel)?></td>
+                      <td><?=h($durationLabel)?></td>
+                      <td><?=h($cashbackLabel)?></td>
+                      <td><span class="badge-status <?=$statusClass?>"><?=h($statusLabel)?></span></td>
+                      <td class="text-end">
+                        <a class="btn btn-sm btn-outline-primary" href="?id=<?= (int)$pkg['id'] ?>">Düzenle</a>
+                        <form method="post" class="d-inline">
+                          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                          <input type="hidden" name="do" value="toggle">
+                          <input type="hidden" name="package_id" value="<?= (int)$pkg['id'] ?>">
+                          <button class="btn btn-sm btn-outline-secondary" type="submit"><?= $pkg['is_active'] ? 'Pasifleştir' : 'Aktifleştir' ?></button>
+                        </form>
+                      </td>
+                    </tr>
+                  <?php endforeach; ?>
+                <?php endif; ?>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/admin/dealers.php
+++ b/admin/dealers.php
@@ -239,6 +239,10 @@ if (!in_array($statusFilter, $validStatusFilters, true)) {
 }
 
 $statusCounts = dealer_status_counts();
+$activeCount = (int)($statusCounts['active'] ?? 0);
+$pendingCount = (int)($statusCounts['pending'] ?? 0);
+$inactiveCount = (int)($statusCounts['inactive'] ?? 0);
+$totalDealers = (int)($statusCounts['total'] ?? ($activeCount + $pendingCount + $inactiveCount));
 $dealerListSql = "SELECT * FROM dealers";
 $dealerListParams = [];
 if ($statusFilter !== 'all') {
@@ -294,6 +298,16 @@ $venueAssignments = dealer_fetch_venue_assignments();
 <?=admin_base_styles()?>
 <style>
   .card-lite{ padding:1.5rem; }
+  .stats-row .stat-card{
+    border-radius:18px;
+    background:#fff;
+    border:1px solid rgba(14,165,181,.12);
+    padding:22px 24px;
+    box-shadow:0 32px 60px -42px rgba(14,165,181,.55);
+  }
+  .stats-row .stat-label{font-size:.78rem;color:var(--admin-muted);letter-spacing:.08em;text-transform:uppercase;}
+  .stats-row .stat-value{font-size:1.9rem;font-weight:700;color:var(--admin-ink);}
+  .stats-row .stat-chip{display:inline-flex;align-items:center;gap:6px;padding:.28rem .85rem;border-radius:999px;background:rgba(14,165,181,.12);color:var(--admin-brand-dark);font-size:.75rem;font-weight:600;}
   .badge-status{padding:.35rem .75rem;border-radius:999px;font-size:.75rem;font-weight:600;}
   .status-active{background:rgba(34,197,94,.15);color:#15803d;}
   .status-pending{background:rgba(250,204,21,.18);color:#854d0e;}
@@ -302,8 +316,9 @@ $venueAssignments = dealer_fetch_venue_assignments();
   .dealer-meta{color:var(--muted); font-size:.9rem;}
   .dealer-meta strong{color:var(--ink);}
   .dealer-code{font-family:"JetBrains Mono",monospace;font-size:.85rem;text-transform:uppercase;letter-spacing:.08em;color:var(--ink);}
-  .dealer-list .list-group-item{padding:1rem 1.25rem;}
-  .dealer-list .list-group-item.active{background:rgba(14,165,181,.08);border-color:rgba(14,165,181,.3);}
+  .dealer-list .list-group-item{padding:1rem 1.25rem;border:none;border-bottom:1px solid rgba(148,163,184,.15);transition:all .2s ease;}
+  .dealer-list .list-group-item:hover{background:rgba(14,165,181,.08);}
+  .dealer-list .list-group-item.active{background:rgba(14,165,181,.12);border-color:rgba(14,165,181,.28);box-shadow:0 18px 30px -26px rgba(14,165,181,.6);}
   .assigned-tags{display:flex;flex-wrap:wrap;gap:.4rem;}
   .assigned-tags .dealer-chip{background:rgba(14,165,181,.12);color:#0f172a;border-radius:999px;padding:.25rem .75rem;font-size:.75rem;font-weight:500;}
   .assigned-tags .dealer-chip span{font-weight:600;color:#0f172a;}
@@ -318,9 +333,10 @@ $venueAssignments = dealer_fetch_venue_assignments();
   .venue-chip-empty{color:var(--muted);font-size:.85rem;}
   .section-subtitle{font-size:.85rem;color:var(--muted);}
   .tab-card{border-radius:18px; background:#fff; border:1px solid rgba(148,163,184,.16); box-shadow:0 22px 45px -28px rgba(15,23,42,.45);}
-  .filter-pills .nav-link{padding:.35rem .65rem;font-size:.75rem;border-radius:999px;color:var(--muted);background:rgba(148,163,184,.18);margin-left:.35rem;}
+  .filter-pills .nav-link{padding:.35rem .65rem;font-size:.75rem;border-radius:999px;color:var(--muted);background:rgba(148,163,184,.18);margin-left:.35rem;transition:all .2s ease;}
   .filter-pills .nav-link:first-child{margin-left:0;}
-  .filter-pills .nav-link.active{background:#0ea5e9;color:#fff;}
+  .filter-pills .nav-link:hover{background:rgba(14,165,181,.18);color:var(--admin-brand-dark);}
+  .filter-pills .nav-link.active{background:var(--admin-brand);color:#fff;}
   .balance-stat{border:1px solid rgba(148,163,184,.2);border-radius:14px;padding:1rem 1.25rem;background:#f8fafc;}
   .balance-stat h6{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:.35rem;}
   .balance-stat .value{font-size:1.35rem;font-weight:700;color:#0f172a;}
@@ -336,10 +352,36 @@ $venueAssignments = dealer_fetch_venue_assignments();
 <?php admin_layout_start('dealers', 'Bayi Yönetimi', 'Bayileri yönetin, salon atayın ve lisans durumlarını takip edin.'); ?>
 
   <?php flash_box(); ?>
+
+  <div class="row g-3 stats-row mb-4">
+    <div class="col-md-4">
+      <div class="stat-card">
+        <span class="stat-label">Toplam Bayi</span>
+        <span class="stat-value"><?=$totalDealers?></span>
+        <span class="stat-chip"><i class="bi bi-people-fill me-1"></i>Portföy</span>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="stat-card">
+        <span class="stat-label">Aktif</span>
+        <span class="stat-value text-success"><?=$activeCount?></span>
+        <span class="stat-chip"><i class="bi bi-lightning-charge me-1"></i>Canlı</span>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="stat-card">
+        <span class="stat-label">Onay Bekliyor</span>
+        <span class="stat-value text-warning"><?=$pendingCount?></span>
+        <span class="stat-chip"><i class="bi bi-hourglass-split me-1"></i>Sırada</span>
+      </div>
+    </div>
+  </div>
+
   <div class="row g-4">
     <div class="col-lg-5">
       <div class="card-lite p-4 mb-4">
-        <h5 class="mb-3">Yeni Bayi Oluştur</h5>
+        <h5 class="mb-1">Yeni Bayi Oluştur</h5>
+        <p class="small text-muted mb-3">Bayi kaydı açıldığında benzersiz bayi kodu otomatik oluşturulur ve aktifleştirildiğinde giriş bilgileri e-posta ile iletilir.</p>
         <form method="post" class="row g-2">
           <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
           <input type="hidden" name="do" value="create">
@@ -383,7 +425,10 @@ $venueAssignments = dealer_fetch_venue_assignments();
       <div class="card-lite p-0">
         <div class="p-3 border-bottom">
           <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
-            <h5 class="m-0">Bayiler</h5>
+            <div>
+              <h5 class="m-0">Bayiler</h5>
+              <span class="small text-muted">Filtreleyerek portföyünüzdeki bayileri yönetin.</span>
+            </div>
             <div class="filter-pills nav nav-pills">
               <?php
                 $statusLabels = [
@@ -403,7 +448,7 @@ $venueAssignments = dealer_fetch_venue_assignments();
             </div>
           </div>
         </div>
-        <div class="list-group list-group-flush" style="max-height:420px;overflow:auto;">
+        <div class="list-group list-group-flush dealer-list" style="max-height:420px;overflow:auto;">
           <?php foreach ($dealersList as $d): ?>
             <?php
               $badge = dealer_status_badge($d['status']);
@@ -419,7 +464,10 @@ $venueAssignments = dealer_fetch_venue_assignments();
             ?>
             <a href="?<?=$linkQuery?>" class="list-group-item list-group-item-action <?= $activeClass ?>">
               <div class="d-flex justify-content-between align-items-center mb-1">
-                <div class="fw-semibold me-2"><?=h($d['name'])?></div>
+                <div>
+                  <div class="fw-semibold me-2"><?=h($d['name'])?></div>
+                  <div class="dealer-meta"><?=h($d['email'])?></div>
+                </div>
                 <span class="badge-status <?=$badgeClass?>"><?=h($badge)?></span>
               </div>
               <div class="d-flex justify-content-between align-items-center">

--- a/admin/dealers.php
+++ b/admin/dealers.php
@@ -435,7 +435,6 @@ $venueAssignments = dealer_fetch_venue_assignments();
       <?php else: ?>
         <?php
           $licenseValue = $selectedDealer['license_expires_at'] ? date('Y-m-d\TH:i', strtotime($selectedDealer['license_expires_at'])) : '';
-          $codes = $selectedCodes;
           $statusLabel = dealer_status_badge($selectedDealer['status']);
           $statusClass = dealer_status_class($selectedDealer['status']);
         ?>

--- a/admin/dealers.php
+++ b/admin/dealers.php
@@ -1066,7 +1066,12 @@ if ($selectedDealer && !array_filter($dealersList, fn($row) => (int)$row['id'] =
             <input type="hidden" name="do" value="assign_venues">
             <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
             <div class="col-12">
-              <select class="form-select js-assignment-select" id="dealer-venues-select" name="venue_ids[]" multiple data-selected="<?=h(implode(',', $assignedVenueIds))?>" data-options-key="venues" data-summary="#dealer-venue-summary" data-empty-text="Bu bayiye henüz salon atanmadı." data-placeholder="Salon arayın"></select>
+              <select class="form-select js-assignment-select" id="dealer-venues-select" name="venue_ids[]" multiple data-selected="<?=h(implode(',', $assignedVenueIds))?>" data-options-key="venues" data-summary="#dealer-venue-summary" data-empty-text="Bu bayiye henüz salon atanmadı." data-placeholder="Salon arayın">
+                <?php foreach ($allVenues as $option): ?>
+                  <?php $optId = (int)$option['id']; ?>
+                  <option value="<?= $optId ?>" <?= in_array($optId, $assignedVenueIds, true) ? 'selected' : '' ?>><?=h($option['name'])?></option>
+                <?php endforeach; ?>
+              </select>
             </div>
             <div class="col-12 d-flex flex-wrap gap-2 justify-content-end">
               <button class="btn btn-outline-secondary" type="button" data-ts-clear="dealer-venues-select">Temizle</button>
@@ -1148,7 +1153,12 @@ if ($selectedDealer && !array_filter($dealersList, fn($row) => (int)$row['id'] =
                         <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
                         <input type="hidden" name="do" value="assign_venue_dealers">
                         <input type="hidden" name="venue_id" value="<?= (int)$venue['id'] ?>">
-                        <select class="form-select js-assignment-select" id="venue-select-<?= (int)$venue['id'] ?>" name="dealer_ids[]" multiple data-selected="<?=h(implode(',', $assignedIds))?>" data-options-key="dealers" data-summary="#venue-summary-<?= (int)$venue['id'] ?>" data-empty-text="Bu salona henüz bayi atanmadı." data-placeholder="Bayi arayın"></select>
+                        <select class="form-select js-assignment-select" id="venue-select-<?= (int)$venue['id'] ?>" name="dealer_ids[]" multiple data-selected="<?=h(implode(',', $assignedIds))?>" data-options-key="dealers" data-summary="#venue-summary-<?= (int)$venue['id'] ?>" data-empty-text="Bu salona henüz bayi atanmadı." data-placeholder="Bayi arayın">
+                          <?php foreach ($allDealers as $option): ?>
+                            <?php $optId = (int)$option['id']; ?>
+                            <option value="<?= $optId ?>" <?= in_array($optId, $assignedIds, true) ? 'selected' : '' ?>><?=h($option['name'])?><?= $option['code'] ? ' • '.h($option['code']) : '' ?><?= $option['email'] ? ' — '.h($option['email']) : '' ?></option>
+                          <?php endforeach; ?>
+                        </select>
                         <div class="d-flex flex-wrap gap-2 justify-content-end mt-3">
                           <button class="btn btn-outline-secondary btn-sm" type="button" data-ts-clear="venue-select-<?= (int)$venue['id'] ?>">Temizle</button>
                           <button class="btn btn-brand btn-sm" type="submit">Kaydet</button>

--- a/admin/dealers.php
+++ b/admin/dealers.php
@@ -817,23 +817,23 @@ if ($selectedDealer && !array_filter($dealersList, fn($row) => (int)$row['id'] =
             </div>
             <div class="col-md-6">
               <label class="form-label">Fatura Ünvanı</label>
-              <input class="form-control" name="billing_title" value="<?=h($selectedDealer['billing_title'])?>" required>
+              <input class="form-control" name="billing_title" value="<?=h($selectedDealer['billing_title'] ?? '')?>" required>
             </div>
             <div class="col-md-6">
               <label class="form-label">Fatura E-postası</label>
-              <input type="email" class="form-control" name="invoice_email" value="<?=h($selectedDealer['invoice_email'])?>" placeholder="finans@firma.com">
+              <input type="email" class="form-control" name="invoice_email" value="<?=h($selectedDealer['invoice_email'] ?? '')?>" placeholder="finans@firma.com">
             </div>
             <div class="col-md-6">
               <label class="form-label">Vergi Dairesi</label>
-              <input class="form-control" name="tax_office" value="<?=h($selectedDealer['tax_office'])?>" required>
+              <input class="form-control" name="tax_office" value="<?=h($selectedDealer['tax_office'] ?? '')?>" required>
             </div>
             <div class="col-md-6">
               <label class="form-label">Vergi Numarası</label>
-              <input class="form-control" name="tax_number" value="<?=h($selectedDealer['tax_number'])?>" required>
+              <input class="form-control" name="tax_number" value="<?=h($selectedDealer['tax_number'] ?? '')?>" required>
             </div>
             <div class="col-12">
               <label class="form-label">Fatura Adresi</label>
-              <textarea class="form-control" name="billing_address" rows="2" required><?=h($selectedDealer['billing_address'])?></textarea>
+              <textarea class="form-control" name="billing_address" rows="2" required><?=h($selectedDealer['billing_address'] ?? '')?></textarea>
             </div>
             <div class="col-md-6">
               <label class="form-label d-flex justify-content-between align-items-center">

--- a/admin/dealers.php
+++ b/admin/dealers.php
@@ -585,14 +585,14 @@ $venueAssignments = dealer_fetch_venue_assignments();
                       <td><?=h(format_currency($req['amount_cents']))?></td>
                       <td><?=h(dealer_topup_status_label($req['status']))?></td>
                       <td class="text-end">
-                        <?php if ($req['status'] === DEALER_TOPUP_STATUS_PENDING): ?>
-                          <div class="d-flex flex-column flex-lg-row gap-2 justify-content-end">
+                        <?php if (in_array($req['status'], [DEALER_TOPUP_STATUS_PENDING, DEALER_TOPUP_STATUS_AWAITING_REVIEW], true)): ?>
+                          <div class="d-flex flex-column flex-lg-row gap-2 justify-content-end align-items-stretch">
                             <form method="post" class="d-flex gap-2">
                               <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
                               <input type="hidden" name="do" value="topup_complete">
                               <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
                               <input type="hidden" name="topup_id" value="<?= (int)$req['id'] ?>">
-                              <input type="text" name="reference" class="form-control form-control-sm" placeholder="Referans (opsiyonel)">
+                              <input type="text" name="reference" class="form-control form-control-sm" placeholder="Referans (opsiyonel)" value="<?=h($req['paytr_reference'] ?? '')?>">
                               <button class="btn btn-sm btn-outline-primary" type="submit">Onayla</button>
                             </form>
                             <form method="post">
@@ -603,6 +603,9 @@ $venueAssignments = dealer_fetch_venue_assignments();
                               <button class="btn btn-sm btn-outline-secondary" type="submit">İptal</button>
                             </form>
                           </div>
+                          <?php if ($req['status'] === DEALER_TOPUP_STATUS_AWAITING_REVIEW): ?>
+                            <div class="text-warning small mt-1">PayTR tarafından ödeme alındı, onay bekliyor.</div>
+                          <?php endif; ?>
                         <?php else: ?>
                           <span class="text-muted small">—</span>
                         <?php endif; ?>

--- a/admin/dealers.php
+++ b/admin/dealers.php
@@ -349,6 +349,19 @@ $buildDealerUrl = function(array $overrides = []) use ($statusFilter, $searchTer
   return $queryString ? ('?'.$queryString) : ($_SERVER['PHP_SELF'] ?? '#');
 };
 if ($selectedDealer) {
+  foreach ([
+    'billing_title' => '',
+    'tax_office' => '',
+    'tax_number' => '',
+    'billing_address' => '',
+    'invoice_email' => '',
+    'tax_document_path' => null,
+  ] as $field => $defaultValue) {
+    if (!array_key_exists($field, $selectedDealer)) {
+      $selectedDealer[$field] = $defaultValue;
+    }
+  }
+
   dealer_refresh_purchase_states($selectedId);
   $walletBalance = dealer_get_balance($selectedId);
   $walletTransactions = dealer_wallet_transactions($selectedId, 10);

--- a/admin/dealers.php
+++ b/admin/dealers.php
@@ -333,10 +333,8 @@ $venueAssignments = dealer_fetch_venue_assignments();
 </style>
 </head>
 <body class="admin-body">
-<?php render_admin_topnav('dealers', 'Bayi Yönetimi', 'Bayileri yönetin, salon atayın ve lisans durumlarını takip edin.'); ?>
+<?php admin_layout_start('dealers', 'Bayi Yönetimi', 'Bayileri yönetin, salon atayın ve lisans durumlarını takip edin.'); ?>
 
-<main class="admin-main">
-  <div class="container">
   <?php flash_box(); ?>
   <div class="row g-4">
     <div class="col-lg-5">
@@ -804,8 +802,7 @@ $venueAssignments = dealer_fetch_venue_assignments();
       </div>
     </div>
   </div>
-  </div>
-</main>
+<?php admin_layout_end(); ?>
 <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function(){

--- a/admin/dealers.php
+++ b/admin/dealers.php
@@ -1,0 +1,394 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
+
+require_admin();
+install_schema();
+
+function parse_license_input(?string $input): ?string {
+  if (!$input) return null;
+  try {
+    $dt = new DateTime($input);
+    return $dt->format('Y-m-d H:i:s');
+  } catch (Throwable $e) {
+    return null;
+  }
+}
+
+$action = $_POST['do'] ?? '';
+if ($action) {
+  csrf_or_die();
+}
+
+if ($action === 'create') {
+  $name  = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $phone = trim($_POST['phone'] ?? '');
+  $company = trim($_POST['company'] ?? '');
+  $notes = trim($_POST['notes'] ?? '');
+  $status = $_POST['status'] ?? DEALER_STATUS_PENDING;
+  $licenseInput = $_POST['license_expires_at'] ?? '';
+  $license = parse_license_input($licenseInput);
+
+  if ($name === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err', 'Ad ve geçerli e-posta gerekli.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+  if (dealer_find_by_email($email)) {
+    flash('err', 'Bu e-posta zaten kayıtlı.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+
+  $pdo = pdo();
+  $pdo->prepare("INSERT INTO dealers (name,email,phone,company,notes,status,license_expires_at,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?)")
+      ->execute([$name,$email,$phone,$company,$notes,$status,$license, now(), now()]);
+  $dealerId = (int)$pdo->lastInsertId();
+  dealer_ensure_codes($dealerId);
+
+  if ($status === DEALER_STATUS_ACTIVE) {
+    $plain = dealer_random_password();
+    $hash  = password_hash($plain, PASSWORD_DEFAULT);
+    $pdo->prepare("UPDATE dealers SET password_hash=?, approved_at=?, updated_at=? WHERE id=?")
+        ->execute([$hash, now(), now(), $dealerId]);
+    $dealer = dealer_get($dealerId);
+    dealer_send_welcome_mail($dealer, $plain);
+  }
+
+  flash('ok', 'Bayi kaydedildi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'update') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+
+  $name  = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $phone = trim($_POST['phone'] ?? '');
+  $company = trim($_POST['company'] ?? '');
+  $notes = trim($_POST['notes'] ?? '');
+  $status = $_POST['status'] ?? DEALER_STATUS_PENDING;
+  $licenseInput = $_POST['license_expires_at'] ?? '';
+  $license = parse_license_input($licenseInput);
+
+  if ($name === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err','Ad ve geçerli e-posta gerekli.');
+    redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+  }
+  $st = pdo()->prepare("SELECT id FROM dealers WHERE email=? AND id<>? LIMIT 1");
+  $st->execute([$email, $dealerId]);
+  if ($st->fetch()) {
+    flash('err','Bu e-posta başka bir bayide kayıtlı.');
+    redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+  }
+
+  pdo()->prepare("UPDATE dealers SET name=?, email=?, phone=?, company=?, notes=?, status=?, license_expires_at=?, updated_at=? WHERE id=?")
+      ->execute([$name,$email,$phone,$company,$notes,$status,$license, now(), $dealerId]);
+
+  if ($status === DEALER_STATUS_ACTIVE && empty($dealer['password_hash'])) {
+    $plain = dealer_random_password();
+    $hash  = password_hash($plain, PASSWORD_DEFAULT);
+    pdo()->prepare("UPDATE dealers SET password_hash=?, approved_at=?, updated_at=? WHERE id=?")
+        ->execute([$hash, now(), now(), $dealerId]);
+    $dealer = dealer_get($dealerId);
+    dealer_send_welcome_mail($dealer, $plain);
+  }
+
+  flash('ok','Bilgiler güncellendi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'assign_venues') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  $venues = $_POST['venue_ids'] ?? [];
+  dealer_assign_venues($dealerId, $venues);
+  flash('ok','Salon atamaları güncellendi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'regenerate_code') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $type = $_POST['type'] ?? DEALER_CODE_TRIAL;
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  dealer_regenerate_code($dealerId, $type);
+  flash('ok','Kod güncellendi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'set_code_event') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $type = $_POST['type'] ?? DEALER_CODE_STATIC;
+  $eventId = (int)($_POST['event_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  if ($eventId && !dealer_event_belongs_to_dealer($dealerId, $eventId)) {
+    flash('err','Seçilen düğün bu bayiye ait değil.');
+  } else {
+    dealer_set_code_target($dealerId, $type, $eventId ?: null);
+    flash('ok','Kod bağlantısı kaydedildi.');
+  }
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+if ($action === 'send_password') {
+  $dealerId = (int)($_POST['dealer_id'] ?? 0);
+  $dealer = dealer_get($dealerId);
+  if (!$dealer) { flash('err','Bayi bulunamadı.'); redirect($_SERVER['PHP_SELF']); }
+  if ($dealer['status'] !== DEALER_STATUS_ACTIVE) {
+    flash('err','Önce bayiyi aktif hale getirin.');
+    redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+  }
+  $plain = dealer_random_password();
+  $hash = password_hash($plain, PASSWORD_DEFAULT);
+  pdo()->prepare("UPDATE dealers SET password_hash=?, approved_at=COALESCE(approved_at,?), updated_at=? WHERE id=?")
+      ->execute([$hash, now(), now(), $dealerId]);
+  $dealer = dealer_get($dealerId);
+  dealer_send_welcome_mail($dealer, $plain);
+  flash('ok','Yeni şifre e-posta ile gönderildi.');
+  redirect($_SERVER['PHP_SELF'].'?id='.$dealerId);
+}
+
+$dealers = pdo()->query("SELECT * FROM dealers ORDER BY created_at DESC")->fetchAll();
+$selectedId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$selectedDealer = $selectedId ? dealer_get($selectedId) : null;
+$selectedCodes = $selectedDealer ? dealer_sync_codes($selectedId) : [];
+$assignedVenues = $selectedDealer ? dealer_fetch_venues($selectedId) : [];
+$assignedVenueIds = array_map(fn($v) => (int)$v['id'], $assignedVenues);
+$allVenues = pdo()->query("SELECT * FROM venues ORDER BY name")->fetchAll();
+$events = $selectedDealer ? dealer_allowed_events($selectedId) : [];
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Yönetimi</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
+<style>
+  .card-lite{ padding:1.5rem; }
+  .badge-status{padding:.35rem .75rem;border-radius:999px;font-size:.75rem;font-weight:600;}
+  .status-active{background:rgba(34,197,94,.15);color:#15803d;}
+  .status-pending{background:rgba(250,204,21,.18);color:#854d0e;}
+  .status-inactive{background:rgba(248,113,113,.16);color:#b91c1c;}
+  .dealer-list .card-lite{padding:1.2rem 1.5rem;}
+  .dealer-meta{color:var(--muted); font-size:.9rem;}
+  .dealer-meta strong{color:var(--ink);}
+  .tab-card{border-radius:18px; background:#fff; border:1px solid rgba(148,163,184,.16); box-shadow:0 22px 45px -28px rgba(15,23,42,.45);}
+</style>
+</head>
+<body class="admin-body">
+<?php render_admin_topnav('dealers', 'Bayi Yönetimi', 'Bayileri yönetin, salon atayın ve lisans durumlarını takip edin.'); ?>
+
+<main class="admin-main">
+  <div class="container">
+  <?php flash_box(); ?>
+  <div class="row g-4">
+    <div class="col-lg-5">
+      <div class="card-lite p-4 mb-4">
+        <h5 class="mb-3">Yeni Bayi Oluştur</h5>
+        <form method="post" class="row g-2">
+          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+          <input type="hidden" name="do" value="create">
+          <div class="col-12">
+            <label class="form-label">Ad Soyad</label>
+            <input class="form-control" name="name" required>
+          </div>
+          <div class="col-12">
+            <label class="form-label">E-posta</label>
+            <input type="email" class="form-control" name="email" required>
+          </div>
+          <div class="col-6">
+            <label class="form-label">Telefon</label>
+            <input class="form-control" name="phone">
+          </div>
+          <div class="col-6">
+            <label class="form-label">Firma</label>
+            <input class="form-control" name="company">
+          </div>
+          <div class="col-12">
+            <label class="form-label">Not</label>
+            <textarea class="form-control" name="notes" rows="2"></textarea>
+          </div>
+          <div class="col-6">
+            <label class="form-label">Durum</label>
+            <select class="form-select" name="status">
+              <option value="pending">Onay Bekliyor</option>
+              <option value="active">Aktif</option>
+              <option value="inactive">Pasif</option>
+            </select>
+          </div>
+          <div class="col-6">
+            <label class="form-label">Lisans Bitişi</label>
+            <input type="datetime-local" class="form-control" name="license_expires_at">
+          </div>
+          <div class="col-12 d-grid">
+            <button class="btn btn-brand" type="submit">Kaydet</button>
+          </div>
+        </form>
+      </div>
+      <div class="card-lite p-0">
+        <div class="p-3 border-bottom"><h5 class="m-0">Bayiler</h5></div>
+        <div class="list-group list-group-flush" style="max-height:420px;overflow:auto;">
+          <?php foreach ($dealers as $d): ?>
+            <?php
+              $badge = dealer_status_badge($d['status']);
+              $activeClass = ($selectedId === (int)$d['id']) ? 'active' : '';
+              $license = $d['license_expires_at'] ? date('d.m.Y', strtotime($d['license_expires_at'])) : '—';
+            ?>
+            <a href="?id=<?= (int)$d['id'] ?>" class="list-group-item list-group-item-action <?= $activeClass ?>">
+              <div class="fw-semibold"><?=h($d['name'])?></div>
+              <div class="d-flex justify-content-between small text-muted">
+                <span><?=h($badge)?></span>
+                <span>Lisans: <?=h($license)?></span>
+              </div>
+            </a>
+          <?php endforeach; ?>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-7">
+      <?php if (!$selectedDealer): ?>
+        <div class="card-lite p-4">
+          <h5 class="mb-2">Bayi seçin</h5>
+          <p class="text-muted">Soldaki listeden bir bayi seçerek detaylarını görüntüleyin.</p>
+        </div>
+      <?php else: ?>
+        <?php
+          $licenseValue = $selectedDealer['license_expires_at'] ? date('Y-m-d\TH:i', strtotime($selectedDealer['license_expires_at'])) : '';
+          $codes = $selectedCodes;
+        ?>
+        <div class="card-lite p-4 mb-4">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h5 class="m-0"><?=h($selectedDealer['name'])?></h5>
+            <form method="post" class="m-0">
+              <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+              <input type="hidden" name="do" value="send_password">
+              <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+              <button class="btn btn-sm btn-outline-primary" type="submit">Yeni Şifre Gönder</button>
+            </form>
+          </div>
+          <form method="post" class="row g-2">
+            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="do" value="update">
+            <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+            <div class="col-md-6">
+              <label class="form-label">Ad Soyad</label>
+              <input class="form-control" name="name" value="<?=h($selectedDealer['name'])?>" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">E-posta</label>
+              <input type="email" class="form-control" name="email" value="<?=h($selectedDealer['email'])?>" required>
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Telefon</label>
+              <input class="form-control" name="phone" value="<?=h($selectedDealer['phone'])?>">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Firma</label>
+              <input class="form-control" name="company" value="<?=h($selectedDealer['company'])?>">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Durum</label>
+              <select class="form-select" name="status">
+                <option value="pending" <?= $selectedDealer['status']==='pending'?'selected':'' ?>>Onay Bekliyor</option>
+                <option value="active" <?= $selectedDealer['status']==='active'?'selected':'' ?>>Aktif</option>
+                <option value="inactive" <?= $selectedDealer['status']==='inactive'?'selected':'' ?>>Pasif</option>
+              </select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Lisans Bitiş</label>
+              <input type="datetime-local" class="form-control" name="license_expires_at" value="<?=h($licenseValue)?>">
+            </div>
+            <div class="col-12">
+              <label class="form-label">Not</label>
+              <textarea class="form-control" name="notes" rows="2"><?=h($selectedDealer['notes'])?></textarea>
+            </div>
+            <div class="col-12 d-grid">
+              <button class="btn btn-brand" type="submit">Bilgileri Güncelle</button>
+            </div>
+          </form>
+        </div>
+
+        <div class="card-lite p-4 mb-4">
+          <h5 class="mb-3">Salon Atamaları</h5>
+          <form method="post" class="row g-3">
+            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="do" value="assign_venues">
+            <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+            <div class="col-12">
+              <select class="form-select" name="venue_ids[]" multiple size="8">
+                <?php foreach ($allVenues as $v): ?>
+                  <option value="<?= (int)$v['id'] ?>" <?= in_array((int)$v['id'], $assignedVenueIds, true) ? 'selected' : '' ?>><?=h($v['name'])?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <div class="col-12 d-grid">
+              <button class="btn btn-outline-primary" type="submit">Atamaları Kaydet</button>
+            </div>
+          </form>
+        </div>
+
+        <div class="card-lite p-4">
+          <h5 class="mb-3">Kodlar</h5>
+          <div class="row g-3">
+            <?php foreach ([DEALER_CODE_STATIC=>'Kalıcı Kod', DEALER_CODE_TRIAL=>'Deneme Kodu'] as $type=>$label):
+              $code = $codes[$type] ?? null;
+              $url = $code ? BASE_URL.'/qr.php?code='.urlencode($code['code']) : '';
+            ?>
+            <div class="col-md-6">
+              <div class="border rounded-3 p-3 h-100">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                  <h6 class="mb-0"><?=h($label)?></h6>
+                  <form method="post" class="m-0">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="regenerate_code">
+                    <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+                    <input type="hidden" name="type" value="<?=h($type)?>">
+                    <button class="btn btn-sm btn-outline-secondary" type="submit">Yenile</button>
+                  </form>
+                </div>
+                <?php if ($code): ?>
+                  <p class="fw-semibold">Kod: <?=h($code['code'])?></p>
+                  <p class="small text-muted"><a href="<?=h($url)?>" target="_blank">QR bağlantısı</a></p>
+                  <form method="post" class="vstack gap-2">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="set_code_event">
+                    <input type="hidden" name="dealer_id" value="<?= (int)$selectedDealer['id'] ?>">
+                    <input type="hidden" name="type" value="<?=h($type)?>">
+                    <label class="form-label small">Bağlı düğün</label>
+                    <select class="form-select form-select-sm" name="event_id">
+                      <option value="0">— Seçili değil —</option>
+                      <?php foreach ($events as $ev): ?>
+                        <?php
+                          $sel = ($code['target_event_id'] ?? null) == $ev['id'] ? 'selected' : '';
+                          $dateLabel = $ev['event_date'] ? date('d.m.Y', strtotime($ev['event_date'])) : 'Tarihsiz';
+                        ?>
+                        <option value="<?= (int)$ev['id'] ?>" <?=$sel?>><?=h($dateLabel.' • '.$ev['title'])?></option>
+                      <?php endforeach; ?>
+                    </select>
+                    <button class="btn btn-sm btn-brand" type="submit">Kaydet</button>
+                  </form>
+                <?php else: ?>
+                  <p class="text-muted">Kod oluşturulamadı.</p>
+                <?php endif; ?>
+              </div>
+            </div>
+            <?php endforeach; ?>
+          </div>
+        </div>
+      <?php endif; ?>
+    </div>
+  </div>
+  </div>
+</main>
+</body>
+</html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -81,77 +81,113 @@ $next = $_GET['next'] ?? ($_POST['next'] ?? 'dashboard.php');
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
     :root{ --brand:#0ea5b5; --brand-dark:#0b8b98; --ink:#0f172a; --muted:#64748b; }
-    body{ min-height:100vh; margin:0; background:linear-gradient(135deg,rgba(14,165,181,.18),rgba(14,165,181,.04)); font-family:'Inter','Segoe UI',system-ui,-apple-system,sans-serif; display:flex; align-items:center; justify-content:center; padding:2rem; color:var(--ink); }
-    .auth-card{ width:100%; max-width:460px; background:#fff; border-radius:22px; border:1px solid rgba(148,163,184,.18); box-shadow:0 32px 60px -30px rgba(15,23,42,.4); padding:2.8rem 2.4rem; }
-    .brand{ font-weight:800; font-size:1.4rem; letter-spacing:.3px; }
-    .subtitle{ color:var(--muted); font-size:.95rem; }
-    .btn-brand{ background:var(--brand); color:#fff; border:none; border-radius:12px; padding:.7rem 1.1rem; font-weight:600; }
-    .btn-brand:hover{ background:var(--brand-dark); color:#fff; }
-    label{ font-weight:600; color:var(--muted); }
-    .form-control{ border-radius:12px; border:1px solid rgba(148,163,184,.35); padding:.65rem .85rem; }
-    .form-control:focus{ border-color:var(--brand); box-shadow:0 0 0 .2rem rgba(14,165,181,.15); }
-    .alert{ border-radius:12px; }
-    .first-run-badge{ display:inline-flex; align-items:center; gap:.4rem; background:rgba(14,165,181,.12); color:var(--brand-dark); padding:.35rem .85rem; border-radius:999px; font-weight:600; font-size:.82rem; }
+    *{box-sizing:border-box;}
+    body{min-height:100vh;margin:0;display:flex;align-items:center;justify-content:center;padding:2.5rem;background:radial-gradient(circle at top,#ecfeff 0%,#f8fafc 55%,#eef2ff 100%);font-family:'Inter','Segoe UI',system-ui,-apple-system,sans-serif;color:var(--ink);}
+    .auth-shell{width:100%;max-width:1040px;background:#fff;border-radius:28px;box-shadow:0 40px 120px -45px rgba(15,23,42,.45);display:flex;overflow:hidden;border:1px solid rgba(148,163,184,.18);}
+    .auth-visual{flex:1;position:relative;padding:3rem 3.2rem;background:linear-gradient(135deg,rgba(14,165,181,.92),rgba(14,165,181,.72)),url('https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=1200&q=80') center/cover;color:#fff;display:flex;flex-direction:column;justify-content:space-between;min-height:100%;}
+    .auth-visual::after{content:"";position:absolute;inset:0;background:linear-gradient(160deg,rgba(15,23,42,.05),rgba(15,23,42,.35));mix-blend-mode:multiply;}
+    .auth-visual > *{position:relative;z-index:1;}
+    .visual-badge{display:inline-flex;align-items:center;gap:.55rem;background:rgba(255,255,255,.16);border-radius:999px;padding:.45rem 1.1rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;font-size:.78rem;}
+    .visual-title{font-size:2rem;font-weight:800;line-height:1.2;margin-top:1.5rem;margin-bottom:1rem;}
+    .visual-text{font-size:1rem;line-height:1.6;color:rgba(255,255,255,.85);max-width:420px;}
+    .visual-list{list-style:none;padding:0;margin:1.5rem 0 0;display:flex;flex-direction:column;gap:.85rem;}
+    .visual-list li{display:flex;align-items:flex-start;gap:.7rem;font-weight:600;color:rgba(255,255,255,.9);}
+    .visual-list span{display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;border-radius:50%;background:rgba(255,255,255,.18);font-size:.9rem;}
+    .visual-footer{font-size:.82rem;color:rgba(255,255,255,.75);margin-top:2.5rem;max-width:320px;}
+    .auth-form{flex:1;padding:3rem 3.2rem;display:flex;flex-direction:column;justify-content:center;gap:1.75rem;}
+    .brand{font-weight:800;font-size:1.6rem;color:var(--ink);letter-spacing:.2px;}
+    .brand span{display:block;font-size:.92rem;font-weight:600;color:var(--muted);margin-top:.35rem;}
+    .alert{border-radius:14px;font-weight:500;}
+    form .form-label{font-weight:600;color:var(--muted);}
+    .form-control{border-radius:14px;border:1px solid rgba(148,163,184,.35);padding:.7rem 1rem;font-size:1rem;}
+    .form-control:focus{border-color:var(--brand);box-shadow:0 0 0 .25rem rgba(14,165,181,.18);}
+    .btn-brand{background:var(--brand);color:#fff;border:none;border-radius:14px;padding:.8rem 1rem;font-weight:700;font-size:1rem;transition:background .2s ease,transform .2s ease;}
+    .btn-brand:hover{background:var(--brand-dark);transform:translateY(-1px);color:#fff;}
+    .form-note{font-size:.9rem;color:var(--muted);line-height:1.5;}
+    .back-link{font-weight:600;text-decoration:none;color:var(--brand);}
+    .back-link:hover{text-decoration:underline;color:var(--brand-dark);}
+    .first-run-badge{display:inline-flex;align-items:center;gap:.45rem;background:rgba(14,165,181,.12);color:var(--brand-dark);padding:.4rem .9rem;border-radius:999px;font-weight:600;font-size:.85rem;}
+    @media (max-width: 992px){body{padding:1.5rem;} .auth-shell{flex-direction:column;} .auth-visual{min-height:260px;padding:2.6rem;} .auth-form{padding:2.4rem;} }
+    @media (max-width: 576px){.auth-form{padding:2rem;} .visual-title{font-size:1.6rem;} }
   </style>
 </head>
 <body>
-  <div class="auth-card">
-    <div class="mb-4 text-center">
-      <?php if ($mode === 'setup'): ?>
-        <span class="first-run-badge">🚀 İlk Kurulum</span>
+  <div class="auth-shell">
+    <aside class="auth-visual">
+      <div>
+        <span class="visual-badge">BİKARE Studio</span>
+        <h1 class="visual-title">Etkinlik yönetiminin kalbi burada.</h1>
+        <p class="visual-text">BİKARE ile kampanyaları planlayın, bayilerinizi yönetin ve çiftleriniz için unutulmaz dijital deneyimler hazırlayın. Yönetici paneli tüm operasyonu tek ekranda toplar.</p>
+        <ul class="visual-list">
+          <li><span>✓</span>Gerçek zamanlı etkinlik performansı ve raporlar</li>
+          <li><span>✓</span>Bayi ve salon ağınızı tek noktadan yönetin</li>
+          <li><span>✓</span>Misafir deneyimini marka standartlarında yönlendirin</li>
+        </ul>
+      </div>
+      <p class="visual-footer">BİKARE, Zerosoft güvencesiyle etkinlik teknolojisini yeniden tanımlar.</p>
+    </aside>
+    <section class="auth-form">
+      <div>
+        <?php if ($mode === 'setup'): ?>
+          <span class="first-run-badge">🚀 İlk Kurulum</span>
+        <?php endif; ?>
+        <div class="brand"><?=h(APP_NAME)?> <span>Yönetim Paneli</span></div>
+      </div>
+
+      <?php if ($m = flash('ok')): ?>
+        <div class="alert alert-success mb-0"><?=$m?></div>
       <?php endif; ?>
-      <div class="brand mt-2"><?=h(APP_NAME)?></div>
-      <div class="subtitle">Yönetim Paneli</div>
-    </div>
+      <?php if ($err): ?>
+        <div class="alert alert-danger mb-0"><?=$err?></div>
+      <?php endif; ?>
 
-    <?php if ($m = flash('ok')): ?>
-      <div class="alert alert-success"><?=$m?></div>
-    <?php endif; ?>
-    <?php if ($err): ?>
-      <div class="alert alert-danger"><?=$err?></div>
-    <?php endif; ?>
+      <?php if ($mode === 'setup'): ?>
+        <div>
+          <p class="form-note">İlk süperadmin hesabınızı oluşturun. Bu hesap, ekibinizi davet etmek ve tüm organizasyonel ayarları yapmak için kullanılacaktır.</p>
+          <form method="post" class="vstack gap-3">
+            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+            <div>
+              <label class="form-label">Ad Soyad</label>
+              <input class="form-control" type="text" name="name" required autofocus placeholder="Örn. Ayşe Yılmaz">
+            </div>
+            <div>
+              <label class="form-label">E-posta</label>
+              <input class="form-control" type="email" name="email" required placeholder="ornek@firma.com">
+            </div>
+            <div>
+              <label class="form-label">Şifre</label>
+              <input class="form-control" type="password" name="password" required placeholder="En az 8 karakter">
+            </div>
+            <div>
+              <label class="form-label">Şifre (Tekrar)</label>
+              <input class="form-control" type="password" name="password_confirm" required>
+            </div>
+            <button class="btn-brand mt-2 w-100">İlk Süperadmini Oluştur</button>
+          </form>
+        </div>
+      <?php else: ?>
+        <div>
+          <p class="form-note">Yönetici hesabınızla giriş yapın ve paneldeki canlı etkinlikleri, bayi bakiyelerini ve kampanyaları takip etmeye devam edin.</p>
+          <form method="post" class="vstack gap-3">
+            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="next" value="<?=h($next)?>">
+            <div>
+              <label class="form-label">E-posta</label>
+              <input class="form-control" type="email" name="email" required autofocus placeholder="ornek@firma.com">
+            </div>
+            <div>
+              <label class="form-label">Şifre</label>
+              <input class="form-control" type="password" name="password" required placeholder="Şifrenizi yazın">
+            </div>
+            <button class="btn-brand mt-2 w-100">Giriş Yap</button>
+          </form>
+        </div>
+      <?php endif; ?>
 
-    <?php if ($mode === 'setup'): ?>
-      <form method="post" class="vstack gap-3">
-        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-        <div>
-          <label class="form-label">Ad Soyad</label>
-          <input class="form-control" type="text" name="name" required autofocus placeholder="Örn. Ayşe Yılmaz">
-        </div>
-        <div>
-          <label class="form-label">E-posta</label>
-          <input class="form-control" type="email" name="email" required placeholder="ornek@firma.com">
-        </div>
-        <div>
-          <label class="form-label">Şifre</label>
-          <input class="form-control" type="password" name="password" required placeholder="En az 8 karakter">
-        </div>
-        <div>
-          <label class="form-label">Şifre (Tekrar)</label>
-          <input class="form-control" type="password" name="password_confirm" required>
-        </div>
-        <button class="btn btn-brand mt-2 w-100">İlk Süperadmini Oluştur</button>
-      </form>
-      <p class="subtitle text-center mt-3">Bu hesap süperadmin yetkisine sahip olacak ve diğer yöneticileri davet edebilecek.</p>
-    <?php else: ?>
-      <form method="post" class="vstack gap-3">
-        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-        <input type="hidden" name="next" value="<?=h($next)?>">
-        <div>
-          <label class="form-label">E-posta</label>
-          <input class="form-control" type="email" name="email" required autofocus>
-        </div>
-        <div>
-          <label class="form-label">Şifre</label>
-          <input class="form-control" type="password" name="password" required>
-        </div>
-        <button class="btn btn-brand mt-2 w-100">Giriş Yap</button>
-      </form>
-    <?php endif; ?>
-
-    <div class="mt-4 text-center">
-      <a class="text-decoration-none" href="../index.php">← Ana sayfaya dön</a>
-    </div>
+      <div>
+        <a class="back-link" href="../index.php">← bikare.com.tr ana sayfasına dön</a>
+      </div>
+    </section>
   </div>
 </body>
 </html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -17,13 +17,41 @@ if (is_admin_logged_in()) {
   redirect($next);
 }
 
-// İlk admin yoksa oluşturmak için (ilk kurulumda 1 kez aktif edin, sonra bu satırı silebilirsiniz)
-// ensure_first_admin('admin@site.com', 'Sifre123', 'Yönetici');
-
+$firstRun = ((int)pdo()->query("SELECT COUNT(*) FROM users")->fetchColumn()) === 0;
+$mode = $firstRun ? 'setup' : 'login';
 $err = null;
 
+if ($mode === 'setup' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+  csrf_or_die();
+
+  $name  = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $pass  = (string)($_POST['password'] ?? '');
+  $pass2 = (string)($_POST['password_confirm'] ?? '');
+
+  if (mb_strlen($name) < 3) {
+    $err = 'Lütfen en az 3 karakterlik bir ad girin.';
+  } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    $err = 'Geçerli bir e-posta adresi girin.';
+  } elseif (mb_strlen($pass) < 8) {
+    $err = 'Şifre en az 8 karakter olmalıdır.';
+  } elseif ($pass !== $pass2) {
+    $err = 'Şifreler eşleşmiyor.';
+  } else {
+    try {
+      pdo()->prepare("INSERT INTO users (email,password_hash,name,role,created_at,updated_at) VALUES (?,?,?,?,?,?)")
+          ->execute([$email, password_hash($pass, PASSWORD_DEFAULT), $name, 'superadmin', now(), now()]);
+      admin_login($email, $pass);
+      flash('ok', 'İlk yönetici hesabı hazır!');
+      redirect('dashboard.php');
+    } catch (Throwable $e) {
+      $err = 'Hesap oluşturulamadı. Lütfen bilgileri kontrol edin.';
+    }
+  }
+}
+
 // Giriş denemesi
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+if ($mode === 'login' && $_SERVER['REQUEST_METHOD'] === 'POST') {
   csrf_or_die(); // CSRF kontrolü
 
   $email = trim($_POST['email'] ?? '');
@@ -34,9 +62,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $err = 'E-posta ve şifre zorunludur.';
   } else {
     if (admin_login($email, $pass)) {
-      // Başarılı → yönlendir
-      // İsteğe bağlı: admin adını session'a yazmak istiyorsanız:
-      // $_SESSION['uname'] = admin_user()['name'] ?? $email;
       redirect($next);
     } else {
       $err = 'E-posta veya şifre hatalı.';
@@ -52,21 +77,31 @@ $next = $_GET['next'] ?? ($_POST['next'] ?? 'dashboard.php');
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Yönetici Girişi — <?=h(APP_NAME)?></title>
+  <title><?= $mode === 'setup' ? 'İlk Yönetici Kurulumu' : 'Yönetici Girişi' ?> — <?=h(APP_NAME)?></title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
-    :root{ --zs:#0ea5b5; }
-    body{ min-height:100vh; display:flex; align-items:center; justify-content:center; background:linear-gradient(180deg,#f0fbfd,#fff) }
-    .cardx{ width:100%; max-width:420px; background:#fff; border:1px solid #e9eef5; border-radius:18px; box-shadow:0 10px 30px rgba(2,6,23,.06) }
-    .btn-zs{ background:var(--zs); color:#fff; border:none; border-radius:12px; padding:.65rem 1rem; font-weight:700 }
-    .brand{ font-weight:800; letter-spacing:.2px; }
+    :root{ --brand:#0ea5b5; --brand-dark:#0b8b98; --ink:#0f172a; --muted:#64748b; }
+    body{ min-height:100vh; margin:0; background:linear-gradient(135deg,rgba(14,165,181,.18),rgba(14,165,181,.04)); font-family:'Inter','Segoe UI',system-ui,-apple-system,sans-serif; display:flex; align-items:center; justify-content:center; padding:2rem; color:var(--ink); }
+    .auth-card{ width:100%; max-width:460px; background:#fff; border-radius:22px; border:1px solid rgba(148,163,184,.18); box-shadow:0 32px 60px -30px rgba(15,23,42,.4); padding:2.8rem 2.4rem; }
+    .brand{ font-weight:800; font-size:1.4rem; letter-spacing:.3px; }
+    .subtitle{ color:var(--muted); font-size:.95rem; }
+    .btn-brand{ background:var(--brand); color:#fff; border:none; border-radius:12px; padding:.7rem 1.1rem; font-weight:600; }
+    .btn-brand:hover{ background:var(--brand-dark); color:#fff; }
+    label{ font-weight:600; color:var(--muted); }
+    .form-control{ border-radius:12px; border:1px solid rgba(148,163,184,.35); padding:.65rem .85rem; }
+    .form-control:focus{ border-color:var(--brand); box-shadow:0 0 0 .2rem rgba(14,165,181,.15); }
+    .alert{ border-radius:12px; }
+    .first-run-badge{ display:inline-flex; align-items:center; gap:.4rem; background:rgba(14,165,181,.12); color:var(--brand-dark); padding:.35rem .85rem; border-radius:999px; font-weight:600; font-size:.82rem; }
   </style>
 </head>
 <body>
-  <div class="cardx p-4">
-    <div class="mb-3 text-center">
-      <div class="brand"><?=h(APP_NAME)?></div>
-      <div class="text-muted small">Yönetici Paneli</div>
+  <div class="auth-card">
+    <div class="mb-4 text-center">
+      <?php if ($mode === 'setup'): ?>
+        <span class="first-run-badge">🚀 İlk Kurulum</span>
+      <?php endif; ?>
+      <div class="brand mt-2"><?=h(APP_NAME)?></div>
+      <div class="subtitle">Yönetim Paneli</div>
     </div>
 
     <?php if ($m = flash('ok')): ?>
@@ -76,18 +111,46 @@ $next = $_GET['next'] ?? ($_POST['next'] ?? 'dashboard.php');
       <div class="alert alert-danger"><?=$err?></div>
     <?php endif; ?>
 
-    <form method="post" class="vstack gap-2">
-      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-      <input type="hidden" name="next" value="<?=h($next)?>">
-      <label class="form-label">E-posta</label>
-      <input class="form-control" type="email" name="email" required autofocus>
-      <label class="form-label mt-2">Şifre</label>
-      <input class="form-control" type="password" name="password" required>
-      <button class="btn btn-zs mt-3 w-100">Giriş Yap</button>
-    </form>
+    <?php if ($mode === 'setup'): ?>
+      <form method="post" class="vstack gap-3">
+        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+        <div>
+          <label class="form-label">Ad Soyad</label>
+          <input class="form-control" type="text" name="name" required autofocus placeholder="Örn. Ayşe Yılmaz">
+        </div>
+        <div>
+          <label class="form-label">E-posta</label>
+          <input class="form-control" type="email" name="email" required placeholder="ornek@firma.com">
+        </div>
+        <div>
+          <label class="form-label">Şifre</label>
+          <input class="form-control" type="password" name="password" required placeholder="En az 8 karakter">
+        </div>
+        <div>
+          <label class="form-label">Şifre (Tekrar)</label>
+          <input class="form-control" type="password" name="password_confirm" required>
+        </div>
+        <button class="btn btn-brand mt-2 w-100">İlk Süperadmini Oluştur</button>
+      </form>
+      <p class="subtitle text-center mt-3">Bu hesap süperadmin yetkisine sahip olacak ve diğer yöneticileri davet edebilecek.</p>
+    <?php else: ?>
+      <form method="post" class="vstack gap-3">
+        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+        <input type="hidden" name="next" value="<?=h($next)?>">
+        <div>
+          <label class="form-label">E-posta</label>
+          <input class="form-control" type="email" name="email" required autofocus>
+        </div>
+        <div>
+          <label class="form-label">Şifre</label>
+          <input class="form-control" type="password" name="password" required>
+        </div>
+        <button class="btn btn-brand mt-2 w-100">Giriş Yap</button>
+      </form>
+    <?php endif; ?>
 
-    <div class="mt-3 text-center">
-      <a class="small" href="../index.php">Ana sayfa</a>
+    <div class="mt-4 text-center">
+      <a class="text-decoration-none" href="../index.php">← Ana sayfaya dön</a>
     </div>
   </div>
 </body>

--- a/admin/partials/ui.php
+++ b/admin/partials/ui.php
@@ -13,8 +13,8 @@ if (!function_exists('admin_base_styles')) {
         --admin-muted:#64748b;
         --admin-bg:#eef2f9;
         --admin-surface:#ffffff;
-        --admin-sidebar:#0f172a;
-        --admin-sidebar-accent:#1e3a8a;
+        --admin-sidebar:#0ea5b5;
+        --admin-sidebar-accent:#0b8b98;
         /* Eski değişkenlerle uyumluluk */
         --brand:var(--admin-brand);
         --brand-dark:var(--admin-brand-dark);
@@ -39,8 +39,8 @@ if (!function_exists('admin_base_styles')) {
 
       .admin-sidebar {
         width:280px;
-        background:linear-gradient(160deg,var(--admin-sidebar) 0%,var(--admin-sidebar-accent) 85%);
-        color:#f8fafc;
+        background:linear-gradient(165deg,var(--admin-sidebar) 0%,var(--admin-sidebar-accent) 92%);
+        color:#f0fdfd;
         display:flex;
         flex-direction:column;
         padding:28px 22px 32px;
@@ -83,10 +83,11 @@ if (!function_exists('admin_base_styles')) {
         gap:12px;
         padding:10px 12px;
         border-radius:12px;
-        color:rgba(248,250,252,.8);
+        color:rgba(255,255,255,.82);
         font-weight:500;
         text-decoration:none;
         transition:all .2s ease;
+        pointer-events:auto;
       }
 
       .sidebar-link i {
@@ -101,16 +102,20 @@ if (!function_exists('admin_base_styles')) {
       }
 
       .sidebar-link.active {
-        background:#fff;
-        color:var(--admin-brand);
-        box-shadow:0 15px 30px -18px rgba(15,23,42,.65);
+        background:rgba(255,255,255,.22);
+        color:#fff;
+        box-shadow:0 18px 34px -22px rgba(10,126,142,.65);
+      }
+
+      .sidebar-link.active i {
+        color:#fff;
       }
 
       .sidebar-footer {
         margin-top:2rem;
         padding:14px 16px;
         border-radius:14px;
-        background:rgba(255,255,255,.09);
+        background:rgba(255,255,255,.16);
         font-size:.85rem;
         line-height:1.5;
       }
@@ -420,7 +425,7 @@ CSS;
     echo '</nav>';
     echo '<div class="sidebar-footer">';
     echo '<strong>Destek</strong>';
-    echo 'Zerosoft ekibi ile iletişime geçmek için <a class="text-white text-decoration-underline" href="mailto:'.h($supportEmail).'">'.h($supportEmail).'</a> adresine yazabilirsiniz.';
+    echo 'Zerosoft ekibi ile iletişime geçmek için <a class="text-white text-decoration-none fw-semibold" href="mailto:'.h($supportEmail).'">'.h($supportEmail).'</a> adresine yazabilirsiniz.';
     echo '</div>';
     echo '</aside>';
 

--- a/admin/partials/ui.php
+++ b/admin/partials/ui.php
@@ -51,10 +51,11 @@ CSS;
   function render_admin_topnav(string $active = '', string $title = '', string $subtitle = ''): void {
     $me = admin_user();
     $links = [
-      'dashboard' => ['href' => BASE_URL.'/admin/dashboard.php', 'label' => 'Genel Bakış'],
-      'venues'    => ['href' => BASE_URL.'/admin/venues.php',    'label' => 'Salonlar'],
-      'users'     => ['href' => BASE_URL.'/admin/users.php',     'label' => 'Çiftler'],
-      'dealers'   => ['href' => BASE_URL.'/admin/dealers.php',   'label' => 'Bayiler'],
+      'dashboard'  => ['href' => BASE_URL.'/admin/dashboard.php',  'label' => 'Genel Bakış'],
+      'campaigns'  => ['href' => BASE_URL.'/admin/campaigns.php',  'label' => 'Kampanyalar'],
+      'venues'     => ['href' => BASE_URL.'/admin/venues.php',     'label' => 'Salonlar'],
+      'users'      => ['href' => BASE_URL.'/admin/users.php',      'label' => 'Etkinlikler'],
+      'dealers'    => ['href' => BASE_URL.'/admin/dealers.php',    'label' => 'Bayiler'],
     ];
     if (is_superadmin()) {
       $links['team'] = ['href' => BASE_URL.'/admin/team.php', 'label' => 'Yönetim'];

--- a/admin/partials/ui.php
+++ b/admin/partials/ui.php
@@ -58,6 +58,7 @@ CSS;
       'dealers'    => ['href' => BASE_URL.'/admin/dealers.php',    'label' => 'Bayiler'],
     ];
     if (is_superadmin()) {
+      $links['site'] = ['href' => BASE_URL.'/admin/site_content.php', 'label' => 'Site İçerikleri'];
       $links['packages'] = ['href' => BASE_URL.'/admin/dealer_packages.php', 'label' => 'Paketler'];
       $links['team'] = ['href' => BASE_URL.'/admin/team.php', 'label' => 'Yönetim'];
     }

--- a/admin/partials/ui.php
+++ b/admin/partials/ui.php
@@ -3,99 +3,463 @@ if (!function_exists('admin_base_styles')) {
   function admin_base_styles(): string {
     return <<<'CSS'
     <style>
-      :root{
-        --brand:#0ea5b5;
-        --brand-dark:#0b8b98;
-        --ink:#0f172a;
-        --muted:#64748b;
-        --surface:#ffffff;
-        --soft:#f1f7fb;
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+      @import url('https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css');
+
+      :root {
+        --admin-brand:#0ea5b5;
+        --admin-brand-dark:#0b8b98;
+        --admin-ink:#0f172a;
+        --admin-muted:#64748b;
+        --admin-bg:#eef2f9;
+        --admin-surface:#ffffff;
+        --admin-sidebar:#0f172a;
+        --admin-sidebar-accent:#1e3a8a;
+        /* Eski değişkenlerle uyumluluk */
+        --brand:var(--admin-brand);
+        --brand-dark:var(--admin-brand-dark);
+        --ink:var(--admin-ink);
+        --muted:var(--admin-muted);
+        --surface:var(--admin-surface);
       }
-      body.admin-body{background:var(--soft);color:var(--ink);min-height:100vh;font-family:'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;}
-      .admin-topnav{background:var(--surface);border-bottom:1px solid rgba(148,163,184,.22);box-shadow:0 10px 30px rgba(15,23,42,.05);position:sticky;top:0;z-index:1030;}
-      .admin-topnav .navbar-brand{font-weight:700;letter-spacing:.2px;color:var(--ink);}
-      .admin-topnav .navbar-toggler{border-color:rgba(148,163,184,.45);}
-      .admin-topnav .navbar-toggler:focus{box-shadow:0 0 0 .2rem rgba(14,165,181,.25);}
-      .admin-topnav .navbar-toggler-icon{background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(15,23,42,0.7)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");}
-      .admin-topnav .nav-link{font-weight:600;color:var(--muted);border-radius:12px;padding:.45rem .95rem;}
-      .admin-topnav .nav-link:hover{color:var(--brand-dark);background:rgba(14,165,181,.08);}
-      .admin-topnav .nav-link.active{color:var(--brand);background:rgba(14,165,181,.14);}
-      .admin-topnav .user-chip{background:rgba(14,165,181,.12);border-radius:999px;padding:.35rem .85rem;font-size:.85rem;color:var(--brand-dark);font-weight:600;}
-      .admin-hero{background:linear-gradient(120deg,rgba(14,165,181,.18),rgba(14,165,181,.04));padding:2.4rem 0 1.9rem;margin-bottom:2rem;}
-      .admin-hero h1{font-weight:700;margin-bottom:.35rem;}
-      .admin-hero p{margin:0;color:var(--muted);font-size:.97rem;max-width:720px;}
-      .admin-main{padding-bottom:4rem;}
-      .card-lite{border-radius:20px;background:var(--surface);border:1px solid rgba(148,163,184,.18);box-shadow:0 28px 50px -32px rgba(15,23,42,.55);}
-      .card-section{padding:1.7rem 1.5rem;}
-      .btn-brand{background:var(--brand);border:none;color:#fff;border-radius:12px;font-weight:600;padding:.58rem 1.3rem;}
-      .btn-brand:hover{background:var(--brand-dark);color:#fff;}
-      .btn-brand-outline{background:#fff;border:1px solid rgba(14,165,181,.6);color:var(--brand);border-radius:12px;font-weight:600;padding:.55rem 1.2rem;}
-      .badge-soft{background:rgba(14,165,181,.12);color:var(--brand-dark);border-radius:999px;padding:.35rem .75rem;font-size:.75rem;font-weight:600;}
-      .table thead th{color:var(--muted);font-weight:600;text-transform:uppercase;font-size:.75rem;letter-spacing:.04em;border-bottom:1px solid rgba(148,163,184,.25);}
-      .table tbody td{vertical-align:middle;}
-      .form-control, .form-select{border-radius:12px;border:1px solid rgba(148,163,184,.45);padding:.6rem .75rem;}
-      .form-control:focus, .form-select:focus{border-color:var(--brand);box-shadow:0 0 0 .2rem rgba(14,165,181,.15);}
-      @media (max-width: 991px){
-        .admin-topnav{position:static;}
-        .admin-hero{padding:1.7rem 0 1.2rem;margin-bottom:1.2rem;}
+
+      body.admin-body {
+        background:var(--admin-bg);
+        color:var(--admin-ink);
+        min-height:100vh;
+        font-family:'Inter','Segoe UI',system-ui,-apple-system,sans-serif;
+        margin:0;
       }
-      @media print{
-        .admin-header, .admin-hero{display:none !important;}
-        body.admin-body{background:#fff;}
-        .admin-main{padding:0;}
+
+      .admin-app {
+        min-height:100vh;
+        display:flex;
+        background:var(--admin-bg);
+      }
+
+      .admin-sidebar {
+        width:280px;
+        background:linear-gradient(160deg,var(--admin-sidebar) 0%,var(--admin-sidebar-accent) 85%);
+        color:#f8fafc;
+        display:flex;
+        flex-direction:column;
+        padding:28px 22px 32px;
+        position:relative;
+        z-index:1030;
+        transition:transform .3s ease;
+      }
+
+      .admin-sidebar .sidebar-brand {
+        display:flex;
+        align-items:center;
+        gap:12px;
+        font-weight:700;
+        font-size:1.18rem;
+        letter-spacing:.3px;
+        margin-bottom:2.2rem;
+      }
+
+      .admin-sidebar .sidebar-brand span {
+        display:inline-flex;
+        align-items:center;
+        justify-content:center;
+        width:40px;
+        height:40px;
+        border-radius:12px;
+        background:rgba(255,255,255,.16);
+        font-weight:700;
+      }
+
+      .sidebar-nav {
+        display:flex;
+        flex-direction:column;
+        gap:6px;
+        margin-bottom:auto;
+      }
+
+      .sidebar-link {
+        display:flex;
+        align-items:center;
+        gap:12px;
+        padding:10px 12px;
+        border-radius:12px;
+        color:rgba(248,250,252,.8);
+        font-weight:500;
+        text-decoration:none;
+        transition:all .2s ease;
+      }
+
+      .sidebar-link i {
+        font-size:1.05rem;
+      }
+
+      .sidebar-link:hover,
+      .sidebar-link:focus {
+        color:#fff;
+        background:rgba(255,255,255,.12);
+        text-decoration:none;
+      }
+
+      .sidebar-link.active {
+        background:#fff;
+        color:var(--admin-brand);
+        box-shadow:0 15px 30px -18px rgba(15,23,42,.65);
+      }
+
+      .sidebar-footer {
+        margin-top:2rem;
+        padding:14px 16px;
+        border-radius:14px;
+        background:rgba(255,255,255,.09);
+        font-size:.85rem;
+        line-height:1.5;
+      }
+
+      .sidebar-footer strong {
+        display:block;
+        font-size:.95rem;
+      }
+
+      .admin-workspace {
+        flex:1;
+        display:flex;
+        flex-direction:column;
+        position:relative;
+      }
+
+      .admin-toolbar {
+        display:flex;
+        align-items:center;
+        justify-content:space-between;
+        gap:16px;
+        padding:22px 32px 18px;
+      }
+
+      .toolbar-left {
+        display:flex;
+        align-items:center;
+        gap:16px;
+        flex:1;
+      }
+
+      .sidebar-toggle {
+        border:none;
+        background:#fff;
+        color:var(--admin-ink);
+        border-radius:12px;
+        width:46px;
+        height:46px;
+        display:inline-flex;
+        align-items:center;
+        justify-content:center;
+        box-shadow:0 10px 25px -15px rgba(15,23,42,.35);
+      }
+
+      .toolbar-search {
+        background:#fff;
+        border-radius:14px;
+        padding:10px 16px;
+        display:flex;
+        align-items:center;
+        gap:10px;
+        box-shadow:0 18px 40px -24px rgba(15,23,42,.45);
+        flex:1;
+        max-width:520px;
+      }
+
+      .toolbar-search input {
+        border:none;
+        outline:none;
+        width:100%;
+        font-size:.95rem;
+      }
+
+      .toolbar-right {
+        display:flex;
+        align-items:center;
+        gap:18px;
+      }
+
+      .toolbar-chip {
+        display:flex;
+        align-items:center;
+        gap:10px;
+        background:#fff;
+        border-radius:999px;
+        padding:8px 16px;
+        font-size:.85rem;
+        box-shadow:0 12px 30px -20px rgba(15,23,42,.5);
+        color:var(--admin-muted);
+      }
+
+      .toolbar-user {
+        display:flex;
+        align-items:center;
+        gap:12px;
+        background:#fff;
+        border-radius:999px;
+        padding:8px 14px 8px 8px;
+        box-shadow:0 18px 40px -24px rgba(15,23,42,.45);
+      }
+
+      .toolbar-user .avatar {
+        width:42px;
+        height:42px;
+        border-radius:50%;
+        background:var(--admin-brand);
+        color:#fff;
+        font-weight:600;
+        display:flex;
+        align-items:center;
+        justify-content:center;
+      }
+
+      .toolbar-user span {
+        display:flex;
+        flex-direction:column;
+        line-height:1.2;
+        font-size:.85rem;
+        color:var(--admin-ink);
+      }
+
+      .toolbar-user small {
+        color:var(--admin-muted);
+      }
+
+      .admin-hero {
+        padding:0 32px 28px;
+      }
+
+      .admin-hero-card {
+        background:linear-gradient(130deg,rgba(14,165,181,.18),rgba(14,165,181,.05));
+        border-radius:22px;
+        padding:28px 32px;
+        box-shadow:0 32px 60px -42px rgba(14,165,181,.8);
+      }
+
+      .admin-hero h1 {
+        font-weight:700;
+        margin-bottom:12px;
+      }
+
+      .admin-hero p {
+        margin:0;
+        color:var(--admin-muted);
+        max-width:780px;
+      }
+
+      .admin-main {
+        flex:1;
+        padding-bottom:48px;
+      }
+
+      .admin-main-inner {
+        width:100%;
+      }
+
+      .card-lite {
+        border-radius:20px;
+        background:var(--admin-surface);
+        border:1px solid rgba(15,23,42,.06);
+        box-shadow:0 28px 45px -30px rgba(15,23,42,.35);
+        padding:24px 26px;
+      }
+
+      .admin-section-title {
+        font-weight:600;
+        margin-bottom:18px;
+        display:flex;
+        justify-content:space-between;
+        align-items:center;
+        gap:16px;
+      }
+
+      .btn-brand {
+        background:var(--admin-brand);
+        border:none;
+        border-radius:12px;
+        color:#fff;
+        font-weight:600;
+        padding:.6rem 1.4rem;
+      }
+
+      .btn-brand:hover,
+      .btn-brand:focus {
+        background:var(--admin-brand-dark);
+        color:#fff;
+      }
+
+      .btn-brand-outline {
+        background:#fff;
+        border:1px solid rgba(14,165,181,.45);
+        border-radius:12px;
+        color:var(--admin-brand);
+        font-weight:600;
+        padding:.55rem 1.35rem;
+      }
+
+      .btn-brand-outline:hover,
+      .btn-brand-outline:focus {
+        background:rgba(14,165,181,.12);
+        color:var(--admin-brand-dark);
+      }
+
+      .badge-soft {
+        background:rgba(14,165,181,.12);
+        color:var(--admin-brand-dark);
+        border-radius:999px;
+        padding:.35rem .8rem;
+        font-size:.75rem;
+        font-weight:600;
+      }
+
+      .alert {
+        border-radius:14px;
+        border:none;
+        box-shadow:0 12px 35px -25px rgba(15,23,42,.55);
+        padding:.85rem 1.1rem;
+      }
+
+      table.table thead th {
+        font-size:.75rem;
+        text-transform:uppercase;
+        letter-spacing:.04em;
+        color:var(--admin-muted);
+        border-bottom:1px solid rgba(15,23,42,.08);
+      }
+
+      table.table tbody td {
+        vertical-align:middle;
+      }
+
+      .form-control,
+      .form-select {
+        border-radius:12px !important;
+        border:1px solid rgba(148,163,184,.45);
+        padding:.6rem .8rem;
+      }
+
+      .form-control:focus,
+      .form-select:focus {
+        border-color:var(--admin-brand);
+        box-shadow:0 0 0 .2rem rgba(14,165,181,.15);
+      }
+
+      @media (max-width: 991px) {
+        .admin-sidebar {
+          position:fixed;
+          inset:0 auto 0 0;
+          transform:translateX(-105%);
+          width:250px;
+          box-shadow:25px 0 60px -40px rgba(15,23,42,.85);
+        }
+
+        body.sidebar-open .admin-sidebar {
+          transform:none;
+        }
+
+        body.sidebar-open::after {
+          content:'';
+          position:fixed;
+          inset:0;
+          background:rgba(15,23,42,.45);
+          z-index:1025;
+        }
+
+        .admin-toolbar {
+          padding:18px 20px 16px;
+        }
+
+        .toolbar-left {
+          gap:10px;
+        }
+
+        .toolbar-search {
+          display:none;
+        }
+      }
+
+      @media (min-width: 992px) {
+        .sidebar-toggle {
+          display:none;
+        }
       }
     </style>
 CSS;
   }
 
-  function render_admin_topnav(string $active = '', string $title = '', string $subtitle = ''): void {
+  function admin_layout_start(string $active = '', string $title = '', string $subtitle = ''): void {
     $me = admin_user();
     $links = [
-      'dashboard'  => ['href' => BASE_URL.'/admin/dashboard.php',  'label' => 'Genel Bakış'],
-      'campaigns'  => ['href' => BASE_URL.'/admin/campaigns.php',  'label' => 'Kampanyalar'],
-      'venues'     => ['href' => BASE_URL.'/admin/venues.php',     'label' => 'Salonlar'],
-      'users'      => ['href' => BASE_URL.'/admin/users.php',      'label' => 'Etkinlikler'],
-      'dealers'    => ['href' => BASE_URL.'/admin/dealers.php',    'label' => 'Bayiler'],
+      'dashboard' => ['href' => BASE_URL.'/admin/dashboard.php', 'label' => 'Genel Bakış', 'icon' => 'bi-speedometer2'],
+      'campaigns' => ['href' => BASE_URL.'/admin/campaigns.php', 'label' => 'Kampanyalar', 'icon' => 'bi-megaphone'],
+      'venues'    => ['href' => BASE_URL.'/admin/venues.php', 'label' => 'Salon Yönetimi', 'icon' => 'bi-building'],
+      'users'     => ['href' => BASE_URL.'/admin/users.php', 'label' => 'Etkinlikler', 'icon' => 'bi-calendar3'],
+      'dealers'   => ['href' => BASE_URL.'/admin/dealers.php', 'label' => 'Bayiler', 'icon' => 'bi-shop'],
     ];
     if (is_superadmin()) {
-      $links['site'] = ['href' => BASE_URL.'/admin/site_content.php', 'label' => 'Site İçerikleri'];
-      $links['packages'] = ['href' => BASE_URL.'/admin/dealer_packages.php', 'label' => 'Paketler'];
-      $links['team'] = ['href' => BASE_URL.'/admin/team.php', 'label' => 'Yönetim'];
+      $links['packages'] = ['href' => BASE_URL.'/admin/dealer_packages.php', 'label' => 'Paketler', 'icon' => 'bi-boxes'];
+      $links['team']     = ['href' => BASE_URL.'/admin/team.php', 'label' => 'Yönetici Ekibi', 'icon' => 'bi-people'];
+      $links['site']     = ['href' => BASE_URL.'/admin/site_content.php', 'label' => 'Site İçerikleri', 'icon' => 'bi-sliders'];
     }
-    echo '<header class="admin-header">';
-    echo '<nav class="admin-topnav navbar navbar-expand-lg">';
-    echo '<div class="container">';
-    echo '<a class="navbar-brand" href="'.h(BASE_URL.'/admin/dashboard.php').'">'.h(APP_NAME).'</a>';
-    echo '<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false" aria-label="Menü">';
-    echo '<span class="navbar-toggler-icon"></span>';
-    echo '</button>';
-    echo '<div class="collapse navbar-collapse" id="adminNav">';
-    echo '<ul class="navbar-nav me-auto mb-2 mb-lg-0">';
+
+    $displayName = $me['name'] ?? $me['email'] ?? '';
+    $initial = $displayName ? mb_strtoupper(mb_substr($displayName, 0, 1, 'UTF-8'), 'UTF-8') : 'A';
+    $roleLabel = is_superadmin() ? 'Süperadmin' : 'Admin';
+
+    $supportEmail = defined('SITE_SUPPORT_EMAIL') && SITE_SUPPORT_EMAIL ? SITE_SUPPORT_EMAIL : 'destek@zerosoft.com.tr';
+
+    echo '<div class="admin-app">';
+    echo '<aside class="admin-sidebar" id="adminSidebar">';
+    echo '<div class="sidebar-brand"><span>'.mb_strtoupper(mb_substr(APP_NAME, 0, 2, 'UTF-8')).'</span>'.h(APP_NAME).' Panel</div>';
+    echo '<nav class="sidebar-nav">';
     foreach ($links as $key => $link) {
-      $cls = 'nav-link'.($active === $key ? ' active' : '');
-      echo '<li class="nav-item"><a class="'.$cls.'" href="'.h($link['href']).'">'.h($link['label']).'</a></li>';
+      $cls = 'sidebar-link'.($active === $key ? ' active' : '');
+      echo '<a class="'.$cls.'" href="'.h($link['href']).'"><i class="bi '.$link['icon'].'"></i><span>'.h($link['label']).'</span></a>';
     }
-    echo '</ul>';
-    echo '<div class="d-flex align-items-center gap-3 mb-2 mb-lg-0">';
-    if ($me) {
-      $roleLabel = is_superadmin() ? 'Süperadmin' : 'Admin';
-      echo '<span class="user-chip">'.h($me['name'] ?? $me['email']).' • '.h($roleLabel).'</span>';
-    }
-    echo '<a class="text-decoration-none fw-semibold" href="'.h(BASE_URL.'/admin/login.php?logout=1').'">Çıkış</a>';
-    echo '</div>';
-    echo '</div>';
-    echo '</div>';
     echo '</nav>';
+    echo '<div class="sidebar-footer">';
+    echo '<strong>Destek</strong>';
+    echo 'Zerosoft ekibi ile iletişime geçmek için <a class="text-white text-decoration-underline" href="mailto:'.h($supportEmail).'">'.h($supportEmail).'</a> adresine yazabilirsiniz.';
+    echo '</div>';
+    echo '</aside>';
+
+    echo '<div class="admin-workspace">';
+    echo '<header class="admin-toolbar">';
+    echo '<div class="toolbar-left">';
+    echo '<button class="sidebar-toggle" type="button" data-sidebar-toggle><i class="bi bi-list"></i></button>';
+    echo '<div class="toolbar-search"><i class="bi bi-search"></i><input type="search" placeholder="Panelde ara..." aria-label="Panelde ara"></div>';
+    echo '</div>';
+    echo '<div class="toolbar-right">';
+    echo '<div class="toolbar-chip"><i class="bi bi-calendar3"></i>'.date('d.m.Y').'</div>';
+    echo '<div class="toolbar-user">';
+    echo '<div class="avatar">'.h($initial).'</div>';
+    echo '<span><strong>'.h($displayName).'</strong><small>'.h($roleLabel).'</small></span>';
+    echo '<a class="ms-2 text-decoration-none text-danger" href="'.h(BASE_URL.'/admin/login.php?logout=1').'" title="Çıkış Yap"><i class="bi bi-box-arrow-right"></i></a>';
+    echo '</div>';
+    echo '</div>';
+    echo '</header>';
+
     if ($title !== '') {
-      echo '<div class="admin-hero">';
-      echo '<div class="container">';
+      echo '<section class="admin-hero">';
+      echo '<div class="admin-hero-card">';
       echo '<h1>'.h($title).'</h1>';
       if ($subtitle !== '') {
         echo '<p>'.h($subtitle).'</p>';
       }
       echo '</div>';
-      echo '</div>';
+      echo '</section>';
     }
-    echo '</header>';
+
+    echo '<main class="admin-main">';
+    echo '<div class="admin-main-inner container-fluid px-3 px-xl-4 py-4">';
+  }
+
+  function admin_layout_end(): void {
+    echo '</div>'; // admin-main-inner
+    echo '</main>';
+    echo '</div>'; // admin-workspace
+    echo '</div>'; // admin-app
+    echo '<script>document.querySelectorAll("[data-sidebar-toggle]").forEach(function(btn){btn.addEventListener("click",function(){document.body.classList.toggle("sidebar-open");});});document.addEventListener("click",function(ev){if(!document.body.classList.contains("sidebar-open")) return;var sidebar=document.getElementById("adminSidebar");if(!sidebar) return;if(sidebar.contains(ev.target)) return;var toggle=ev.target.closest("[data-sidebar-toggle]");if(toggle) return;document.body.classList.remove("sidebar-open");});</script>';
   }
 }

--- a/admin/partials/ui.php
+++ b/admin/partials/ui.php
@@ -58,6 +58,7 @@ CSS;
       'dealers'    => ['href' => BASE_URL.'/admin/dealers.php',    'label' => 'Bayiler'],
     ];
     if (is_superadmin()) {
+      $links['packages'] = ['href' => BASE_URL.'/admin/dealer_packages.php', 'label' => 'Paketler'];
       $links['team'] = ['href' => BASE_URL.'/admin/team.php', 'label' => 'Yönetim'];
     }
     echo '<header class="admin-header">';

--- a/admin/partials/ui.php
+++ b/admin/partials/ui.php
@@ -1,0 +1,98 @@
+<?php
+if (!function_exists('admin_base_styles')) {
+  function admin_base_styles(): string {
+    return <<<'CSS'
+    <style>
+      :root{
+        --brand:#0ea5b5;
+        --brand-dark:#0b8b98;
+        --ink:#0f172a;
+        --muted:#64748b;
+        --surface:#ffffff;
+        --soft:#f1f7fb;
+      }
+      body.admin-body{background:var(--soft);color:var(--ink);min-height:100vh;font-family:'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;}
+      .admin-topnav{background:var(--surface);border-bottom:1px solid rgba(148,163,184,.22);box-shadow:0 10px 30px rgba(15,23,42,.05);position:sticky;top:0;z-index:1030;}
+      .admin-topnav .navbar-brand{font-weight:700;letter-spacing:.2px;color:var(--ink);}
+      .admin-topnav .navbar-toggler{border-color:rgba(148,163,184,.45);}
+      .admin-topnav .navbar-toggler:focus{box-shadow:0 0 0 .2rem rgba(14,165,181,.25);}
+      .admin-topnav .navbar-toggler-icon{background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(15,23,42,0.7)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");}
+      .admin-topnav .nav-link{font-weight:600;color:var(--muted);border-radius:12px;padding:.45rem .95rem;}
+      .admin-topnav .nav-link:hover{color:var(--brand-dark);background:rgba(14,165,181,.08);}
+      .admin-topnav .nav-link.active{color:var(--brand);background:rgba(14,165,181,.14);}
+      .admin-topnav .user-chip{background:rgba(14,165,181,.12);border-radius:999px;padding:.35rem .85rem;font-size:.85rem;color:var(--brand-dark);font-weight:600;}
+      .admin-hero{background:linear-gradient(120deg,rgba(14,165,181,.18),rgba(14,165,181,.04));padding:2.4rem 0 1.9rem;margin-bottom:2rem;}
+      .admin-hero h1{font-weight:700;margin-bottom:.35rem;}
+      .admin-hero p{margin:0;color:var(--muted);font-size:.97rem;max-width:720px;}
+      .admin-main{padding-bottom:4rem;}
+      .card-lite{border-radius:20px;background:var(--surface);border:1px solid rgba(148,163,184,.18);box-shadow:0 28px 50px -32px rgba(15,23,42,.55);}
+      .card-section{padding:1.7rem 1.5rem;}
+      .btn-brand{background:var(--brand);border:none;color:#fff;border-radius:12px;font-weight:600;padding:.58rem 1.3rem;}
+      .btn-brand:hover{background:var(--brand-dark);color:#fff;}
+      .btn-brand-outline{background:#fff;border:1px solid rgba(14,165,181,.6);color:var(--brand);border-radius:12px;font-weight:600;padding:.55rem 1.2rem;}
+      .badge-soft{background:rgba(14,165,181,.12);color:var(--brand-dark);border-radius:999px;padding:.35rem .75rem;font-size:.75rem;font-weight:600;}
+      .table thead th{color:var(--muted);font-weight:600;text-transform:uppercase;font-size:.75rem;letter-spacing:.04em;border-bottom:1px solid rgba(148,163,184,.25);}
+      .table tbody td{vertical-align:middle;}
+      .form-control, .form-select{border-radius:12px;border:1px solid rgba(148,163,184,.45);padding:.6rem .75rem;}
+      .form-control:focus, .form-select:focus{border-color:var(--brand);box-shadow:0 0 0 .2rem rgba(14,165,181,.15);}
+      @media (max-width: 991px){
+        .admin-topnav{position:static;}
+        .admin-hero{padding:1.7rem 0 1.2rem;margin-bottom:1.2rem;}
+      }
+      @media print{
+        .admin-header, .admin-hero{display:none !important;}
+        body.admin-body{background:#fff;}
+        .admin-main{padding:0;}
+      }
+    </style>
+CSS;
+  }
+
+  function render_admin_topnav(string $active = '', string $title = '', string $subtitle = ''): void {
+    $me = admin_user();
+    $links = [
+      'dashboard' => ['href' => BASE_URL.'/admin/dashboard.php', 'label' => 'Genel Bakış'],
+      'venues'    => ['href' => BASE_URL.'/admin/venues.php',    'label' => 'Salonlar'],
+      'users'     => ['href' => BASE_URL.'/admin/users.php',     'label' => 'Çiftler'],
+      'dealers'   => ['href' => BASE_URL.'/admin/dealers.php',   'label' => 'Bayiler'],
+    ];
+    if (is_superadmin()) {
+      $links['team'] = ['href' => BASE_URL.'/admin/team.php', 'label' => 'Yönetim'];
+    }
+    echo '<header class="admin-header">';
+    echo '<nav class="admin-topnav navbar navbar-expand-lg">';
+    echo '<div class="container">';
+    echo '<a class="navbar-brand" href="'.h(BASE_URL.'/admin/dashboard.php').'">'.h(APP_NAME).'</a>';
+    echo '<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false" aria-label="Menü">';
+    echo '<span class="navbar-toggler-icon"></span>';
+    echo '</button>';
+    echo '<div class="collapse navbar-collapse" id="adminNav">';
+    echo '<ul class="navbar-nav me-auto mb-2 mb-lg-0">';
+    foreach ($links as $key => $link) {
+      $cls = 'nav-link'.($active === $key ? ' active' : '');
+      echo '<li class="nav-item"><a class="'.$cls.'" href="'.h($link['href']).'">'.h($link['label']).'</a></li>';
+    }
+    echo '</ul>';
+    echo '<div class="d-flex align-items-center gap-3 mb-2 mb-lg-0">';
+    if ($me) {
+      $roleLabel = is_superadmin() ? 'Süperadmin' : 'Admin';
+      echo '<span class="user-chip">'.h($me['name'] ?? $me['email']).' • '.h($roleLabel).'</span>';
+    }
+    echo '<a class="text-decoration-none fw-semibold" href="'.h(BASE_URL.'/admin/login.php?logout=1').'">Çıkış</a>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
+    echo '</nav>';
+    if ($title !== '') {
+      echo '<div class="admin-hero">';
+      echo '<div class="container">';
+      echo '<h1>'.h($title).'</h1>';
+      if ($subtitle !== '') {
+        echo '<p>'.h($subtitle).'</p>';
+      }
+      echo '</div>';
+      echo '</div>';
+    }
+    echo '</header>';
+  }
+}

--- a/admin/partials/ui.php
+++ b/admin/partials/ui.php
@@ -46,17 +46,24 @@ if (!function_exists('admin_base_styles')) {
         padding:28px 22px 32px;
         position:relative;
         z-index:1030;
-        transition:transform .3s ease;
+        transition:transform .3s ease,width .3s ease,padding .3s ease;
       }
 
       .admin-sidebar .sidebar-brand {
         display:flex;
         align-items:center;
+        justify-content:space-between;
         gap:12px;
         font-weight:700;
         font-size:1.18rem;
         letter-spacing:.3px;
         margin-bottom:2.2rem;
+      }
+
+      .admin-sidebar .sidebar-brand .brand-mark {
+        display:flex;
+        align-items:center;
+        gap:12px;
       }
 
       .admin-sidebar .sidebar-brand span {
@@ -68,6 +75,22 @@ if (!function_exists('admin_base_styles')) {
         border-radius:12px;
         background:rgba(255,255,255,.16);
         font-weight:700;
+      }
+
+      .admin-sidebar .sidebar-brand strong {
+        font-size:1.05rem;
+      }
+
+      .sidebar-collapse {
+        border:none;
+        background:rgba(255,255,255,.14);
+        color:#fff;
+        width:38px;
+        height:38px;
+        border-radius:12px;
+        display:inline-flex;
+        align-items:center;
+        justify-content:center;
       }
 
       .sidebar-nav {
@@ -350,6 +373,49 @@ if (!function_exists('admin_base_styles')) {
         box-shadow:0 0 0 .2rem rgba(14,165,181,.15);
       }
 
+      body.sidebar-collapsed .admin-sidebar {
+        width:90px;
+        padding:28px 14px 32px;
+      }
+
+      body.sidebar-collapsed .admin-sidebar .sidebar-brand {
+        justify-content:center;
+      }
+
+      body.sidebar-collapsed .admin-sidebar .sidebar-brand strong {
+        display:none;
+      }
+
+      body.sidebar-collapsed .sidebar-footer {
+        display:none;
+      }
+
+      body.sidebar-collapsed .sidebar-link {
+        justify-content:center;
+        padding:12px;
+      }
+
+      body.sidebar-collapsed .sidebar-link span,
+      body.sidebar-collapsed .sidebar-link .sidebar-label {
+        display:none;
+      }
+
+      body.sidebar-collapsed .sidebar-link i {
+        font-size:1.2rem;
+      }
+
+      body.sidebar-collapsed .admin-toolbar {
+        padding-left:22px;
+      }
+
+      body.sidebar-collapsed .toolbar-search {
+        max-width:420px;
+      }
+
+      body.sidebar-collapsed .toolbar-user span strong {
+        max-width:140px;
+      }
+
       @media (max-width: 991px) {
         .admin-sidebar {
           position:fixed;
@@ -383,12 +449,6 @@ if (!function_exists('admin_base_styles')) {
           display:none;
         }
       }
-
-      @media (min-width: 992px) {
-        .sidebar-toggle {
-          display:none;
-        }
-      }
     </style>
 CSS;
   }
@@ -416,11 +476,14 @@ CSS;
 
     echo '<div class="admin-app">';
     echo '<aside class="admin-sidebar" id="adminSidebar">';
-    echo '<div class="sidebar-brand"><span>'.mb_strtoupper(mb_substr(APP_NAME, 0, 2, 'UTF-8')).'</span>'.h(APP_NAME).' Panel</div>';
+    echo '<div class="sidebar-brand">';
+    echo '<div class="brand-mark"><span>'.mb_strtoupper(mb_substr(APP_NAME, 0, 2, 'UTF-8')).'</span><strong>'.h(APP_NAME).' Panel</strong></div>';
+    echo '<button class="sidebar-collapse" type="button" data-sidebar-toggle aria-label="Menüyü daralt"><i class="bi bi-chevron-double-left"></i></button>';
+    echo '</div>';
     echo '<nav class="sidebar-nav">';
     foreach ($links as $key => $link) {
       $cls = 'sidebar-link'.($active === $key ? ' active' : '');
-      echo '<a class="'.$cls.'" href="'.h($link['href']).'"><i class="bi '.$link['icon'].'"></i><span>'.h($link['label']).'</span></a>';
+      echo '<a class="'.$cls.'" href="'.h($link['href']).'" title="'.h($link['label']).'"><i class="bi '.$link['icon'].'"></i><span class="sidebar-label">'.h($link['label']).'</span></a>';
     }
     echo '</nav>';
     echo '<div class="sidebar-footer">';
@@ -432,7 +495,7 @@ CSS;
     echo '<div class="admin-workspace">';
     echo '<header class="admin-toolbar">';
     echo '<div class="toolbar-left">';
-    echo '<button class="sidebar-toggle" type="button" data-sidebar-toggle><i class="bi bi-list"></i></button>';
+    echo '<button class="sidebar-toggle" type="button" data-sidebar-toggle aria-label="Menüyü aç/kapat"><i class="bi bi-list"></i></button>';
     echo '<div class="toolbar-search"><i class="bi bi-search"></i><input type="search" placeholder="Panelde ara..." aria-label="Panelde ara"></div>';
     echo '</div>';
     echo '<div class="toolbar-right">';
@@ -465,6 +528,11 @@ CSS;
     echo '</main>';
     echo '</div>'; // admin-workspace
     echo '</div>'; // admin-app
-    echo '<script>document.querySelectorAll("[data-sidebar-toggle]").forEach(function(btn){btn.addEventListener("click",function(){document.body.classList.toggle("sidebar-open");});});document.addEventListener("click",function(ev){if(!document.body.classList.contains("sidebar-open")) return;var sidebar=document.getElementById("adminSidebar");if(!sidebar) return;if(sidebar.contains(ev.target)) return;var toggle=ev.target.closest("[data-sidebar-toggle]");if(toggle) return;document.body.classList.remove("sidebar-open");});</script>';
+    echo '<script>(function(){var body=document.body;var sidebar=document.getElementById("adminSidebar");var collapseBtn=sidebar?sidebar.querySelector(".sidebar-collapse"):null;var collapseIcon=collapseBtn?collapseBtn.querySelector("i"):null;var mql=window.matchMedia("(max-width: 991px)");var key="adminSidebarCollapsed";function isMobile(){return mql.matches;}function updateIcon(state){if(!collapseIcon) return;if(state){collapseIcon.classList.remove("bi-chevron-double-left");collapseIcon.classList.add("bi-chevron-double-right");}else{collapseIcon.classList.add("bi-chevron-double-left");collapseIcon.classList.remove("bi-chevron-double-right");}}function setCollapsed(state){if(state){body.classList.add("sidebar-collapsed");localStorage.setItem(key,"1");}else{body.classList.remove("sidebar-collapsed");localStorage.removeItem(key);}updateIcon(state);}function toggle(){if(isMobile()){body.classList.toggle("sidebar-open");return;}setCollapsed(!body.classList.contains("sidebar-collapsed"));}
+    document.querySelectorAll("[data-sidebar-toggle]").forEach(function(btn){btn.addEventListener("click",function(ev){ev.preventDefault();toggle();});});
+    document.addEventListener("click",function(ev){if(!body.classList.contains("sidebar-open")) return;if(sidebar && sidebar.contains(ev.target)) return;var toggleBtn=ev.target.closest("[data-sidebar-toggle]");if(toggleBtn) return;body.classList.remove("sidebar-open");});
+    function applyStored(){if(isMobile()){body.classList.remove("sidebar-collapsed");updateIcon(false);return;}var stored=localStorage.getItem(key)==="1";setCollapsed(stored);}applyStored();
+    if(mql.addEventListener){mql.addEventListener("change",function(){applyStored();body.classList.remove("sidebar-open");});}else if(mql.addListener){mql.addListener(function(){applyStored();body.classList.remove("sidebar-open");});}
+    })();</script>';
   }
 }

--- a/admin/site_content.php
+++ b/admin/site_content.php
@@ -102,160 +102,241 @@ while (count($navItems) < 5) {
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <?=admin_base_styles()?>
   <style>
+    .settings-shell{display:flex;flex-direction:column;gap:1.5rem;}
+    .pane-nav{background:#fff;border-radius:18px;padding:1.5rem;box-shadow:0 24px 60px -45px rgba(15,23,42,.55);}
+    .pane-nav h6{font-weight:700;font-size:1.05rem;margin-bottom:1rem;color:var(--admin-ink);}
+    .pane-button{width:100%;display:flex;align-items:center;gap:.85rem;border:none;background:rgba(14,165,181,.08);color:var(--admin-ink);padding:.8rem 1rem;border-radius:14px;font-weight:600;transition:all .2s ease;}
+    .pane-button i{font-size:1.05rem;color:var(--admin-brand);transition:inherit;}
+    .pane-button:not(:last-child){margin-bottom:.65rem;}
+    .pane-button:hover,.pane-button:focus{background:rgba(14,165,181,.16);color:var(--admin-brand);outline:none;}
+    .pane-button.active{background:var(--admin-brand);color:#fff;box-shadow:0 12px 30px -20px rgba(14,165,181,.9);}
+    .pane-button.active i{color:#fff;}
+    .content-pane{display:none;}
+    .content-pane.active{display:block;}
     .repeater-item{border:1px dashed rgba(14,165,181,.35);border-radius:16px;padding:1rem 1.25rem;background:#fff;}
     .repeater-item + .repeater-item{margin-top:1rem;}
     .btn-add-row{border-radius:12px;}
+    @media (max-width: 991px){
+      .settings-shell{gap:1rem;}
+    }
   </style>
 </head>
 <body class="admin-body">
-<?php admin_layout_start('site', 'Site İçerikleri', 'Landing sayfası metinlerini ve sıkça sorulan soruları yönetin.'); ?>
+<?php admin_layout_start('site', 'Site İçerikleri', 'Landing sayfanızdaki blokları düzenleyin ve hızlıca yayınlayın.'); ?>
     <?php flash_box(); ?>
-    <form method="post" class="card card-lite">
-      <div class="card-section border-bottom">
-        <h5 class="fw-bold mb-3">İletişim Alanı</h5>
-        <div class="row g-3">
-          <div class="col-md-6">
-            <label class="form-label">Başlık</label>
-            <input type="text" name="contact_title" class="form-control" value="<?=h($content['contact_title'] ?? '')?>">
-          </div>
-          <div class="col-md-6">
-            <label class="form-label">Açıklama</label>
-            <input type="text" name="contact_text" class="form-control" value="<?=h($content['contact_text'] ?? '')?>">
-          </div>
-          <div class="col-md-4">
-            <label class="form-label">Telefon</label>
-            <input type="text" name="contact_phone" class="form-control" value="<?=h($content['contact_phone'] ?? '')?>">
-          </div>
-          <div class="col-md-4">
-            <label class="form-label">E-posta</label>
-            <input type="email" name="contact_email" class="form-control" value="<?=h($content['contact_email'] ?? '')?>">
-          </div>
-          <div class="col-md-4">
-            <label class="form-label">Adres</label>
-            <input type="text" name="contact_address" class="form-control" value="<?=h($content['contact_address'] ?? '')?>">
-          </div>
-          <div class="col-md-6">
-            <label class="form-label">Web Adresi</label>
-            <input type="text" name="contact_website" class="form-control" value="<?=h($content['contact_website'] ?? '')?>" placeholder="https://...">
-          </div>
-          <div class="col-md-6">
-            <label class="form-label">Web Etiketi</label>
-            <input type="text" name="contact_website_label" class="form-control" value="<?=h($content['contact_website_label'] ?? '')?>" placeholder="zerosoft.com.tr">
-          </div>
-          <div class="col-md-6">
-            <label class="form-label">Birincil Buton Metni</label>
-            <input type="text" name="contact_primary_label" class="form-control" value="<?=h($content['contact_primary_label'] ?? '')?>">
-          </div>
-          <div class="col-md-6">
-            <label class="form-label">Birincil Buton URL</label>
-            <input type="text" name="contact_primary_url" class="form-control" value="<?=h($content['contact_primary_url'] ?? '')?>">
-          </div>
-          <div class="col-md-6">
-            <label class="form-label">İkincil Buton Metni</label>
-            <input type="text" name="contact_secondary_label" class="form-control" value="<?=h($content['contact_secondary_label'] ?? '')?>">
-          </div>
-          <div class="col-md-6">
-            <label class="form-label">İkincil Buton URL</label>
-            <input type="text" name="contact_secondary_url" class="form-control" value="<?=h($content['contact_secondary_url'] ?? '')?>">
+    <form method="post" class="settings-shell" novalidate>
+      <div class="row g-4 align-items-start">
+        <div class="col-lg-4">
+          <div class="pane-nav">
+            <h6>İçerik Başlıkları</h6>
+            <button type="button" class="pane-button active" data-pane-target="contact"><i class="bi bi-person-rolodex"></i>İletişim Bilgileri</button>
+            <button type="button" class="pane-button" data-pane-target="cta"><i class="bi bi-bullseye"></i>Çağrı Alanı</button>
+            <button type="button" class="pane-button" data-pane-target="faq"><i class="bi bi-chat-dots"></i>Sıkça Sorulanlar</button>
+            <button type="button" class="pane-button" data-pane-target="footer"><i class="bi bi-columns-gap"></i>Footer İçeriği</button>
           </div>
         </div>
-        <hr class="my-4">
-        <div class="row g-3">
-          <div class="col-md-4">
-            <label class="form-label">CTA Rozeti</label>
-            <input type="text" name="contact_cta_badge" class="form-control" value="<?=h($content['contact_cta_badge'] ?? '')?>">
-          </div>
-          <div class="col-md-4">
-            <label class="form-label">CTA Başlığı</label>
-            <input type="text" name="contact_cta_title" class="form-control" value="<?=h($content['contact_cta_title'] ?? '')?>">
-          </div>
-          <div class="col-md-4">
-            <label class="form-label">CTA Buton Metni</label>
-            <input type="text" name="contact_cta_button_label" class="form-control" value="<?=h($content['contact_cta_button_label'] ?? '')?>">
-          </div>
-          <div class="col-12">
-            <label class="form-label">CTA Açıklaması</label>
-            <textarea name="contact_cta_text" class="form-control" rows="3"><?=h($content['contact_cta_text'] ?? '')?></textarea>
-          </div>
-          <div class="col-12">
-            <label class="form-label">CTA Buton URL</label>
-            <input type="text" name="contact_cta_button_url" class="form-control" value="<?=h($content['contact_cta_button_url'] ?? '')?>">
-          </div>
-        </div>
-      </div>
-
-      <div class="card-section border-bottom">
-        <h5 class="fw-bold mb-3">Sıkça Sorulan Sorular</h5>
-        <div id="faqRepeater">
-          <?php foreach ($faqItems as $index => $faq): ?>
-            <div class="repeater-item" data-index="<?=$index?>">
-              <div class="row g-3 align-items-start">
-                <div class="col-md-6">
-                  <label class="form-label">Soru</label>
-                  <input type="text" class="form-control" name="faq_question[]" value="<?=h($faq['question'])?>" placeholder="Soru metni">
+        <div class="col-lg-8">
+          <div class="card card-lite content-pane active" data-pane="contact">
+            <div class="card-section border-bottom">
+              <div class="d-flex align-items-start justify-content-between flex-wrap gap-3 mb-3">
+                <div>
+                  <h5 class="fw-bold mb-1">İletişim Bilgileri</h5>
+                  <p class="text-muted mb-0">Footer ve iletişim bloklarında yer alan temel bilgileri güncelleyin.</p>
                 </div>
-                <div class="col-md-6">
-                  <label class="form-label">Cevap</label>
-                  <textarea class="form-control" name="faq_answer[]" rows="2" placeholder="Cevap metni"><?=h($faq['answer'])?></textarea>
-                </div>
+                <span class="badge rounded-pill text-bg-light text-uppercase" style="letter-spacing:.05em;color:var(--admin-brand);background:rgba(14,165,181,.15);">#0ea5b5</span>
               </div>
-            </div>
-          <?php endforeach; ?>
-        </div>
-        <button type="button" class="btn btn-sm btn-outline-secondary mt-3 btn-add-row" data-target="faq">+ Soru Ekle</button>
-      </div>
-
-      <div class="card-section border-bottom">
-        <h5 class="fw-bold mb-3">Footer İçeriği</h5>
-        <div class="row g-3">
-          <div class="col-md-6">
-            <label class="form-label">Hakkımızda Metni</label>
-            <textarea name="footer_about" class="form-control" rows="4"><?=h($content['footer_about'] ?? '')?></textarea>
-          </div>
-          <div class="col-md-6">
-            <label class="form-label">Firma Adı</label>
-            <input type="text" name="footer_company" class="form-control" value="<?=h($content['footer_company'] ?? '')?>">
-            <div class="mt-3">
-              <label class="form-label">Alt Satır (Sol)</label>
-              <input type="text" name="footer_disclaimer_left" class="form-control" value="<?=h($content['footer_disclaimer_left'] ?? '')?>">
-            </div>
-            <div class="mt-3">
-              <label class="form-label">Alt Satır (Sağ)</label>
-              <input type="text" name="footer_disclaimer_right" class="form-control" value="<?=h($content['footer_disclaimer_right'] ?? '')?>">
-            </div>
-          </div>
-        </div>
-        <hr class="my-4">
-        <h6 class="fw-semibold">Footer Navigasyonu</h6>
-        <div id="navRepeater">
-          <?php foreach ($navItems as $item): ?>
-            <div class="repeater-item">
               <div class="row g-3">
                 <div class="col-md-6">
-                  <label class="form-label">Etiket</label>
-                  <input type="text" class="form-control" name="nav_label[]" value="<?=h($item['label'])?>" placeholder="Örn. Paketler">
+                  <label class="form-label">Başlık</label>
+                  <input type="text" name="contact_title" class="form-control" value="<?=h($content['contact_title'] ?? '')?>">
                 </div>
                 <div class="col-md-6">
-                  <label class="form-label">Bağlantı</label>
-                  <input type="text" class="form-control" name="nav_url[]" value="<?=h($item['url'])?>" placeholder="#paketler">
+                  <label class="form-label">Açıklama</label>
+                  <input type="text" name="contact_text" class="form-control" value="<?=h($content['contact_text'] ?? '')?>">
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label">Telefon</label>
+                  <input type="text" name="contact_phone" class="form-control" value="<?=h($content['contact_phone'] ?? '')?>">
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label">E-posta</label>
+                  <input type="email" name="contact_email" class="form-control" value="<?=h($content['contact_email'] ?? '')?>">
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label">Adres</label>
+                  <input type="text" name="contact_address" class="form-control" value="<?=h($content['contact_address'] ?? '')?>">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">Web Adresi</label>
+                  <input type="text" name="contact_website" class="form-control" value="<?=h($content['contact_website'] ?? '')?>" placeholder="https://...">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">Web Etiketi</label>
+                  <input type="text" name="contact_website_label" class="form-control" value="<?=h($content['contact_website_label'] ?? '')?>" placeholder="zerosoft.com.tr">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">Birincil Buton Metni</label>
+                  <input type="text" name="contact_primary_label" class="form-control" value="<?=h($content['contact_primary_label'] ?? '')?>">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">Birincil Buton URL</label>
+                  <input type="text" name="contact_primary_url" class="form-control" value="<?=h($content['contact_primary_url'] ?? '')?>">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">İkincil Buton Metni</label>
+                  <input type="text" name="contact_secondary_label" class="form-control" value="<?=h($content['contact_secondary_label'] ?? '')?>">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">İkincil Buton URL</label>
+                  <input type="text" name="contact_secondary_url" class="form-control" value="<?=h($content['contact_secondary_url'] ?? '')?>">
                 </div>
               </div>
             </div>
-          <?php endforeach; ?>
+          </div>
+
+          <div class="card card-lite content-pane" data-pane="cta">
+            <div class="card-section">
+              <div class="d-flex align-items-start justify-content-between flex-wrap gap-3 mb-3">
+                <div>
+                  <h5 class="fw-bold mb-1">Çağrı Alanı</h5>
+                  <p class="text-muted mb-0">Anasayfanın alt bölümünde yer alan harekete geçirici mesajı şekillendirin.</p>
+                </div>
+                <i class="bi bi-megaphone-fill" style="font-size:1.6rem;color:var(--admin-brand);"></i>
+              </div>
+              <div class="row g-3">
+                <div class="col-md-4">
+                  <label class="form-label">CTA Rozeti</label>
+                  <input type="text" name="contact_cta_badge" class="form-control" value="<?=h($content['contact_cta_badge'] ?? '')?>">
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label">CTA Başlığı</label>
+                  <input type="text" name="contact_cta_title" class="form-control" value="<?=h($content['contact_cta_title'] ?? '')?>">
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label">CTA Buton Metni</label>
+                  <input type="text" name="contact_cta_button_label" class="form-control" value="<?=h($content['contact_cta_button_label'] ?? '')?>">
+                </div>
+                <div class="col-12">
+                  <label class="form-label">CTA Açıklaması</label>
+                  <textarea name="contact_cta_text" class="form-control" rows="3"><?=h($content['contact_cta_text'] ?? '')?></textarea>
+                </div>
+                <div class="col-12">
+                  <label class="form-label">CTA Buton URL</label>
+                  <input type="text" name="contact_cta_button_url" class="form-control" value="<?=h($content['contact_cta_button_url'] ?? '')?>">
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card card-lite content-pane" data-pane="faq">
+            <div class="card-section">
+              <div class="d-flex align-items-start justify-content-between flex-wrap gap-3 mb-3">
+                <div>
+                  <h5 class="fw-bold mb-1">Sıkça Sorulan Sorular</h5>
+                  <p class="text-muted mb-0">Ziyaretçilerin en çok merak ettiği başlıkları hızlıca düzenleyin.</p>
+                </div>
+                <span class="badge text-bg-light" style="color:var(--admin-brand);background:rgba(14,165,181,.15);">En az 3 önerilir</span>
+              </div>
+              <div data-repeater="faq">
+                <?php foreach ($faqItems as $index => $faq): ?>
+                  <div class="repeater-item" data-index="<?=$index?>">
+                    <div class="row g-3 align-items-start">
+                      <div class="col-md-6">
+                        <label class="form-label">Soru</label>
+                        <input type="text" class="form-control" name="faq_question[]" value="<?=h($faq['question'])?>" placeholder="Soru metni">
+                      </div>
+                      <div class="col-md-6">
+                        <label class="form-label">Cevap</label>
+                        <textarea class="form-control" name="faq_answer[]" rows="2" placeholder="Cevap metni"><?=h($faq['answer'])?></textarea>
+                      </div>
+                    </div>
+                  </div>
+                <?php endforeach; ?>
+              </div>
+              <button type="button" class="btn btn-sm btn-outline-secondary mt-3 btn-add-row" data-target="faq">+ Soru Ekle</button>
+            </div>
+          </div>
+
+          <div class="card card-lite content-pane" data-pane="footer">
+            <div class="card-section">
+              <div class="d-flex align-items-start justify-content-between flex-wrap gap-3 mb-3">
+                <div>
+                  <h5 class="fw-bold mb-1">Footer İçeriği</h5>
+                  <p class="text-muted mb-0">Hakkımızda alanı, alt satırlar ve hızlı bağlantıları buradan yönetin.</p>
+                </div>
+                <i class="bi bi-layout-text-window-reverse" style="font-size:1.6rem;color:var(--admin-brand);"></i>
+              </div>
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label class="form-label">Hakkımızda Metni</label>
+                  <textarea name="footer_about" class="form-control" rows="4"><?=h($content['footer_about'] ?? '')?></textarea>
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">Firma Adı</label>
+                  <input type="text" name="footer_company" class="form-control" value="<?=h($content['footer_company'] ?? '')?>">
+                  <div class="mt-3">
+                    <label class="form-label">Alt Satır (Sol)</label>
+                    <input type="text" name="footer_disclaimer_left" class="form-control" value="<?=h($content['footer_disclaimer_left'] ?? '')?>">
+                  </div>
+                  <div class="mt-3">
+                    <label class="form-label">Alt Satır (Sağ)</label>
+                    <input type="text" name="footer_disclaimer_right" class="form-control" value="<?=h($content['footer_disclaimer_right'] ?? '')?>">
+                  </div>
+                </div>
+              </div>
+              <hr class="my-4">
+              <h6 class="fw-semibold">Footer Navigasyonu</h6>
+              <div data-repeater="nav">
+                <?php foreach ($navItems as $item): ?>
+                  <div class="repeater-item">
+                    <div class="row g-3">
+                      <div class="col-md-6">
+                        <label class="form-label">Etiket</label>
+                        <input type="text" class="form-control" name="nav_label[]" value="<?=h($item['label'])?>" placeholder="Örn. Paketler">
+                      </div>
+                      <div class="col-md-6">
+                        <label class="form-label">Bağlantı</label>
+                        <input type="text" class="form-control" name="nav_url[]" value="<?=h($item['url'])?>" placeholder="#paketler">
+                      </div>
+                    </div>
+                  </div>
+                <?php endforeach; ?>
+              </div>
+              <button type="button" class="btn btn-sm btn-outline-secondary mt-3 btn-add-row" data-target="nav">+ Navigasyon Öğesi Ekle</button>
+            </div>
+          </div>
         </div>
-        <button type="button" class="btn btn-sm btn-outline-secondary mt-3 btn-add-row" data-target="nav">+ Navigasyon Öğesi Ekle</button>
       </div>
 
-      <div class="card-section d-flex justify-content-between align-items-center flex-wrap gap-3">
-        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-        <span class="text-muted small">Girdiğiniz içerik anasayfada anında güncellenecektir.</span>
-        <button type="submit" class="btn btn-brand">Değişiklikleri Kaydet</button>
+      <div class="card card-lite">
+        <div class="card-section d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
+          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+          <div>
+            <h6 class="fw-semibold mb-1">Kaydet ve Yayına Al</h6>
+            <p class="text-muted small mb-0">Güncellemeleriniz kaydedildiğinde BİKARE anasayfasında hemen görüntülenir.</p>
+          </div>
+          <button type="submit" class="btn btn-brand px-4">Değişiklikleri Kaydet</button>
+        </div>
       </div>
     </form>
 <?php admin_layout_end(); ?>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 (function(){
+  const panes = document.querySelectorAll('.content-pane');
+  const buttons = document.querySelectorAll('[data-pane-target]');
+  const activate = (id) => {
+    panes.forEach(pane => {
+      pane.classList.toggle('active', pane.dataset.pane === id);
+    });
+    buttons.forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.paneTarget === id);
+    });
+  };
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => activate(btn.dataset.paneTarget));
+  });
+
   const templateFaq = () => {
     const wrapper = document.createElement('div');
     wrapper.className = 'repeater-item';
@@ -294,10 +375,10 @@ while (count($navItems) < 5) {
     btn.addEventListener('click', () => {
       const target = btn.dataset.target;
       if (target === 'faq') {
-        document.getElementById('faqRepeater').appendChild(templateFaq());
+        document.querySelector('[data-repeater="faq"]').appendChild(templateFaq());
       }
       if (target === 'nav') {
-        document.getElementById('navRepeater').appendChild(templateNav());
+        document.querySelector('[data-repeater="nav"]').appendChild(templateNav());
       }
     });
   });

--- a/admin/site_content.php
+++ b/admin/site_content.php
@@ -108,9 +108,7 @@ while (count($navItems) < 5) {
   </style>
 </head>
 <body class="admin-body">
-<?php render_admin_topnav('site', 'Site İçerikleri', 'Landing sayfası metinlerini ve sıkça sorulan soruları yönetin.'); ?>
-<main class="admin-main">
-  <div class="container py-4">
+<?php admin_layout_start('site', 'Site İçerikleri', 'Landing sayfası metinlerini ve sıkça sorulan soruları yönetin.'); ?>
     <?php flash_box(); ?>
     <form method="post" class="card card-lite">
       <div class="card-section border-bottom">
@@ -254,8 +252,7 @@ while (count($navItems) < 5) {
         <button type="submit" class="btn btn-brand">Değişiklikleri Kaydet</button>
       </div>
     </form>
-  </div>
-</main>
+<?php admin_layout_end(); ?>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 (function(){

--- a/admin/site_content.php
+++ b/admin/site_content.php
@@ -1,0 +1,310 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/site.php';
+require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
+
+require_admin();
+require_superadmin();
+install_schema();
+
+$defaults = site_content_defaults();
+$content = site_settings_all();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  csrf_or_die();
+
+  $payload = [
+    'contact_title' => trim($_POST['contact_title'] ?? ''),
+    'contact_text' => trim($_POST['contact_text'] ?? ''),
+    'contact_phone' => trim($_POST['contact_phone'] ?? ''),
+    'contact_email' => trim($_POST['contact_email'] ?? ''),
+    'contact_address' => trim($_POST['contact_address'] ?? ''),
+    'contact_website' => trim($_POST['contact_website'] ?? ''),
+    'contact_website_label' => trim($_POST['contact_website_label'] ?? ''),
+    'contact_primary_label' => trim($_POST['contact_primary_label'] ?? ''),
+    'contact_primary_url' => trim($_POST['contact_primary_url'] ?? ''),
+    'contact_secondary_label' => trim($_POST['contact_secondary_label'] ?? ''),
+    'contact_secondary_url' => trim($_POST['contact_secondary_url'] ?? ''),
+    'contact_cta_badge' => trim($_POST['contact_cta_badge'] ?? ''),
+    'contact_cta_title' => trim($_POST['contact_cta_title'] ?? ''),
+    'contact_cta_text' => trim($_POST['contact_cta_text'] ?? ''),
+    'contact_cta_button_label' => trim($_POST['contact_cta_button_label'] ?? ''),
+    'contact_cta_button_url' => trim($_POST['contact_cta_button_url'] ?? ''),
+    'footer_about' => trim($_POST['footer_about'] ?? ''),
+    'footer_company' => trim($_POST['footer_company'] ?? ''),
+    'footer_disclaimer_left' => trim($_POST['footer_disclaimer_left'] ?? ''),
+    'footer_disclaimer_right' => trim($_POST['footer_disclaimer_right'] ?? ''),
+  ];
+
+  $faqItems = [];
+  $faqQuestions = $_POST['faq_question'] ?? [];
+  $faqAnswers = $_POST['faq_answer'] ?? [];
+  foreach ($faqQuestions as $idx => $question) {
+    $question = trim($question);
+    $answer = trim($faqAnswers[$idx] ?? '');
+    if ($question === '' && $answer === '') {
+      continue;
+    }
+    if ($question === '' || $answer === '') {
+      continue;
+    }
+    $faqItems[] = ['question' => $question, 'answer' => $answer];
+  }
+  if (!$faqItems) {
+    $faqItems = $defaults['faq_items'];
+  }
+  $payload['faq_items'] = $faqItems;
+
+  $navItems = [];
+  $navLabels = $_POST['nav_label'] ?? [];
+  $navUrls = $_POST['nav_url'] ?? [];
+  foreach ($navLabels as $idx => $label) {
+    $label = trim($label);
+    $url = trim($navUrls[$idx] ?? '');
+    if ($label === '' && $url === '') {
+      continue;
+    }
+    if ($label === '' || $url === '') {
+      continue;
+    }
+    $navItems[] = ['label' => $label, 'url' => $url];
+  }
+  if (!$navItems) {
+    $navItems = $defaults['footer_nav_links'];
+  }
+  $payload['footer_nav_links'] = $navItems;
+
+  site_settings_update($payload);
+  flash('ok', 'Site içerikleri güncellendi.');
+  redirect(BASE_URL.'/admin/site_content.php');
+}
+
+$content = site_settings_all();
+$faqItems = $content['faq_items'];
+$navItems = $content['footer_nav_links'];
+
+while (count($faqItems) < 4) {
+  $faqItems[] = ['question' => '', 'answer' => ''];
+}
+while (count($navItems) < 5) {
+  $navItems[] = ['label' => '', 'url' => ''];
+}
+
+?><!doctype html>
+<html lang="tr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Site İçerikleri • <?=h(APP_NAME)?></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <?=admin_base_styles()?>
+  <style>
+    .repeater-item{border:1px dashed rgba(14,165,181,.35);border-radius:16px;padding:1rem 1.25rem;background:#fff;}
+    .repeater-item + .repeater-item{margin-top:1rem;}
+    .btn-add-row{border-radius:12px;}
+  </style>
+</head>
+<body class="admin-body">
+<?php render_admin_topnav('site', 'Site İçerikleri', 'Landing sayfası metinlerini ve sıkça sorulan soruları yönetin.'); ?>
+<main class="admin-main">
+  <div class="container py-4">
+    <?php flash_box(); ?>
+    <form method="post" class="card card-lite">
+      <div class="card-section border-bottom">
+        <h5 class="fw-bold mb-3">İletişim Alanı</h5>
+        <div class="row g-3">
+          <div class="col-md-6">
+            <label class="form-label">Başlık</label>
+            <input type="text" name="contact_title" class="form-control" value="<?=h($content['contact_title'] ?? '')?>">
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Açıklama</label>
+            <input type="text" name="contact_text" class="form-control" value="<?=h($content['contact_text'] ?? '')?>">
+          </div>
+          <div class="col-md-4">
+            <label class="form-label">Telefon</label>
+            <input type="text" name="contact_phone" class="form-control" value="<?=h($content['contact_phone'] ?? '')?>">
+          </div>
+          <div class="col-md-4">
+            <label class="form-label">E-posta</label>
+            <input type="email" name="contact_email" class="form-control" value="<?=h($content['contact_email'] ?? '')?>">
+          </div>
+          <div class="col-md-4">
+            <label class="form-label">Adres</label>
+            <input type="text" name="contact_address" class="form-control" value="<?=h($content['contact_address'] ?? '')?>">
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Web Adresi</label>
+            <input type="text" name="contact_website" class="form-control" value="<?=h($content['contact_website'] ?? '')?>" placeholder="https://...">
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Web Etiketi</label>
+            <input type="text" name="contact_website_label" class="form-control" value="<?=h($content['contact_website_label'] ?? '')?>" placeholder="zerosoft.com.tr">
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Birincil Buton Metni</label>
+            <input type="text" name="contact_primary_label" class="form-control" value="<?=h($content['contact_primary_label'] ?? '')?>">
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Birincil Buton URL</label>
+            <input type="text" name="contact_primary_url" class="form-control" value="<?=h($content['contact_primary_url'] ?? '')?>">
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">İkincil Buton Metni</label>
+            <input type="text" name="contact_secondary_label" class="form-control" value="<?=h($content['contact_secondary_label'] ?? '')?>">
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">İkincil Buton URL</label>
+            <input type="text" name="contact_secondary_url" class="form-control" value="<?=h($content['contact_secondary_url'] ?? '')?>">
+          </div>
+        </div>
+        <hr class="my-4">
+        <div class="row g-3">
+          <div class="col-md-4">
+            <label class="form-label">CTA Rozeti</label>
+            <input type="text" name="contact_cta_badge" class="form-control" value="<?=h($content['contact_cta_badge'] ?? '')?>">
+          </div>
+          <div class="col-md-4">
+            <label class="form-label">CTA Başlığı</label>
+            <input type="text" name="contact_cta_title" class="form-control" value="<?=h($content['contact_cta_title'] ?? '')?>">
+          </div>
+          <div class="col-md-4">
+            <label class="form-label">CTA Buton Metni</label>
+            <input type="text" name="contact_cta_button_label" class="form-control" value="<?=h($content['contact_cta_button_label'] ?? '')?>">
+          </div>
+          <div class="col-12">
+            <label class="form-label">CTA Açıklaması</label>
+            <textarea name="contact_cta_text" class="form-control" rows="3"><?=h($content['contact_cta_text'] ?? '')?></textarea>
+          </div>
+          <div class="col-12">
+            <label class="form-label">CTA Buton URL</label>
+            <input type="text" name="contact_cta_button_url" class="form-control" value="<?=h($content['contact_cta_button_url'] ?? '')?>">
+          </div>
+        </div>
+      </div>
+
+      <div class="card-section border-bottom">
+        <h5 class="fw-bold mb-3">Sıkça Sorulan Sorular</h5>
+        <div id="faqRepeater">
+          <?php foreach ($faqItems as $index => $faq): ?>
+            <div class="repeater-item" data-index="<?=$index?>">
+              <div class="row g-3 align-items-start">
+                <div class="col-md-6">
+                  <label class="form-label">Soru</label>
+                  <input type="text" class="form-control" name="faq_question[]" value="<?=h($faq['question'])?>" placeholder="Soru metni">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">Cevap</label>
+                  <textarea class="form-control" name="faq_answer[]" rows="2" placeholder="Cevap metni"><?=h($faq['answer'])?></textarea>
+                </div>
+              </div>
+            </div>
+          <?php endforeach; ?>
+        </div>
+        <button type="button" class="btn btn-sm btn-outline-secondary mt-3 btn-add-row" data-target="faq">+ Soru Ekle</button>
+      </div>
+
+      <div class="card-section border-bottom">
+        <h5 class="fw-bold mb-3">Footer İçeriği</h5>
+        <div class="row g-3">
+          <div class="col-md-6">
+            <label class="form-label">Hakkımızda Metni</label>
+            <textarea name="footer_about" class="form-control" rows="4"><?=h($content['footer_about'] ?? '')?></textarea>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Firma Adı</label>
+            <input type="text" name="footer_company" class="form-control" value="<?=h($content['footer_company'] ?? '')?>">
+            <div class="mt-3">
+              <label class="form-label">Alt Satır (Sol)</label>
+              <input type="text" name="footer_disclaimer_left" class="form-control" value="<?=h($content['footer_disclaimer_left'] ?? '')?>">
+            </div>
+            <div class="mt-3">
+              <label class="form-label">Alt Satır (Sağ)</label>
+              <input type="text" name="footer_disclaimer_right" class="form-control" value="<?=h($content['footer_disclaimer_right'] ?? '')?>">
+            </div>
+          </div>
+        </div>
+        <hr class="my-4">
+        <h6 class="fw-semibold">Footer Navigasyonu</h6>
+        <div id="navRepeater">
+          <?php foreach ($navItems as $item): ?>
+            <div class="repeater-item">
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label class="form-label">Etiket</label>
+                  <input type="text" class="form-control" name="nav_label[]" value="<?=h($item['label'])?>" placeholder="Örn. Paketler">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">Bağlantı</label>
+                  <input type="text" class="form-control" name="nav_url[]" value="<?=h($item['url'])?>" placeholder="#paketler">
+                </div>
+              </div>
+            </div>
+          <?php endforeach; ?>
+        </div>
+        <button type="button" class="btn btn-sm btn-outline-secondary mt-3 btn-add-row" data-target="nav">+ Navigasyon Öğesi Ekle</button>
+      </div>
+
+      <div class="card-section d-flex justify-content-between align-items-center flex-wrap gap-3">
+        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+        <span class="text-muted small">Girdiğiniz içerik anasayfada anında güncellenecektir.</span>
+        <button type="submit" class="btn btn-brand">Değişiklikleri Kaydet</button>
+      </div>
+    </form>
+  </div>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+(function(){
+  const templateFaq = () => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'repeater-item';
+    wrapper.innerHTML = `
+      <div class="row g-3 align-items-start">
+        <div class="col-md-6">
+          <label class="form-label">Soru</label>
+          <input type="text" class="form-control" name="faq_question[]" placeholder="Soru metni">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">Cevap</label>
+          <textarea class="form-control" name="faq_answer[]" rows="2" placeholder="Cevap metni"></textarea>
+        </div>
+      </div>`;
+    return wrapper;
+  };
+
+  const templateNav = () => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'repeater-item';
+    wrapper.innerHTML = `
+      <div class="row g-3">
+        <div class="col-md-6">
+          <label class="form-label">Etiket</label>
+          <input type="text" class="form-control" name="nav_label[]" placeholder="Örn. Paketler">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">Bağlantı</label>
+          <input type="text" class="form-control" name="nav_url[]" placeholder="#paketler">
+        </div>
+      </div>`;
+    return wrapper;
+  };
+
+  document.querySelectorAll('.btn-add-row').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = btn.dataset.target;
+      if (target === 'faq') {
+        document.getElementById('faqRepeater').appendChild(templateFaq());
+      }
+      if (target === 'nav') {
+        document.getElementById('navRepeater').appendChild(templateNav());
+      }
+    });
+  });
+})();
+</script>
+</body>
+</html>

--- a/admin/team.php
+++ b/admin/team.php
@@ -126,10 +126,8 @@ $admins = pdo()->query("SELECT id, name, email, role, created_at, last_login_at 
   </style>
 </head>
 <body class="admin-body">
-<?php render_admin_topnav('team', 'Yönetici Ekibi', 'Süperadmin ve admin rollerini yönetin, ekip arkadaşlarınızı davet edin.'); ?>
+<?php admin_layout_start('team', 'Yönetici Ekibi', 'Süperadmin ve admin rollerini yönetin, ekip arkadaşlarınızı davet edin.'); ?>
 
-<main class="admin-main">
-  <div class="container">
     <?php flash_box(); ?>
 
     <div class="row g-4">
@@ -234,7 +232,6 @@ $admins = pdo()->query("SELECT id, name, email, role, created_at, last_login_at 
         </div>
       </div>
     </div>
-  </div>
-</main>
+<?php admin_layout_end(); ?>
 </body>
 </html>

--- a/admin/team.php
+++ b/admin/team.php
@@ -1,0 +1,240 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
+
+require_admin();
+require_superadmin();
+install_schema();
+
+function superadmin_count(): int {
+  return (int)pdo()->query("SELECT COUNT(*) FROM users WHERE role='superadmin'")->fetchColumn();
+}
+
+$me = admin_user();
+$action = $_POST['do'] ?? '';
+if ($action) {
+  csrf_or_die();
+}
+
+if ($action === 'create') {
+  $name  = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $role  = $_POST['role'] ?? 'admin';
+  $pass  = (string)($_POST['password'] ?? '');
+  $pass2 = (string)($_POST['password_confirm'] ?? '');
+
+  if (mb_strlen($name) < 3) {
+    flash('err', 'Ad en az 3 karakter olmalıdır.');
+  } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err', 'Geçerli bir e-posta girin.');
+  } elseif (!in_array($role, ['admin','superadmin'], true)) {
+    flash('err', 'Geçersiz rol seçimi.');
+  } elseif (mb_strlen($pass) < 8) {
+    flash('err', 'Şifre en az 8 karakter olmalıdır.');
+  } elseif ($pass !== $pass2) {
+    flash('err', 'Şifreler eşleşmiyor.');
+  } else {
+    $st = pdo()->prepare("SELECT id FROM users WHERE email=? LIMIT 1");
+    $st->execute([$email]);
+    if ($st->fetch()) {
+      flash('err', 'Bu e-posta ile kayıtlı bir yönetici zaten var.');
+    } else {
+      pdo()->prepare("INSERT INTO users (email,password_hash,name,role,created_at,updated_at) VALUES (?,?,?,?,?,?)")
+          ->execute([$email, password_hash($pass, PASSWORD_DEFAULT), $name, $role, now(), now()]);
+      flash('ok', 'Yeni yönetici hesabı oluşturuldu.');
+    }
+  }
+  redirect($_SERVER['REQUEST_URI']);
+}
+
+if ($action === 'update_role') {
+  $userId = (int)($_POST['user_id'] ?? 0);
+  $role   = $_POST['role'] ?? 'admin';
+  if (!in_array($role, ['admin','superadmin'], true)) {
+    flash('err', 'Geçersiz rol seçimi.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  $st = pdo()->prepare("SELECT id, role FROM users WHERE id=? LIMIT 1");
+  $st->execute([$userId]);
+  $target = $st->fetch();
+  if (!$target) {
+    flash('err', 'Kullanıcı bulunamadı.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  if ($target['role'] === 'superadmin' && $role !== 'superadmin' && superadmin_count() <= 1) {
+    flash('err', 'Sistemde en az bir süperadmin kalmalıdır.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  pdo()->prepare("UPDATE users SET role=?, updated_at=? WHERE id=?")
+      ->execute([$role, now(), $userId]);
+  if ($userId === ($me['id'] ?? 0)) {
+    $_SESSION['admin']['role'] = $role;
+  }
+  flash('ok', 'Rol güncellendi.');
+  redirect($_SERVER['REQUEST_URI']);
+}
+
+if ($action === 'reset_password') {
+  $userId = (int)($_POST['user_id'] ?? 0);
+  $pass   = (string)($_POST['password'] ?? '');
+  $pass2  = (string)($_POST['password_confirm'] ?? '');
+  if (mb_strlen($pass) < 8) {
+    flash('err', 'Yeni şifre en az 8 karakter olmalıdır.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  if ($pass !== $pass2) {
+    flash('err', 'Yeni şifreler eşleşmiyor.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  $st = pdo()->prepare("SELECT id FROM users WHERE id=? LIMIT 1");
+  $st->execute([$userId]);
+  if (!$st->fetch()) {
+    flash('err', 'Kullanıcı bulunamadı.');
+    redirect($_SERVER['REQUEST_URI']);
+  }
+  pdo()->prepare("UPDATE users SET password_hash=?, updated_at=? WHERE id=?")
+      ->execute([password_hash($pass, PASSWORD_DEFAULT), now(), $userId]);
+  if ($userId === ($me['id'] ?? 0)) {
+    flash('ok', 'Şifreniz güncellendi.');
+  } else {
+    flash('ok', 'Şifre başarıyla sıfırlandı.');
+  }
+  redirect($_SERVER['REQUEST_URI']);
+}
+
+$admins = pdo()->query("SELECT id, name, email, role, created_at, last_login_at FROM users ORDER BY created_at DESC")->fetchAll();
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title><?=h(APP_NAME)?> — Yönetici Ekibi</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <?=admin_base_styles()?>
+  <style>
+    .team-card{ border-radius:20px; border:1px solid rgba(148,163,184,.16); box-shadow:0 22px 45px -30px rgba(15,23,42,.45); }
+    .role-chip{ display:inline-flex; align-items:center; gap:.35rem; padding:.35rem .8rem; border-radius:999px; font-weight:600; }
+    .role-chip.admin{ background:rgba(148,163,184,.2); color:#475569; }
+    .role-chip.superadmin{ background:rgba(14,165,181,.16); color:#0b8b98; }
+    details summary{ cursor:pointer; font-weight:600; color:var(--brand); }
+    details summary::-webkit-details-marker{ display:none; }
+    details[open] summary{ color:var(--brand-dark); }
+  </style>
+</head>
+<body class="admin-body">
+<?php render_admin_topnav('team', 'Yönetici Ekibi', 'Süperadmin ve admin rollerini yönetin, ekip arkadaşlarınızı davet edin.'); ?>
+
+<main class="admin-main">
+  <div class="container">
+    <?php flash_box(); ?>
+
+    <div class="row g-4">
+      <div class="col-lg-4">
+        <div class="card-lite p-4 team-card">
+          <h5 class="mb-3">Yeni Yönetici Davet Et</h5>
+          <form method="post" class="vstack gap-3">
+            <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="do" value="create">
+            <div>
+              <label class="form-label">Ad Soyad</label>
+              <input class="form-control" name="name" required placeholder="Örn. Mehmet Kara">
+            </div>
+            <div>
+              <label class="form-label">E-posta</label>
+              <input class="form-control" type="email" name="email" required placeholder="ornek@firma.com">
+            </div>
+            <div>
+              <label class="form-label">Rol</label>
+              <select class="form-select" name="role">
+                <option value="admin">Admin</option>
+                <option value="superadmin">Süperadmin</option>
+              </select>
+            </div>
+            <div>
+              <label class="form-label">Geçici Şifre</label>
+              <input class="form-control" type="password" name="password" required placeholder="En az 8 karakter">
+            </div>
+            <div>
+              <label class="form-label">Şifre (Tekrar)</label>
+              <input class="form-control" type="password" name="password_confirm" required>
+            </div>
+            <button class="btn btn-brand mt-2">Yöneticiyi Oluştur</button>
+            <p class="text-muted small mb-0">Hesap oluşturulduktan sonra parolayı paylaşmayı unutmayın. Girişte değiştirilebilir.</p>
+          </form>
+        </div>
+      </div>
+
+      <div class="col-lg-8">
+        <div class="card-lite p-4 team-card">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h5 class="mb-0">Mevcut Yöneticiler</h5>
+            <span class="text-muted small">Toplam <?=count($admins)?> yönetici</span>
+          </div>
+          <div class="table-responsive">
+            <table class="table align-middle">
+              <thead>
+                <tr>
+                  <th>Adı</th>
+                  <th>E-posta</th>
+                  <th>Rol</th>
+                  <th>Son Giriş</th>
+                  <th class="text-end">İşlemler</th>
+                </tr>
+              </thead>
+              <tbody>
+                <?php foreach ($admins as $admin): ?>
+                  <tr>
+                    <td>
+                      <div class="fw-semibold"><?=h($admin['name'] ?: '—')?><?= $admin['id'] === ($me['id'] ?? 0) ? ' <span class="badge bg-info">Siz</span>' : '' ?></div>
+                      <div class="text-muted small">Oluşturulma: <?=h($admin['created_at'])?></div>
+                    </td>
+                    <td><?=h($admin['email'])?></td>
+                    <td>
+                      <span class="role-chip <?=h($admin['role'])?>"><?= $admin['role'] === 'superadmin' ? 'Süperadmin' : 'Admin' ?></span>
+                    </td>
+                    <td>
+                      <?php if ($admin['last_login_at']): ?>
+                        <span class="text-muted small"><?=h($admin['last_login_at'])?></span>
+                      <?php else: ?>
+                        <span class="text-muted small">Henüz giriş yapmadı</span>
+                      <?php endif; ?>
+                    </td>
+                    <td class="text-end">
+                      <form method="post" class="d-inline-flex gap-2 align-items-center flex-wrap justify-content-end">
+                        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                        <input type="hidden" name="do" value="update_role">
+                        <input type="hidden" name="user_id" value="<?=$admin['id']?>">
+                        <select class="form-select form-select-sm" name="role">
+                          <option value="admin" <?=$admin['role']==='admin'?'selected':''?>>Admin</option>
+                          <option value="superadmin" <?=$admin['role']==='superadmin'?'selected':''?>>Süperadmin</option>
+                        </select>
+                        <button class="btn btn-sm btn-brand-outline" type="submit">Rolü Kaydet</button>
+                      </form>
+                      <details class="mt-2">
+                        <summary>Parola Sıfırla</summary>
+                        <form method="post" class="vstack gap-2 mt-2">
+                          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                          <input type="hidden" name="do" value="reset_password">
+                          <input type="hidden" name="user_id" value="<?=$admin['id']?>">
+                          <input class="form-control form-control-sm" type="password" name="password" placeholder="Yeni şifre" required>
+                          <input class="form-control form-control-sm" type="password" name="password_confirm" placeholder="Şifre tekrar" required>
+                          <button class="btn btn-sm btn-brand" type="submit">Parolayı Güncelle</button>
+                        </form>
+                      </details>
+                    </td>
+                  </tr>
+                <?php endforeach; ?>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/admin/users.php
+++ b/admin/users.php
@@ -4,6 +4,7 @@ require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
 
 require_admin();
 install_schema();
@@ -141,35 +142,28 @@ if ($detail_id) {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?=h(APP_NAME)?> — Kullanıcılar & Ödemeler</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
 <style>
-  :root{ --zs:#0ea5b5; --ink:#0f172a; --muted:#64748b; --soft:#f6fbfd; }
-  body{ background:linear-gradient(180deg,#eef8fb,#fff) no-repeat; color:var(--ink) }
-  .card-lite{ border:1px solid #e8eff5; border-radius:18px; background:#fff; box-shadow:0 6px 20px rgba(2,6,23,.05) }
-  .btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600 }
-  .btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:12px; font-weight:600 }
-  .muted{ color:var(--muted) }
-  .badge-soft{ background:#eef5ff; color:#334155 }
+  .card-lite{ border-radius:20px; border:1px solid rgba(148,163,184,.16); box-shadow:0 18px 45px -28px rgba(15,23,42,.4); }
+  .btn-zs{ background:var(--brand); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600; }
+  .btn-zs:hover{ background:var(--brand-dark); color:#fff; }
+  .btn-zs-outline{ background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
+  .btn-zs-outline:hover{ background:rgba(14,165,181,.12); color:var(--brand-dark); }
+  .muted{ color:var(--muted); }
+  .badge-soft{ background:rgba(14,165,181,.14); color:var(--brand-dark); border-radius:999px; padding:.3rem .7rem; font-weight:600; }
   @media print{
-    .no-print{ display:none !important }
-    body{ background:#fff }
-    .card-lite{ border:none; box-shadow:none }
-    table{ font-size:12px }
+    .admin-header, .admin-hero, .no-print{ display:none !important; }
+    body.admin-body{ background:#fff; }
+    .card-lite{ border:none; box-shadow:none; }
+    table{ font-size:12px; }
   }
 </style>
 </head>
-<body>
-<nav class="navbar bg-white border-bottom no-print">
-  <div class="container">
-    <a class="navbar-brand fw-semibold" href="<?=h(BASE_URL)?>"><?=h(APP_NAME)?></a>
-    <div class="small">
-      <a href="<?=h(BASE_URL)?>/admin/dashboard.php" class="text-decoration-none">Panel</a>
-      <span class="mx-2">•</span>
-      <a href="<?=h(BASE_URL)?>/admin/login.php?logout=1" class="text-decoration-none">Çıkış</a>
-    </div>
-  </div>
-</nav>
+<body class="admin-body">
+<?php render_admin_topnav('users', 'Çiftler & Ödemeler', 'Etkinlik hesaplarını, lisans sürelerini ve ödeme durumlarını inceleyin.'); ?>
 
-<div class="container py-4">
+<main class="admin-main">
+  <div class="container">
   <?php flash_box(); ?>
 
   <!-- Filtreler -->
@@ -360,6 +354,7 @@ if ($detail_id) {
       </div>
     <?php endif; ?>
   </div>
-</div>
+  </div>
+</main>
 </body>
 </html>

--- a/admin/users.php
+++ b/admin/users.php
@@ -160,10 +160,8 @@ if ($detail_id) {
 </style>
 </head>
 <body class="admin-body">
-<?php render_admin_topnav('users', 'Etkinlik Hesapları', 'Etkinlik panellerini, lisans sürelerini ve ödeme durumlarını inceleyin.'); ?>
+<?php admin_layout_start('users', 'Etkinlik Hesapları', 'Etkinlik panellerini, lisans sürelerini ve ödeme durumlarını inceleyin.'); ?>
 
-<main class="admin-main">
-  <div class="container">
   <?php flash_box(); ?>
 
   <!-- Filtreler -->
@@ -354,7 +352,6 @@ if ($detail_id) {
       </div>
     <?php endif; ?>
   </div>
-  </div>
-</main>
+<?php admin_layout_end(); ?>
 </body>
 </html>

--- a/admin/users.php
+++ b/admin/users.php
@@ -160,7 +160,7 @@ if ($detail_id) {
 </style>
 </head>
 <body class="admin-body">
-<?php render_admin_topnav('users', 'Çiftler & Ödemeler', 'Etkinlik hesaplarını, lisans sürelerini ve ödeme durumlarını inceleyin.'); ?>
+<?php render_admin_topnav('users', 'Etkinlik Hesapları', 'Etkinlik panellerini, lisans sürelerini ve ödeme durumlarını inceleyin.'); ?>
 
 <main class="admin-main">
   <div class="container">
@@ -169,7 +169,7 @@ if ($detail_id) {
   <!-- Filtreler -->
   <div class="card-lite p-3 mb-3 no-print">
     <div class="d-flex justify-content-between align-items-center">
-      <h5 class="m-0">Kullanıcılar & Ödemeler</h5>
+      <h5 class="m-0">Etkinlik Hesapları & Ödemeler</h5>
       <div class="d-flex gap-2">
         <button class="btn btn-sm btn-outline-secondary" onclick="window.print()">Yazdır / PDF</button>
       </div>

--- a/admin/venue_events.php
+++ b/admin/venue_events.php
@@ -4,6 +4,7 @@ require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
 
 require_admin();
 install_schema();
@@ -200,34 +201,23 @@ if (isset($_GET['export']) && $_GET['export']==='pdf') {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?=h(APP_NAME)?> — <?=h($VNAME)?> / Düğünler</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
 <style>
-  :root{ --zs:#0ea5b5; --zs-soft:#e0f7fb; --ink:#0f172a; --muted:#6b7280; }
-  body{ background:linear-gradient(180deg,var(--zs-soft),#fff) no-repeat }
-  .card-lite{ border:1px solid #eef2f7; border-radius:18px; background:#fff; box-shadow:0 6px 20px rgba(17,24,39,.05) }
-  .btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600 }
-  .btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:12px; font-weight:600 }
-  .muted{ color:var(--muted) }
-  .group-title{ font-weight:800; color:#0f172a; margin:8px 0 6px }
-  .badge-soft{ background:#eef5ff; color:#334155; border-radius:999px; padding:.25rem .55rem; font-weight:600 }
+  .btn-zs{ background:var(--brand); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600; }
+  .btn-zs:hover{ background:var(--brand-dark); color:#fff; }
+  .btn-zs-outline{ background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
+  .btn-zs-outline:hover{ background:rgba(14,165,181,.12); color:var(--brand-dark); }
+  .muted{ color:var(--muted); }
+  .group-title{ font-weight:800; color:var(--ink); margin:8px 0 6px; }
+  .badge-soft{ background:rgba(14,165,181,.14); color:var(--brand-dark); border-radius:999px; padding:.25rem .55rem; font-weight:600; }
   .table td, .table th { vertical-align: middle; }
 </style>
 </head>
-<body>
-<nav class="navbar bg-white border-bottom">
-  <div class="container">
-    <a class="navbar-brand fw-semibold" href="<?=h(BASE_URL)?>"><?=h(APP_NAME)?></a>
-    <div class="small d-flex align-items-center gap-3">
-      <span class="badge-soft">Salon: <?=h($VNAME)?></span>
-      <a class="text-decoration-none" href="venues.php">Salon Değiştir</a>
-      <span>•</span>
-      <a class="text-decoration-none" href="dashboard.php">Panel</a>
-      <span>•</span>
-      <a class="text-decoration-none" href="login.php?logout=1">Çıkış</a>
-    </div>
-  </div>
-</nav>
+<body class="admin-body">
+<?php render_admin_topnav('venues', 'Salon Düğünleri', 'Salon: '.$VNAME.' için etkinlik listesi'); ?>
 
-<div class="container py-4">
+<main class="admin-main">
+  <div class="container">
   <?php flash_box(); ?>
 
   <!-- Filtre + PDF -->
@@ -315,6 +305,7 @@ if (isset($_GET['export']) && $_GET['export']==='pdf') {
       </div>
     <?php endforeach; ?>
   <?php endif; ?>
-</div>
+  </div>
+</main>
 </body>
 </html>

--- a/admin/venue_events.php
+++ b/admin/venue_events.php
@@ -9,13 +9,10 @@ require_once __DIR__.'/partials/ui.php';
 require_admin();
 install_schema();
 
-if (empty($_SESSION['venue_id'])) {
-  flash('err', 'Önce bir salon seçin.');
-  redirect('venues.php');
-}
-$VID   = (int)$_SESSION['venue_id'];
-$VNAME = $_SESSION['venue_name'] ?? 'Salon';
-$VSLUG = $_SESSION['venue_slug'] ?? '';
+$venue = require_current_venue_or_redirect();
+$VID   = (int)$venue['id'];
+$VNAME = $venue['name'];
+$VSLUG = $venue['slug'];
 
 // Yardımcı
 if (!function_exists('fmt_bytes_ve')) {

--- a/admin/venue_events.php
+++ b/admin/venue_events.php
@@ -214,10 +214,8 @@ if (isset($_GET['export']) && $_GET['export']==='pdf') {
 </style>
 </head>
 <body class="admin-body">
-<?php render_admin_topnav('venues', 'Salon Düğünleri', 'Salon: '.$VNAME.' için etkinlik listesi'); ?>
+<?php admin_layout_start('venues', 'Salon Etkinlikleri', 'Salon: '.$VNAME.' için etkinlik listesi'); ?>
 
-<main class="admin-main">
-  <div class="container">
   <?php flash_box(); ?>
 
   <!-- Filtre + PDF -->
@@ -305,7 +303,6 @@ if (isset($_GET['export']) && $_GET['export']==='pdf') {
       </div>
     <?php endforeach; ?>
   <?php endif; ?>
-  </div>
-</main>
+<?php admin_layout_end(); ?>
 </body>
 </html>

--- a/admin/venues.php
+++ b/admin/venues.php
@@ -4,6 +4,7 @@ require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/auth.php';
+require_once __DIR__.'/partials/ui.php';
 
 require_admin();
 install_schema();
@@ -146,14 +147,14 @@ $venues = $st->fetchAll();
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?=h(APP_NAME)?> — Düğün Salonları</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<?=admin_base_styles()?>
 <style>
-  :root{ --zs:#0ea5b5; --zs-soft:#e0f7fb; --muted:#6b7280; }
-  body{ background:linear-gradient(180deg,var(--zs-soft),#fff) no-repeat }
-  .card-lite{ border:1px solid #eef2f7; border-radius:18px; background:#fff; box-shadow:0 6px 20px rgba(17,24,39,.05) }
-  .btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600 }
-  .btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:12px; font-weight:600 }
-  .grid-compact .form-control, .grid-compact .form-select{ height:42px }
-  .muted{ color:var(--muted) }
+  .grid-compact .form-control, .grid-compact .form-select{ height:46px; }
+  .muted{ color:var(--muted); }
+  .btn-zs{ background:var(--brand); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600; }
+  .btn-zs:hover{ background:var(--brand-dark); color:#fff; }
+  .btn-zs-outline{ background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
+  .btn-zs-outline:hover{ background:rgba(14,165,181,.12); color:var(--brand-dark); }
 </style>
 <script>
 function askToggle(){
@@ -162,28 +163,11 @@ function askToggle(){
 }
 </script>
 </head>
-<body>
-<nav class="navbar bg-white border-bottom zs-topbar">
+<body class="admin-body">
+<?php render_admin_topnav('venues', 'Düğün Salonları', 'Salon portföyünüzü yönetin ve etkinliklerinizi organize edin.'); ?>
+
+<main class="admin-main">
   <div class="container">
-    <!-- Sol: Marka -->
-    <a class="navbar-brand fw-semibold d-flex align-items-center gap-2" href="<?=h(BASE_URL)?>">
-      <?=h(APP_NAME)?>
-    </a>
-
-    <!-- Sağ: Aksiyonlar (buton görünümleri senin mevcut stillerle) -->
-    <div class="d-flex align-items-center gap-2">
-      <a href="<?=h(BASE_URL)?>/admin/dashboard.php" class="btn btn-sm btn-zs-outline">Panel</a>
-
-      <!-- Yeni: Kullanıcılar (liste sayfasına gider) -->
-      <a href="<?=h(BASE_URL)?>/admin/users.php" class="btn btn-sm btn-zs">Kullanıcılar</a>
-
-      <span class="text-muted px-1">•</span>
-
-      <a href="<?=h(BASE_URL)?>/admin/login.php?logout=1" class="btn btn-sm btn-outline-secondary">Çıkış</a>
-    </div>
-  </div>
-</nav>
-<div class="container py-4">
   <?php flash_box(); ?>
 
   <!-- Yeni Salon -->
@@ -331,6 +315,7 @@ function askToggle(){
       </div>
     <?php endif; ?>
   </div>
-</div>
+  </div>
+</main>
 </body>
 </html>

--- a/admin/venues.php
+++ b/admin/venues.php
@@ -164,10 +164,8 @@ function askToggle(){
 </script>
 </head>
 <body class="admin-body">
-<?php render_admin_topnav('venues', 'Düğün Salonları', 'Salon portföyünüzü yönetin ve etkinliklerinizi organize edin.'); ?>
+<?php admin_layout_start('venues', 'Düğün Salonları', 'Salon portföyünüzü yönetin ve etkinliklerinizi organize edin.'); ?>
 
-<main class="admin-main">
-  <div class="container">
   <?php flash_box(); ?>
 
   <!-- Yeni Salon -->
@@ -315,7 +313,6 @@ function askToggle(){
       </div>
     <?php endif; ?>
   </div>
-  </div>
-</main>
+<?php admin_layout_end(); ?>
 </body>
 </html>

--- a/admin/venues.php
+++ b/admin/venues.php
@@ -139,6 +139,19 @@ $st = pdo()->prepare("SELECT * FROM venues $W $ORDER");
 $st->execute($args);
 $venues = $st->fetchAll();
 
+$venueTotals = [
+  'all'    => count($venues),
+  'active' => 0,
+  'passive'=> 0,
+];
+foreach ($venues as $venueRow) {
+  if (!empty($venueRow['is_active'])) {
+    $venueTotals['active']++;
+  } else {
+    $venueTotals['passive']++;
+  }
+}
+
 ?>
 <!doctype html>
 <html lang="tr">
@@ -149,12 +162,33 @@ $venues = $st->fetchAll();
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <?=admin_base_styles()?>
 <style>
-  .grid-compact .form-control, .grid-compact .form-select{ height:46px; }
-  .muted{ color:var(--muted); }
-  .btn-zs{ background:var(--brand); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600; }
-  .btn-zs:hover{ background:var(--brand-dark); color:#fff; }
-  .btn-zs-outline{ background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
-  .btn-zs-outline:hover{ background:rgba(14,165,181,.12); color:var(--brand-dark); }
+  .grid-compact .form-control, .grid-compact .form-select { height:46px; }
+  .muted { color:var(--muted); }
+  .btn-zs { background:var(--brand); border:none; color:#fff; border-radius:12px; padding:.55rem 1rem; font-weight:600; }
+  .btn-zs:hover { background:var(--brand-dark); color:#fff; }
+  .btn-zs-outline { background:#fff; border:1px solid rgba(14,165,181,.55); color:var(--brand); border-radius:12px; font-weight:600; }
+  .btn-zs-outline:hover { background:rgba(14,165,181,.12); color:var(--brand-dark); }
+
+  .stats-row .stat-card {
+    border-radius:18px;
+    background:#fff;
+    border:1px solid rgba(14,165,181,.12);
+    padding:20px 22px;
+    box-shadow:0 28px 50px -36px rgba(14,165,181,.55);
+  }
+  .stats-row .stat-label { font-size:.8rem; color:var(--admin-muted); text-transform:uppercase; letter-spacing:.08em; }
+  .stats-row .stat-value { font-size:1.85rem; font-weight:700; color:var(--admin-ink); }
+  .stats-row .stat-chip { display:inline-flex; align-items:center; gap:6px; padding:.28rem .9rem; border-radius:999px; background:rgba(14,165,181,.12); color:var(--admin-brand-dark); font-size:.75rem; font-weight:600; }
+
+  .filter-card { background:#fff; border-radius:20px; border:1px solid rgba(15,23,42,.06); box-shadow:0 24px 45px -32px rgba(15,23,42,.38); }
+  .filter-card h5 { margin-bottom:14px; }
+  .filter-actions { display:flex; gap:10px; flex-wrap:wrap; }
+
+  .venue-table thead th { white-space:nowrap; }
+  .venue-table .badge-status { border-radius:999px; padding:.35rem .85rem; font-size:.75rem; font-weight:600; }
+  .venue-table .badge-active { background:rgba(34,197,94,.18); color:#15803d; }
+  .venue-table .badge-passive { background:rgba(248,113,113,.18); color:#b91c1c; }
+  .venue-table .action-group { display:flex; flex-wrap:wrap; gap:10px; }
 </style>
 <script>
 function askToggle(){
@@ -168,63 +202,93 @@ function askToggle(){
 
   <?php flash_box(); ?>
 
-  <!-- Yeni Salon -->
-  <div class="card-lite p-3 mb-4">
-    <h5 class="mb-3">Yeni Düğün Salonu Ekle</h5>
-    <form method="post" class="row g-2 grid-compact">
-      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-      <input type="hidden" name="do" value="create">
-      <div class="col-md-6">
-        <label class="form-label">Ad</label>
-        <input class="form-control" name="name" placeholder="Örn: Zero Soft Garden" required>
+  <div class="row g-3 stats-row mb-4">
+    <div class="col-md-4">
+      <div class="stat-card">
+        <span class="stat-label">Toplam Salon</span>
+        <span class="stat-value"><?=$venueTotals['all']?></span>
+        <span class="stat-chip"><i class="bi bi-buildings me-1"></i>Portföy</span>
       </div>
-      <div class="col-md-4">
-        <label class="form-label">Slug (opsiyonel)</label>
-        <input class="form-control" name="slug" placeholder="zero-soft-garden">
+    </div>
+    <div class="col-md-4">
+      <div class="stat-card">
+        <span class="stat-label">Aktif</span>
+        <span class="stat-value text-success"><?=$venueTotals['active']?></span>
+        <span class="stat-chip"><i class="bi bi-lightning-charge me-1"></i>Panelde</span>
       </div>
-      <div class="col-md-2 d-grid align-items-end">
-        <button class="btn btn-zs" style="margin-top:30px">Ekle</button>
+    </div>
+    <div class="col-md-4">
+      <div class="stat-card">
+        <span class="stat-label">Pasif</span>
+        <span class="stat-value text-danger"><?=$venueTotals['passive']?></span>
+        <span class="stat-chip"><i class="bi bi-archive me-1"></i>Arşiv</span>
       </div>
-    </form>
+    </div>
   </div>
 
-  <!-- ARAMA / FİLTRE -->
-  <div class="card-lite p-3 mb-3">
-    <h5 class="mb-3">Salonlarda Ara / Filtrele</h5>
-    <form method="get" class="row g-2 grid-compact">
-      <div class="col-md-6">
-        <label class="form-label">Ad veya Slug</label>
-        <input class="form-control" name="q" value="<?=h($q)?>" placeholder="Örn: Garden / garden-salon">
+  <div class="row g-4 mb-4">
+    <div class="col-lg-5">
+      <div class="card-lite p-4 h-100">
+        <h5 class="mb-3">Yeni Düğün Salonu Ekle</h5>
+        <p class="small text-muted mb-4">Markanıza yeni salonlar ekleyin ve ekiplerinizi tek tıkla yetkilendirin.</p>
+        <form method="post" class="row g-3 grid-compact">
+          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+          <input type="hidden" name="do" value="create">
+          <div class="col-12">
+            <label class="form-label">Salon Adı</label>
+            <input class="form-control" name="name" placeholder="Örn: Zerosoft Garden" required>
+          </div>
+          <div class="col-12">
+            <label class="form-label">Slug (opsiyonel)</label>
+            <input class="form-control" name="slug" placeholder="zerosoft-garden">
+          </div>
+          <div class="col-12 d-grid">
+            <button class="btn btn-zs"><i class="bi bi-plus-lg me-1"></i>Salonu Kaydet</button>
+          </div>
+        </form>
       </div>
-      <div class="col-md-3">
-        <label class="form-label">Durum</label>
-        <select class="form-select" name="status">
-          <option value="">Tümü</option>
-          <option value="1" <?= $status==='1'?'selected':'' ?>>Aktif</option>
-          <option value="0" <?= $status==='0'?'selected':'' ?>>Pasif</option>
-        </select>
+    </div>
+    <div class="col-lg-7">
+      <div class="card-lite p-4 h-100 filter-card">
+        <h5 class="mb-3">Salonlarda Ara / Filtrele</h5>
+        <form method="get" class="row g-3 grid-compact">
+          <div class="col-md-6">
+            <label class="form-label">Ad veya Slug</label>
+            <input class="form-control" name="q" value="<?=h($q)?>" placeholder="Örn: Garden / garden-salon">
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">Durum</label>
+            <select class="form-select" name="status">
+              <option value="">Tümü</option>
+              <option value="1" <?= $status==='1'?'selected':'' ?>>Aktif</option>
+              <option value="0" <?= $status==='0'?'selected':'' ?>>Pasif</option>
+            </select>
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">Sırala</label>
+            <select class="form-select" name="order">
+              <option value="new" <?= $order==='new'?'selected':'' ?>>En yeni</option>
+              <option value="name_az" <?= $order==='name_az'?'selected':'' ?>>A→Z</option>
+              <option value="name_za" <?= $order==='name_za'?'selected':'' ?>>Z→A</option>
+            </select>
+          </div>
+          <div class="col-12 d-flex justify-content-between align-items-center flex-wrap gap-2">
+            <div class="small muted">Toplam <?=$venueTotals['all']?> salon listeleniyor.</div>
+            <div class="filter-actions">
+              <button class="btn btn-zs-outline" type="submit"><i class="bi bi-funnel me-1"></i>Filtrele</button>
+              <a class="btn btn-zs" href="<?=h($_SERVER['PHP_SELF'])?>"><i class="bi bi-arrow-counterclockwise me-1"></i>Temizle</a>
+            </div>
+          </div>
+        </form>
       </div>
-      <div class="col-md-3">
-        <label class="form-label">Sırala</label>
-        <select class="form-select" name="order">
-          <option value="new" <?= $order==='new'?'selected':'' ?>>Yeni Eklenen</option>
-          <option value="name_az" <?= $order==='name_az'?'selected':'' ?>>Ada göre (A→Z)</option>
-          <option value="name_za" <?= $order==='name_za'?'selected':'' ?>>Ada göre (Z→A)</option>
-        </select>
-      </div>
-      <div class="col-12 d-flex gap-2">
-        <button class="btn btn-zs-outline">Filtrele</button>
-        <a class="btn btn-outline-secondary" href="<?=h($_SERVER['PHP_SELF'])?>">Temizle</a>
-      </div>
-    </form>
+    </div>
   </div>
 
-  <!-- Salon Listesi -->
-  <div class="card-lite p-3">
-    <div class="d-flex justify-content-between align-items-center mb-2">
-      <h5 class="m-0">Salonlar</h5>
+  <div class="card-lite p-4">
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-2 mb-3">
+      <h5 class="mb-0">Salonlar</h5>
       <div class="small muted">
-        <?= count($venues) ?> sonuç
+        <?=$venueTotals['all']?> sonuç
         <?php if($q!==''): ?> • “<?=h($q)?>”<?php endif; ?>
         <?php if($status==='1'): ?> • sadece aktif<?php elseif($status==='0'): ?> • sadece pasif<?php endif; ?>
       </div>
@@ -234,67 +298,60 @@ function askToggle(){
       <div class="muted">Kriterlere uygun salon bulunamadı.</div>
     <?php else: ?>
       <div class="table-responsive">
-        <table class="table align-middle">
+        <table class="table align-middle venue-table">
           <thead>
             <tr>
-              <th>Ad</th>
+              <th>Salon</th>
               <th>Slug</th>
               <th>Durum</th>
-              <th style="width:420px">İşlemler</th>
+              <th style="width:440px">İşlemler</th>
             </tr>
           </thead>
           <tbody>
             <?php foreach($venues as $v): ?>
               <tr>
                 <td class="fw-semibold"><?=h($v['name'])?></td>
-                <td class="small"><?=h($v['slug'])?></td>
-                <td>
-                  <?= $v['is_active'] ? '<span class="badge bg-success">Aktif</span>'
-                                      : '<span class="badge bg-secondary">Pasif</span>' ?>
+                <td class="small text-muted"><?=h($v['slug'])?></td>
+                <td class="text-nowrap">
+                  <span class="badge-status <?= $v['is_active'] ? 'badge-active' : 'badge-passive' ?>"><?= $v['is_active'] ? 'Aktif' : 'Pasif' ?></span>
                 </td>
                 <td>
-                  <!-- Seç -->
-                  <form method="post" class="d-inline">
-                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-                    <input type="hidden" name="do" value="select">
-                    <input type="hidden" name="id" value="<?=$v['id']?>">
-                    <button class="btn btn-sm btn-zs">Seç ve Panele Git</button>
-                  </form>
-
-                  <!-- Aktif/Pasif -->
-                  <form method="post" class="d-inline" onsubmit="return askToggle()">
-                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-                    <input type="hidden" name="do" value="toggle">
-                    <input type="hidden" name="id" value="<?=$v['id']?>">
-                    <button class="btn btn-sm btn-outline-secondary">
-                      <?= $v['is_active'] ? 'Pasifleştir' : 'Aktifleştir' ?>
+                  <div class="action-group">
+                    <form method="post">
+                      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                      <input type="hidden" name="do" value="select">
+                      <input type="hidden" name="id" value="<?=$v['id']?>">
+                      <button class="btn btn-sm btn-zs" type="submit"><i class="bi bi-layout-text-window me-1"></i>Seç ve Panele Git</button>
+                    </form>
+                    <form method="post" onsubmit="return askToggle()">
+                      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                      <input type="hidden" name="do" value="toggle">
+                      <input type="hidden" name="id" value="<?=$v['id']?>">
+                      <button class="btn btn-sm btn-zs-outline" type="submit">
+                        <i class="bi bi-arrow-repeat me-1"></i><?= $v['is_active'] ? 'Pasifleştir' : 'Aktifleştir' ?>
+                      </button>
+                    </form>
+                    <form method="post">
+                      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                      <input type="hidden" name="do" value="select">
+                      <input type="hidden" name="goto_events" value="1">
+                      <input type="hidden" name="id" value="<?=$v['id']?>">
+                      <button class="btn btn-sm btn-brand-outline" type="submit"><i class="bi bi-calendar-event me-1"></i>Etkinlikleri Gör</button>
+                    </form>
+                    <button class="btn btn-sm btn-light border" type="button" onclick="document.getElementById('edit<?=$v['id']?>').classList.toggle('d-none')">
+                      <i class="bi bi-pencil-square me-1"></i>Düzenle
                     </button>
-                  </form>
-
-                  <!-- Geçmiş günleri gör (seç + venue_events.php'ye git) -->
-                  <form method="post" class="d-inline">
-                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-                    <input type="hidden" name="do" value="select">
-                    <input type="hidden" name="goto_events" value="1">
-                    <input type="hidden" name="id" value="<?=$v['id']?>">
-                    <button class="btn btn-sm btn-zs-outline">Geçmiş günleri gör</button>
-                  </form>
-
-                  <!-- Düzenle aç/kapa -->
-                  <button class="btn btn-sm btn-zs-outline" type="button"
-                          onclick="document.getElementById('edit<?=$v['id']?>').classList.toggle('d-none')">
-                    Düzenle
-                  </button>
+                  </div>
                 </td>
               </tr>
               <tr id="edit<?=$v['id']?>" class="d-none">
-                <td colspan="4">
-                  <form method="post" class="row g-2 grid-compact">
+                <td colspan="4" class="bg-light-subtle">
+                  <form method="post" class="row g-3 grid-compact">
                     <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
                     <input type="hidden" name="do" value="update">
                     <input type="hidden" name="id" value="<?=$v['id']?>">
                     <div class="col-md-6">
-                      <label class="form-label">Ad</label>
+                      <label class="form-label">Salon Adı</label>
                       <input class="form-control" name="name" value="<?=h($v['name'])?>">
                     </div>
                     <div class="col-md-4">
@@ -302,7 +359,7 @@ function askToggle(){
                       <input class="form-control" name="slug" value="<?=h($v['slug'])?>">
                     </div>
                     <div class="col-md-2 d-grid align-items-end">
-                      <button class="btn btn-zs" style="margin-top:30px">Kaydet</button>
+                      <button class="btn btn-zs"><i class="bi bi-save me-1"></i>Kaydet</button>
                     </div>
                   </form>
                 </td>

--- a/config.php
+++ b/config.php
@@ -32,7 +32,7 @@ const PAYTR_SITE_OK_URL  = BASE_URL.'/order_paytr_ok.php';
 const PAYTR_SITE_FAIL_URL= BASE_URL.'/order_paytr_fail.php';
 const PAYTR_DEALER_OK_URL   = BASE_URL.'/dealer/paytr_ok.php';
 const PAYTR_DEALER_FAIL_URL = BASE_URL.'/dealer/paytr_fail.php';
-const PAYTR_TEST_MODE    = 0; // 1=test, 0=canlı
+const PAYTR_TEST_MODE    = 1; // 1=test, 0=canlı
 /* ========================================= */
 
 /* =================================================== */

--- a/config.php
+++ b/config.php
@@ -28,6 +28,8 @@ const PAYTR_MERCHANT_SALT= 'eNaS2ot4C8naRR47';
 const PAYTR_OK_URL       = BASE_URL.'/couple/paytr_ok.php';
 const PAYTR_FAIL_URL     = BASE_URL.'/couple/paytr_fail.php';
 const PAYTR_CALLBACK_URL = BASE_URL.'/couple/paytr_callback.php';
+const PAYTR_SITE_OK_URL  = BASE_URL.'/order_paytr_ok.php';
+const PAYTR_SITE_FAIL_URL= BASE_URL.'/order_paytr_fail.php';
 const PAYTR_DEALER_OK_URL   = BASE_URL.'/dealer/paytr_ok.php';
 const PAYTR_DEALER_FAIL_URL = BASE_URL.'/dealer/paytr_fail.php';
 const PAYTR_TEST_MODE    = 0; // 1=test, 0=canlı

--- a/config.php
+++ b/config.php
@@ -28,6 +28,8 @@ const PAYTR_MERCHANT_SALT= 'eNaS2ot4C8naRR47';
 const PAYTR_OK_URL       = BASE_URL.'/couple/paytr_ok.php';
 const PAYTR_FAIL_URL     = BASE_URL.'/couple/paytr_fail.php';
 const PAYTR_CALLBACK_URL = BASE_URL.'/couple/paytr_callback.php';
+const PAYTR_DEALER_OK_URL   = BASE_URL.'/dealer/paytr_ok.php';
+const PAYTR_DEALER_FAIL_URL = BASE_URL.'/dealer/paytr_fail.php';
 const PAYTR_TEST_MODE    = 0; // 1=test, 0=canlı
 /* ========================================= */
 

--- a/config.php
+++ b/config.php
@@ -5,7 +5,7 @@ const DB_NAME   = 'u111878875_foto';
 const DB_USER   = 'u111878875_foto';
 const DB_PASS   = 'Zero671901*';
 const BASE_URL  = 'https://drive.demozerosoft.com.tr'; // kök URL (sonda / yok)
-const APP_NAME  = 'Wedding Share';
+const APP_NAME  = 'BİKARE';
 const SECRET_KEY = 'CHANGE_THIS_LONG_RANDOM_SECRET_32+CHARS';
 
 const MAX_UPLOAD_BYTES = 25 * 1024 * 1024; // 25 MB
@@ -15,7 +15,7 @@ const ALLOWED_MIMES = [
   
 ];
 const MAIL_FROM = 'test@zerosoft.com.tr';
-const MAIL_FROM_NAME = 'Wedding Share';
+const MAIL_FROM_NAME = 'BİKARE';
 const SMTP_HOST = 'smtp.hostinger.com';
 const SMTP_PORT = 465;
 const SMTP_USER = 'test@zerosoft.com.tr';

--- a/couple/list.php
+++ b/couple/list.php
@@ -50,7 +50,7 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ($_POST['do']??'')==='zip'){
   $rows = $st->fetchAll();
   if(!$rows){ flash('err','Seçili öğe bulunamadı.'); redirect($_SERVER['REQUEST_URI']); }
 
-  $zipName = 'wedding_'.date('Ymd_His').'.zip';
+  $zipName = 'bikare_'.date('Ymd_His').'.zip';
   $tmp = sys_get_temp_dir().'/'.$zipName;
   $zip = new ZipArchive();
   if($zip->open($tmp, ZipArchive::CREATE|ZipArchive::OVERWRITE)!==true){ flash('err','ZIP oluşturulamadı.'); redirect($_SERVER['REQUEST_URI']); }

--- a/couple/login.php
+++ b/couple/login.php
@@ -43,37 +43,75 @@ if ($_SERVER['REQUEST_METHOD']==='POST') {
   <title>Giriş — <?=h(APP_NAME)?></title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
-    :root{ --zs:#0ea5b5; }
-    body{ min-height:100vh; display:flex; align-items:center; justify-content:center; background:linear-gradient(180deg,#f0fbfd,#fff) }
-    .cardx{ width:100%; max-width:420px; background:#fff; border:1px solid #e9eef5; border-radius:18px; box-shadow:0 10px 30px rgba(2,6,23,.06) }
-    .btn-zs{ background:var(--zs); color:#fff; border:none; border-radius:12px; padding:.65rem 1rem; font-weight:700 }
-    .brand{ font-weight:800; letter-spacing:.2px; }
+    :root{ --brand:#0ea5b5; --brand-dark:#0b8b98; --ink:#0f172a; --muted:#5b6676; }
+    *{box-sizing:border-box;}
+    body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:2.5rem;background:radial-gradient(circle at top,#e0f7fb 0%,#f8fafc 60%,#fff);font-family:'Inter','Segoe UI',system-ui,-apple-system,sans-serif;color:var(--ink);}
+    .auth-shell{width:100%;max-width:1080px;background:#fff;border-radius:30px;box-shadow:0 48px 120px -60px rgba(15,23,42,.5);display:flex;overflow:hidden;border:1px solid rgba(148,163,184,.18);}
+    .auth-visual{flex:1.05;position:relative;padding:3.1rem;background:linear-gradient(150deg,rgba(14,165,181,.9),rgba(45,212,191,.75)),url('https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=1200&q=80') center/cover;color:#fff;display:flex;flex-direction:column;justify-content:space-between;}
+    .auth-visual::after{content:"";position:absolute;inset:0;background:linear-gradient(160deg,rgba(15,23,42,.12),rgba(15,23,42,.45));}
+    .auth-visual > *{position:relative;z-index:1;}
+    .badge{display:inline-flex;align-items:center;gap:.6rem;padding:.45rem 1.15rem;border-radius:999px;background:rgba(255,255,255,.18);font-weight:600;letter-spacing:.08em;text-transform:uppercase;font-size:.78rem;}
+    .visual-title{font-size:2.15rem;font-weight:800;line-height:1.2;margin:1.6rem 0 1.1rem;max-width:440px;}
+    .visual-text{font-size:1.02rem;line-height:1.7;color:rgba(255,255,255,.88);max-width:440px;}
+    .feature-list{list-style:none;padding:0;margin:1.8rem 0 0;display:flex;flex-direction:column;gap:1rem;}
+    .feature-list li{display:flex;align-items:flex-start;gap:.75rem;font-weight:600;color:rgba(255,255,255,.9);}
+    .feature-list span{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:50%;background:rgba(255,255,255,.18);font-size:1rem;}
+    .visual-footer{font-size:.84rem;color:rgba(255,255,255,.75);max-width:360px;margin-top:2.7rem;}
+    .auth-form{flex:.95;padding:3rem 3.1rem;display:flex;flex-direction:column;justify-content:center;gap:1.7rem;}
+    .brand{font-weight:800;font-size:1.7rem;letter-spacing:.18rem;margin-bottom:.25rem;}
+    .brand span{display:block;font-size:.95rem;font-weight:600;color:var(--muted);margin-top:.35rem;letter-spacing:0;}
+    .form-note{color:var(--muted);font-size:.95rem;line-height:1.6;}
+    .form-control{border-radius:14px;border:1px solid rgba(148,163,184,.3);padding:.78rem 1rem;font-size:1rem;}
+    .form-control:focus{border-color:var(--brand);box-shadow:0 0 0 .25rem rgba(14,165,181,.18);}
+    .btn-brand{background:linear-gradient(135deg,#0ea5b5,#0b8b98);color:#fff;border:none;border-radius:14px;padding:.85rem 1rem;font-weight:700;font-size:1rem;transition:transform .2s ease,box-shadow .2s ease;}
+    .btn-brand:hover{transform:translateY(-1px);box-shadow:0 20px 36px -24px rgba(14,165,181,.65);color:#fff;}
+    .alert{border-radius:14px;font-weight:500;}
+    .footer-links{display:flex;gap:.8rem;font-weight:600;flex-wrap:wrap;}
+    .footer-links a{color:var(--brand);text-decoration:none;}
+    .footer-links a:hover{text-decoration:underline;color:var(--brand-dark);}
+    @media(max-width:992px){body{padding:1.5rem;} .auth-shell{flex-direction:column;} .auth-visual{padding:2.6rem;} .auth-form{padding:2.4rem;}}
+    @media(max-width:576px){.auth-form{padding:2rem;} .visual-title{font-size:1.75rem;}}
   </style>
 </head>
 <body>
-  <div class="cardx p-4">
-    <div class="mb-3 text-center">
-      <div class="brand"><?=h(APP_NAME)?></div>
-      <div class="text-muted small">Çift Girişi</div>
-    </div>
-
-    <?php flash_box(); ?>
-    <?php if ($err): ?><div class="alert alert-danger"><?=h($err)?></div><?php endif; ?>
-
-    <form method="post" class="vstack gap-2">
-      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-      <label class="form-label">E-posta</label>
-      <input class="form-control" type="email" name="email" required autofocus>
-      <label class="form-label mt-2">Şifre</label>
-      <input class="form-control" type="password" name="password" required>
-      <button class="btn btn-zs mt-3 w-100">Giriş Yap</button>
-    </form>
-
-    <div class="mt-3 text-center">
-      <a class="small" href="<?=h(BASE_URL)?>">Anasayfa</a>
-      <span class="mx-2">•</span>
-      <a class="small" href="<?=h(BASE_URL)?>/couple/logout.php">Çıkış</a>
-    </div>
+  <div class="auth-shell">
+    <aside class="auth-visual">
+      <div>
+        <span class="badge">Çift Paneli</span>
+        <h1 class="visual-title">Tüm etkinlik yönetimi tek panelde birleşiyor.</h1>
+        <p class="visual-text">BİKARE çift paneliyle davetli listesinden QR yönetimine, kampanya yayınlarından misafir etkileşimlerine kadar tüm süreci yönetebilirsiniz.</p>
+        <ul class="feature-list">
+          <li><span>✓</span>Misafir yüklemelerini gerçek zamanlı takip edin</li>
+          <li><span>✓</span>Etkinlik görünümünü kişiselleştirin ve davetiyeleri paylaşın</li>
+          <li><span>✓</span>Bayi ve destek ekibiyle tek ekrandan iletişim kurun</li>
+        </ul>
+      </div>
+      <p class="visual-footer">BİKARE, çiftlere kusursuz bir etkinlik deneyimi sunmak için Zerosoft tarafından geliştirildi.</p>
+    </aside>
+    <section class="auth-form">
+      <div>
+        <div class="brand">BİKARE <span>Çift Girişi</span></div>
+        <p class="form-note">Sisteme tanımlı e-posta adresiniz ve şifrenizle giriş yaparak etkinliğinizi yönetebilirsiniz.</p>
+      </div>
+      <?php flash_box(); ?>
+      <?php if ($err): ?><div class="alert alert-danger"><?=h($err)?></div><?php endif; ?>
+      <form method="post" class="vstack gap-3">
+        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+        <div>
+          <label class="form-label">E-posta</label>
+          <input class="form-control" type="email" name="email" required autofocus placeholder="ornek@bikare.com">
+        </div>
+        <div>
+          <label class="form-label">Şifre</label>
+          <input class="form-control" type="password" name="password" required placeholder="Şifrenizi yazın">
+        </div>
+        <button class="btn-brand mt-2 w-100">Giriş Yap</button>
+      </form>
+      <div class="footer-links">
+        <a href="<?=h(BASE_URL)?>">← Anasayfaya dön</a>
+        <a href="<?=h(BASE_URL)?>/couple/logout.php">Panel erişimi mi değişti?</a>
+      </div>
+    </section>
   </div>
 </body>
 </html>

--- a/couple/pay.php
+++ b/couple/pay.php
@@ -36,6 +36,30 @@ if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) { $ip = '1.2.3.4'; }
 $oid = 'EV'.$event_id.'C'.$cid.strtoupper(bin2hex(random_bytes(6)));
 $oid = substr(preg_replace('/[^A-Za-z0-9]/','', $oid), 0, 64);
 
+if (paytr_is_test_mode()) {
+  $merchant_oid = 'TEST-'.$oid;
+  $now = now();
+  pdo()->prepare("INSERT INTO purchases (venue_id,event_id,campaign_id,status,amount,currency,paytr_oid,items_json,created_at,updated_at,paid_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)")
+      ->execute([
+        $VID,
+        $event_id,
+        $cid,
+        'paid',
+        $amount,
+        'TL',
+        $merchant_oid,
+        null,
+        $now,
+        $now,
+        $now,
+      ]);
+  echo '<!doctype html><html lang="tr"><head><meta charset="utf-8"><title>Test Ödemesi</title><link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"></head><body class="p-4">'
+      .'<div class="alert alert-info"><strong>Test modu:</strong> Ödeme simüle edildi ve kaydınız "paid" olarak işaretlendi.</div>'
+      .'<a class="btn btn-primary" href="'.h(BASE_URL).'/couple/index.php">Panele dön</a>'
+      .'</body></html>';
+  exit;
+}
+
 $no_installment=0; $max_installment=0; $currency='TL'; $test=(int)PAYTR_TEST_MODE;
 $hash_str = PAYTR_MERCHANT_ID . $ip . $oid . $email . $amount . $user_basket . $no_installment . $max_installment . $currency . $test;
 $paytr_token = base64_encode(hash_hmac('sha256', $hash_str . PAYTR_MERCHANT_SALT, PAYTR_MERCHANT_KEY, true));

--- a/couple/pay_addons.php
+++ b/couple/pay_addons.php
@@ -149,6 +149,33 @@ if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) { $ip = '1.2.3.4'; }
 $oid = 'EV'.$event_id.'PKT'.strtoupper(bin2hex(random_bytes(8)));
 $oid = substr(preg_replace('/[^A-Za-z0-9]/','', $oid), 0, 64);
 
+if (paytr_is_test_mode()) {
+  $merchant_oid = 'TEST-'.$oid;
+  $now = now();
+  $itemsJson = safe_json_encode($items);
+  pdo()->prepare("INSERT INTO purchases (venue_id,event_id,campaign_id,status,amount,currency,paytr_oid,items_json,created_at,updated_at,paid_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)")
+      ->execute([
+        $VID,
+        $event_id,
+        null,
+        'paid',
+        $totalKurus,
+        'TL',
+        $merchant_oid,
+        $itemsJson,
+        $now,
+        $now,
+        $now,
+      ]);
+  $totalTl = number_format($totalKurus / 100, 2, ',', '.');
+  echo '<!doctype html><html lang="tr"><head><meta charset="utf-8"><title>Test Ödemesi</title><link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"></head><body class="p-4">'
+      .'<div class="alert alert-info"><strong>Test modu:</strong> Ödeme simüle edildi ve seçilen ek paketler "paid" olarak kaydedildi.</div>'
+      .'<p><strong>Toplam:</strong> '.$totalTl.' TL</p>'
+      .'<a class="btn btn-primary" href="'.h(BASE_URL).'/couple/index.php">Panele dön</a>'
+      .'</body></html>';
+  exit;
+}
+
 // PayTR parametreleri
 $no_installment=0; $max_installment=0; $currency='TL'; $test=(int)PAYTR_TEST_MODE;
 

--- a/couple/paytr_callback.php
+++ b/couple/paytr_callback.php
@@ -2,18 +2,22 @@
 require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/site.php';
 
 $oid    = $_POST['merchant_oid'] ?? '';
 $status = $_POST['status'] ?? '';
-if($oid!==''){
+if ($oid !== '') {
   if (strncasecmp($oid, 'DT', 2) === 0) {
     dealer_handle_topup_callback($oid, $status, $_POST);
+  } elseif (strncasecmp($oid, 'SO', 2) === 0) {
+    site_handle_paytr_callback($oid, $status, $_POST);
   } else {
-    $st=pdo()->prepare("SELECT id FROM purchases WHERE paytr_oid=? LIMIT 1");
+    $st = pdo()->prepare("SELECT id FROM purchases WHERE paytr_oid=? LIMIT 1");
     $st->execute([$oid]);
-    if($r=$st->fetch()){
-      $new = ($status==='success')?'paid':'failed';
-      pdo()->prepare("UPDATE purchases SET status=?, updated_at=NOW() WHERE id=?")->execute([$new,$r['id']]);
+    if ($r = $st->fetch()) {
+      $new = ($status === 'success') ? 'paid' : 'failed';
+      pdo()->prepare("UPDATE purchases SET status=?, updated_at=NOW() WHERE id=?")
+          ->execute([$new, $r['id']]);
     }
   }
 }

--- a/couple/paytr_callback.php
+++ b/couple/paytr_callback.php
@@ -1,15 +1,20 @@
 <?php
 require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/dealers.php';
 
 $oid    = $_POST['merchant_oid'] ?? '';
 $status = $_POST['status'] ?? '';
 if($oid!==''){
-  $st=pdo()->prepare("SELECT id FROM purchases WHERE paytr_oid=? LIMIT 1");
-  $st->execute([$oid]);
-  if($r=$st->fetch()){
-    $new = ($status==='success')?'paid':'failed';
-    pdo()->prepare("UPDATE purchases SET status=?, updated_at=NOW() WHERE id=?")->execute([$new,$r['id']]);
+  if (strncasecmp($oid, 'DT', 2) === 0) {
+    dealer_handle_topup_callback($oid, $status, $_POST);
+  } else {
+    $st=pdo()->prepare("SELECT id FROM purchases WHERE paytr_oid=? LIMIT 1");
+    $st->execute([$oid]);
+    if($r=$st->fetch()){
+      $new = ($status==='success')?'paid':'failed';
+      pdo()->prepare("UPDATE purchases SET status=?, updated_at=NOW() WHERE id=?")->execute([$new,$r['id']]);
+    }
   }
 }
 echo "OK";

--- a/dealer/apply.php
+++ b/dealer/apply.php
@@ -1,0 +1,93 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+
+install_schema();
+
+$submitted = isset($_GET['done']);
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  csrf_or_die();
+  $name = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $phone = trim($_POST['phone'] ?? '');
+  $company = trim($_POST['company'] ?? '');
+  $notes = trim($_POST['notes'] ?? '');
+
+  if ($name === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err', 'Lütfen adınızı ve geçerli bir e-posta adresini girin.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+
+  if (dealer_find_by_email($email)) {
+    flash('err', 'Bu e-posta ile kayıtlı bir bayi başvurusu bulunuyor.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+
+  $st = pdo()->prepare("INSERT INTO dealers (name,email,phone,company,notes,status,created_at) VALUES (?,?,?,?,?,'pending',?)");
+  $st->execute([$name,$email,$phone,$company,$notes, now()]);
+  $dealerId = (int)pdo()->lastInsertId();
+  dealer_ensure_codes($dealerId);
+
+  $dealer = dealer_get($dealerId);
+  dealer_notify_new_application($dealer);
+  dealer_send_application_receipt($dealer);
+
+  flash('ok', 'Başvurunuz alınmıştır. En kısa sürede sizinle iletişime geçeceğiz.');
+  redirect($_SERVER['PHP_SELF'].'?done=1');
+}
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Başvurusu</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:linear-gradient(180deg,#fff5f7,#ffffff);}
+  .hero{max-width:640px;margin:40px auto;padding:32px;border-radius:18px;background:#fff;box-shadow:0 12px 40px rgba(15,23,42,.08);}
+</style>
+</head>
+<body>
+<div class="hero">
+  <h1 class="h3 mb-3">Bayi Başvuru Formu</h1>
+  <p class="text-muted">Düğün salonunuz veya organizasyon şirketiniz için başvuru yapın, yönetici onayıyla bayilik paneliniz açılsın.</p>
+  <?php if ($submitted): ?>
+    <?php flash_box(); ?>
+  <?php else: ?>
+    <?php flash_box(); ?>
+    <form method="post" class="row g-3">
+      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+      <div class="col-md-6">
+        <label class="form-label">Ad Soyad</label>
+        <input class="form-control" name="name" required>
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Firma Adı</label>
+        <input class="form-control" name="company">
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">E-posta</label>
+        <input type="email" class="form-control" name="email" required>
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Telefon</label>
+        <input class="form-control" name="phone">
+      </div>
+      <div class="col-12">
+        <label class="form-label">Notlar</label>
+        <textarea class="form-control" name="notes" rows="4" placeholder="Salon sayısı, bulunduğunuz şehir vb."></textarea>
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary" type="submit">Başvuruyu Gönder</button>
+      </div>
+    </form>
+  <?php endif; ?>
+  <div class="mt-4 text-center">
+    <a href="login.php" class="small text-decoration-none">Zaten bayimiz misiniz? Giriş yapın.</a>
+  </div>
+</div>
+</body>
+</html>

--- a/dealer/apply.php
+++ b/dealer/apply.php
@@ -41,53 +41,119 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <!doctype html>
 <html lang="tr">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title><?=h(APP_NAME)?> — Bayi Başvurusu</title>
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<style>
-  body{background:linear-gradient(180deg,#fff5f7,#ffffff);}
-  .hero{max-width:640px;margin:40px auto;padding:32px;border-radius:18px;background:#fff;box-shadow:0 12px 40px rgba(15,23,42,.08);}
-</style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title><?=h(APP_NAME)?> — Bayi Başvurusu</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    :root{ --brand:#0ea5b5; --brand-dark:#0b8b98; --ink:#0f172a; --muted:#5b6678; }
+    *{box-sizing:border-box;}
+    body{margin:0;min-height:100vh;padding:2.5rem;background:radial-gradient(circle at top,#e0f7fb 0%,#f8fafc 55%,#fff);font-family:'Inter','Segoe UI',system-ui,-apple-system,sans-serif;color:var(--ink);display:flex;align-items:center;justify-content:center;}
+    .apply-shell{width:100%;max-width:1200px;background:#fff;border-radius:32px;border:1px solid rgba(148,163,184,.18);box-shadow:0 50px 140px -65px rgba(15,23,42,.55);display:flex;overflow:hidden;}
+    .apply-visual{flex:1.1;position:relative;padding:3rem 3.4rem;background:linear-gradient(145deg,rgba(14,165,181,.9),rgba(14,116,144,.85)),url('https://images.unsplash.com/photo-1526948128573-703ee1aeb6fa?auto=format&fit=crop&w=1200&q=80') center/cover;color:#fff;display:flex;flex-direction:column;justify-content:space-between;}
+    .apply-visual::after{content:"";position:absolute;inset:0;background:linear-gradient(155deg,rgba(15,23,42,.18),rgba(15,23,42,.5));}
+    .apply-visual > *{position:relative;z-index:1;}
+    .badge{display:inline-flex;align-items:center;gap:.65rem;padding:.5rem 1.25rem;border-radius:999px;background:rgba(255,255,255,.18);font-weight:600;letter-spacing:.08em;text-transform:uppercase;font-size:.78rem;}
+    .visual-title{font-size:2.3rem;font-weight:800;line-height:1.15;margin:1.6rem 0 1rem;max-width:430px;}
+    .visual-text{font-size:1.04rem;line-height:1.7;color:rgba(255,255,255,.9);max-width:460px;}
+    .feature-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:1.1rem;margin-top:2rem;}
+    .feature-card{padding:1.1rem 1.2rem;border-radius:18px;background:rgba(255,255,255,.14);backdrop-filter:blur(6px);display:flex;flex-direction:column;gap:.45rem;}
+    .feature-card strong{font-size:1.05rem;}
+    .feature-card p{margin:0;font-size:.92rem;color:rgba(255,255,255,.82);line-height:1.5;}
+    .visual-footer{margin-top:2.6rem;font-size:.84rem;color:rgba(255,255,255,.75);max-width:340px;}
+    .apply-form{flex:.9;padding:3.2rem 3.4rem;display:flex;flex-direction:column;gap:2rem;}
+    .apply-form header{display:flex;flex-direction:column;gap:.6rem;}
+    .apply-form h1{font-size:2rem;font-weight:800;margin:0;}
+    .apply-form p{margin:0;color:var(--muted);font-size:.98rem;line-height:1.6;}
+    form{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1.4rem;}
+    form .full{grid-column:1/-1;}
+    label{font-weight:600;color:var(--muted);margin-bottom:.35rem;display:block;}
+    input,textarea{width:100%;border-radius:14px;border:1px solid rgba(148,163,184,.28);padding:.8rem 1rem;font-size:1rem;}
+    textarea{min-height:140px;resize:vertical;}
+    input:focus,textarea:focus{border-color:var(--brand);box-shadow:0 0 0 .25rem rgba(14,165,181,.18);outline:none;}
+    .btn-brand{grid-column:1/-1;background:linear-gradient(135deg,#0ea5b5,#0b8b98);color:#fff;border:none;border-radius:16px;padding:1rem 1.2rem;font-weight:700;font-size:1rem;transition:transform .2s ease,box-shadow .2s ease;}
+    .btn-brand:hover{transform:translateY(-1px);box-shadow:0 24px 38px -26px rgba(14,165,181,.6);color:#fff;}
+    .alert{border-radius:16px;font-weight:500;}
+    .success-card{background:#f0fdf9;border:1px solid rgba(14,165,181,.25);border-radius:20px;padding:2.2rem;display:flex;flex-direction:column;gap:1rem;}
+    .success-card h2{margin:0;font-weight:800;color:var(--ink);}
+    .success-card p{margin:0;color:var(--muted);line-height:1.6;}
+    .success-card a{align-self:flex-start;font-weight:700;color:var(--brand);text-decoration:none;}
+    .success-card a:hover{text-decoration:underline;color:var(--brand-dark);}
+    .contact-hint{font-size:.9rem;color:var(--muted);} 
+    @media(max-width:992px){body{padding:1.5rem;} .apply-shell{flex-direction:column;} .apply-visual{padding:2.6rem;} .apply-form{padding:2.4rem;}}
+    @media(max-width:576px){.apply-form{padding:2rem;} .visual-title{font-size:1.8rem;}}
+  </style>
 </head>
 <body>
-<div class="hero">
-  <h1 class="h3 mb-3">Bayi Başvuru Formu</h1>
-  <p class="text-muted">Düğün salonunuz veya organizasyon şirketiniz için başvuru yapın, yönetici onayıyla bayilik paneliniz açılsın.</p>
-  <?php if ($submitted): ?>
-    <?php flash_box(); ?>
-  <?php else: ?>
-    <?php flash_box(); ?>
-    <form method="post" class="row g-3">
-      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-      <div class="col-md-6">
-        <label class="form-label">Ad Soyad</label>
-        <input class="form-control" name="name" required>
+  <div class="apply-shell">
+    <aside class="apply-visual">
+      <div>
+        <span class="badge">Bayi Ekosistemi</span>
+        <h1 class="visual-title">BİKARE ile salonunuzun dijital gelirini artırın.</h1>
+        <p class="visual-text">Etkinlik sahiplerine sunduğunuz deneyimi BİKARE teknoloji altyapısıyla güçlendirin. QR davetiye yönetimi, misafir paneli ve cashback yapısıyla salonlarınızın tercih edilirliğini artırın.</p>
+        <div class="feature-grid">
+          <div class="feature-card">
+            <strong>Hızlı Aktivasyon</strong>
+            <p>Onaylandıktan sonra paneliniz ve kalıcı QR yönetiminiz dakikalar içinde hazır hale gelir.</p>
+          </div>
+          <div class="feature-card">
+            <strong>Gelir Paylaşımı</strong>
+            <p>Satılan paketlerden Cashback kazanarak cari bakiyenizi artırın, yeni etkinlikler üretin.</p>
+          </div>
+          <div class="feature-card">
+            <strong>Markalı Deneyim</strong>
+            <p>BİKARE tasarımlı misafir sayfalarıyla çiftlerinize unutulmaz, paylaşılabilir galeriler sunun.</p>
+          </div>
+          <div class="feature-card">
+            <strong>Özel Destek</strong>
+            <p>Zerosoft müşteri başarısı ekibi, operasyonlarınıza özel eğitim ve lansman desteği sağlar.</p>
+          </div>
+        </div>
       </div>
-      <div class="col-md-6">
-        <label class="form-label">Firma Adı</label>
-        <input class="form-control" name="company">
-      </div>
-      <div class="col-md-6">
-        <label class="form-label">E-posta</label>
-        <input type="email" class="form-control" name="email" required>
-      </div>
-      <div class="col-md-6">
-        <label class="form-label">Telefon</label>
-        <input class="form-control" name="phone">
-      </div>
-      <div class="col-12">
-        <label class="form-label">Notlar</label>
-        <textarea class="form-control" name="notes" rows="4" placeholder="Salon sayısı, bulunduğunuz şehir vb."></textarea>
-      </div>
-      <div class="col-12">
-        <button class="btn btn-primary" type="submit">Başvuruyu Gönder</button>
-      </div>
-    </form>
-  <?php endif; ?>
-  <div class="mt-4 text-center">
-    <a href="login.php" class="small text-decoration-none">Zaten bayimiz misiniz? Giriş yapın.</a>
+      <p class="visual-footer">BİKARE bayi programı; düğün salonları, organizasyon firmaları ve etkinlik ajansları için tasarlandı.</p>
+    </aside>
+    <section class="apply-form">
+      <header>
+        <h1>Bayi Başvuru Formu</h1>
+        <p>Bize birkaç bilgi bırakmanız yeterli. Ekibimiz başvurunuzu en kısa sürede inceleyip sizinle iletişime geçecek.</p>
+      </header>
+      <?php if ($submitted): ?>
+        <?php flash_box(); ?>
+        <div class="success-card">
+          <h2>Başvurunuz bize ulaştı! 🎉</h2>
+          <p>BİKARE bayi ekibi en kısa sürede sizinle iletişime geçerek panel kurulumunu ve eğitim sürecini planlayacak. Bu süreçte ek dokümanlara ihtiyaç duyarsak belirttiğiniz e-posta adresinden ulaşacağız.</p>
+          <a href="login.php">Panel hesabınız mı var? Giriş yapın →</a>
+          <div class="contact-hint">Sorularınız için <strong>hello@zerosoft.com.tr</strong> adresine e-posta gönderebilirsiniz.</div>
+        </div>
+      <?php else: ?>
+        <?php flash_box(); ?>
+        <form method="post">
+          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+          <div>
+            <label>Ad Soyad</label>
+            <input name="name" required placeholder="Örn. Ayşe Yılmaz">
+          </div>
+          <div>
+            <label>Firma Adı</label>
+            <input name="company" placeholder="Salon veya organizasyon şirketiniz">
+          </div>
+          <div>
+            <label>E-posta</label>
+            <input type="email" name="email" required placeholder="ornek@firma.com">
+          </div>
+          <div>
+            <label>Telefon</label>
+            <input name="phone" placeholder="05xx xxx xx xx">
+          </div>
+          <div class="full">
+            <label>Notlarınız</label>
+            <textarea name="notes" placeholder="Salon sayısı, bulunduğunuz şehir ve işbirliği beklentileriniz"></textarea>
+          </div>
+          <button class="btn-brand" type="submit">Başvuruyu Gönder</button>
+        </form>
+        <div class="contact-hint">Başvurunuz ile birlikte sözleşme sürecini hızlandırmak için vergi levhanızı ve salon görsellerinizi hazır bulundurabilirsiniz.</div>
+      <?php endif; ?>
+    </section>
   </div>
-</div>
 </body>
 </html>

--- a/dealer/billing.php
+++ b/dealer/billing.php
@@ -214,10 +214,11 @@ $pendingTopups = array_filter($topups, fn($row) => $row['status'] === DEALER_TOP
     </section>
 
     <section class="card-lite p-4 p-lg-5 mb-4">
-      <div class="d-flex justify-content-between align-items-center mb-4">
+      <div class="d-flex justify-content-between align-items-center mb-2">
         <h5 class="section-title mb-0">Paket Seçenekleri</h5>
         <span class="muted">Bakiyeniz: <?=h(format_currency($balance))?></span>
       </div>
+      <p class="text-muted small mb-4">Paket satın alımları cashback oluşturmaz. Web sitesinden gelen müşteri yönlendirmelerinizde bayi kodunuzla <strong>%20 cashback</strong> kazanırsınız.</p>
       <?php if (!$packages): ?>
         <p class="text-muted mb-0">Henüz tanımlanmış paket yok. Lütfen yönetici ile iletişime geçin.</p>
       <?php else: ?>
@@ -227,7 +228,7 @@ $pendingTopups = array_filter($topups, fn($row) => $row['status'] === DEALER_TOP
               $canBuy = $balance >= $package['price_cents'];
               $quotaText = $package['event_quota'] === null ? 'Sınırsız etkinlik' : ($package['event_quota'].' etkinlik hakkı');
               $durationText = $package['duration_days'] ? ($package['duration_days'].' gün geçerli') : 'Süre sınırı yok';
-              $cashbackText = $package['cashback_rate'] > 0 ? ('Tekli satışlarda %'.number_format($package['cashback_rate'] * 100, 0).' cashback') : null;
+              $cashbackText = $package['cashback_rate'] > 0 ? ('Web referans kodunuzla %'.number_format($package['cashback_rate'] * 100, 0).' cashback') : null;
             ?>
             <div class="package-card">
               <div>
@@ -279,6 +280,9 @@ $pendingTopups = array_filter($topups, fn($row) => $row['status'] === DEALER_TOP
                   <td>
                     <div class="fw-semibold"><?=h($purchase['package_name'])?></div>
                     <?php if (!empty($purchase['package_description'])): ?><div class="small text-muted"><?=h($purchase['package_description'])?></div><?php endif; ?>
+                    <?php if (($purchase['source'] ?? null) === DEALER_PURCHASE_SOURCE_LEAD): ?>
+                      <span class="badge bg-info-subtle text-info-emphasis mt-1">Web satış</span>
+                    <?php endif; ?>
                   </td>
                   <td><?=h($statusLabel)?></td>
                   <td><?=h(format_currency($purchase['price_cents']))?></td>

--- a/dealer/billing.php
+++ b/dealer/billing.php
@@ -65,6 +65,12 @@ $walletTransactions = dealer_wallet_transactions($dealerId, 20);
 $purchaseHistory = dealer_fetch_purchases($dealerId);
 $topups = dealer_topups_for_dealer($dealerId);
 $pendingTopups = array_filter($topups, fn($row) => $row['status'] === DEALER_TOPUP_STATUS_PENDING);
+$cashbackPending = dealer_cashback_candidates($dealerId, DEALER_CASHBACK_PENDING);
+$cashbackPendingCount = count($cashbackPending);
+$cashbackPendingAmount = 0;
+foreach ($cashbackPending as $row) {
+  $cashbackPendingAmount += max(0, (int)$row['cashback_amount']);
+}
 
 ?>
 <!doctype html>
@@ -156,12 +162,18 @@ $pendingTopups = array_filter($topups, fn($row) => $row['status'] === DEALER_TOP
           </div>
           <div class="stat-card">
             <h6>Cashback Bekleyen</h6>
-            <strong><?=h($summary['cashback_waiting'])?></strong>
-            <span><?= $summary['cashback_waiting'] ? h(format_currency($summary['cashback_pending_amount']).' bekliyor') : 'Şu anda bekleyen ödeme yok' ?></span>
+            <strong><?=h($cashbackPendingCount)?></strong>
+            <span><?= $cashbackPendingCount ? h(format_currency($cashbackPendingAmount).' onay bekliyor') : 'Şu anda bekleyen ödeme yok' ?></span>
           </div>
         </div>
       </div>
     </section>
+
+    <?php if ($cashbackPendingCount): ?>
+      <div class="alert alert-info mb-4">
+        Web referans siparişlerinizden gelen <strong><?=h(format_currency($cashbackPendingAmount))?></strong> tutarında cashback onay bekliyor. Finans ekibi onayladığında tutar otomatik olarak bakiyenize yansıtılır.
+      </div>
+    <?php endif; ?>
 
     <section id="topup" class="card-lite p-4 p-lg-5 mb-4">
       <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
@@ -218,7 +230,7 @@ $pendingTopups = array_filter($topups, fn($row) => $row['status'] === DEALER_TOP
         <h5 class="section-title mb-0">Paket Seçenekleri</h5>
         <span class="muted">Bakiyeniz: <?=h(format_currency($balance))?></span>
       </div>
-      <p class="text-muted small mb-4">Paket satın alımları cashback oluşturmaz. Web sitesinden gelen müşteri yönlendirmelerinizde bayi kodunuzla <strong>%20 cashback</strong> kazanırsınız.</p>
+      <p class="text-muted small mb-4">Paket satın alımları cashback oluşturmaz. Web sitesinden gelen müşteri yönlendirmelerinizde bayi kodunuzla <strong>%20 cashback</strong> kazanırsınız; tutarlar finans onayından sonra bakiyenize eklenir.</p>
       <?php if (!$packages): ?>
         <p class="text-muted mb-0">Henüz tanımlanmış paket yok. Lütfen yönetici ile iletişime geçin.</p>
       <?php else: ?>

--- a/dealer/billing.php
+++ b/dealer/billing.php
@@ -1,0 +1,320 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+
+install_schema();
+
+dealer_require_login();
+$sessionDealer = dealer_user();
+$dealer = dealer_get((int)$sessionDealer['id']);
+if (!$dealer) {
+  dealer_logout();
+  redirect('login.php');
+}
+
+dealer_refresh_session((int)$dealer['id']);
+$dealerId = (int)$dealer['id'];
+$activeNav = 'billing';
+
+$action = $_POST['do'] ?? '';
+if ($action) {
+  csrf_or_die();
+}
+
+try {
+  if ($action === 'request_topup') {
+    $amountInput = $_POST['amount'] ?? '';
+    $amountCents = money_to_cents($amountInput);
+    if ($amountCents < 10000) {
+      throw new RuntimeException('Minimum 100 TL yükleme yapabilirsiniz.');
+    }
+    dealer_create_topup_request($dealerId, $amountCents);
+    flash('ok', 'Bakiye yükleme talebiniz alındı. PayTR doğrulaması sonrası bakiyenize yansıyacaktır.');
+    redirect('billing.php#topup');
+  }
+  if ($action === 'buy_package') {
+    $packageId = (int)($_POST['package_id'] ?? 0);
+    if ($packageId <= 0) {
+      throw new RuntimeException('Paket seçilmedi.');
+    }
+    dealer_purchase_package($dealerId, $packageId);
+    flash('ok', 'Paket satın alma işlemi tamamlandı.');
+    redirect('billing.php');
+  }
+  if ($action === 'cancel_topup') {
+    $topupId = (int)($_POST['topup_id'] ?? 0);
+    if ($topupId <= 0) {
+      throw new RuntimeException('Kayıt bulunamadı.');
+    }
+    dealer_cancel_topup($topupId, $dealerId);
+    flash('ok', 'Bekleyen yükleme talebiniz iptal edildi.');
+    redirect('billing.php#topup');
+  }
+} catch (Throwable $e) {
+  flash('err', $e->getMessage());
+  redirect('billing.php');
+}
+
+dealer_refresh_purchase_states($dealerId);
+$balance = dealer_get_balance($dealerId);
+$summary = dealer_event_quota_summary($dealerId);
+$packages = dealer_packages_available();
+$walletTransactions = dealer_wallet_transactions($dealerId, 20);
+$purchaseHistory = dealer_fetch_purchases($dealerId);
+$topups = dealer_topups_for_dealer($dealerId);
+$pendingTopups = array_filter($topups, fn($row) => $row['status'] === DEALER_TOPUP_STATUS_PENDING);
+
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bakiye & Paketler</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  :root{
+    --brand:#0ea5b5;
+    --brand-dark:#0b8b98;
+    --ink:#0f172a;
+    --muted:#64748b;
+    --soft:#f1f7fb;
+  }
+  body{background:var(--soft);color:var(--ink);font-family:'Inter','Segoe UI',system-ui,sans-serif;min-height:100vh;}
+  a{color:var(--brand);} a:hover{color:var(--brand-dark);}
+  .dealer-topnav{background:#fff;border-bottom:1px solid rgba(148,163,184,.22);box-shadow:0 12px 30px rgba(15,23,42,.05);}
+  .dealer-topnav .navbar-brand{font-weight:700;color:var(--ink);}
+  .dealer-topnav .nav-link{color:var(--muted);font-weight:600;border-radius:12px;padding:.45rem .95rem;}
+  .dealer-topnav .nav-link:hover{color:var(--brand-dark);background:rgba(14,165,181,.1);}
+  .dealer-topnav .nav-link.active{color:var(--brand);background:rgba(14,165,181,.18);}
+  .dealer-topnav .badge-soft{background:rgba(14,165,181,.12);color:var(--brand-dark);border-radius:999px;padding:.3rem .85rem;font-weight:600;font-size:.85rem;}
+  .billing-hero{padding:2.4rem 0 1.8rem;}
+  .card-lite{border-radius:20px;background:#fff;border:1px solid rgba(148,163,184,.16);box-shadow:0 22px 45px -28px rgba(15,23,42,.45);}
+  .stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1.1rem;}
+  .stat-card{padding:1.35rem;border-radius:16px;background:linear-gradient(150deg,#fff,rgba(14,165,181,.1));}
+  .stat-card h6{font-size:.8rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:.35rem;}
+  .stat-card strong{font-size:1.6rem;display:block;}
+  .stat-card span{color:var(--muted);font-size:.82rem;}
+  .package-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1.2rem;}
+  .package-card{border:1px solid rgba(148,163,184,.25);border-radius:18px;padding:1.4rem;background:#fff;display:flex;flex-direction:column;gap:1rem;box-shadow:0 16px 35px -28px rgba(15,23,42,.45);}
+  .package-card h6{font-weight:700;}
+  .package-card .price{font-size:1.8rem;font-weight:700;}
+  .package-card ul{margin:0;padding-left:1.1rem;color:var(--muted);font-size:.9rem;}
+  .btn-brand{background:var(--brand);border:none;color:#fff;border-radius:14px;padding:.6rem 1.3rem;font-weight:600;}
+  .btn-brand:hover{background:var(--brand-dark);color:#fff;}
+  .btn-outline-brand{background:#fff;border:1px solid rgba(14,165,181,.55);color:var(--brand);border-radius:14px;padding:.6rem 1.3rem;font-weight:600;}
+  .btn-outline-brand:hover{background:rgba(14,165,181,.08);color:var(--brand-dark);}
+  .table thead th{color:var(--muted);font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;}
+  .section-title{font-weight:700;}
+  .muted{color:var(--muted);}
+</style>
+</head>
+<body>
+<header class="dealer-header">
+  <nav class="dealer-topnav navbar navbar-expand-lg py-3">
+    <div class="container">
+      <a class="navbar-brand" href="dashboard.php"><?=h(APP_NAME)?> — Bayi Paneli</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#dealerNav" aria-controls="dealerNav" aria-expanded="false" aria-label="Menü">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="dealerNav">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item"><a class="nav-link<?= $activeNav === 'dashboard' ? ' active' : '' ?>" href="dashboard.php">Genel Bakış</a></li>
+          <li class="nav-item"><a class="nav-link<?= $activeNav === 'venues' ? ' active' : '' ?>" href="dashboard.php#venues">Salonlar</a></li>
+          <li class="nav-item"><a class="nav-link<?= $activeNav === 'billing' ? ' active' : '' ?>" href="billing.php">Bakiye & Paketler</a></li>
+        </ul>
+        <div class="d-flex align-items-center gap-3 mb-2 mb-lg-0">
+          <span class="badge-soft"><?=h($dealer['name'])?></span>
+          <a class="text-decoration-none fw-semibold" href="login.php?logout=1">Çıkış</a>
+        </div>
+      </div>
+    </div>
+  </nav>
+</header>
+<main class="billing-main">
+  <div class="container py-4">
+    <?php flash_box(); ?>
+    <section class="billing-hero mb-4">
+      <div class="card-lite p-4 p-lg-5">
+        <div class="stat-grid">
+          <div class="stat-card">
+            <h6>Bakiye</h6>
+            <strong><?=h(format_currency($balance))?></strong>
+            <span>Bakiye hareketleri ve yüklemeleriniz</span>
+          </div>
+          <div class="stat-card">
+            <h6>Aktif Paket</h6>
+            <strong><?=h(count($summary['active']))?></strong>
+            <span><?= $summary['has_credit'] ? 'Etkinlik oluşturmaya hazırsınız' : 'Paket satın almanız gerekiyor' ?></span>
+          </div>
+          <div class="stat-card">
+            <h6>Kalan Etkinlik</h6>
+            <strong><?=h($summary['has_unlimited'] ? 'Sınırsız' : (string)$summary['remaining_events'])?></strong>
+            <span><?= $summary['has_unlimited'] ? 'Süre bitişi: '.($summary['unlimited_until'] ? date('d.m.Y', strtotime($summary['unlimited_until'])) : 'Süresiz') : 'Kullanılabilir haklarınız' ?></span>
+          </div>
+          <div class="stat-card">
+            <h6>Cashback Bekleyen</h6>
+            <strong><?=h($summary['cashback_waiting'])?></strong>
+            <span><?= $summary['cashback_waiting'] ? h(format_currency($summary['cashback_pending_amount']).' bekliyor') : 'Şu anda bekleyen ödeme yok' ?></span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="topup" class="card-lite p-4 p-lg-5 mb-4">
+      <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+        <div>
+          <h5 class="section-title mb-1">Bakiye Yükle</h5>
+          <p class="muted mb-0">PayTR entegrasyonu ile bakiye yüklemeleri kısa süre içinde otomatikleşecektir. Şimdilik talepleriniz manuel olarak onaylanır.</p>
+        </div>
+        <form class="d-flex flex-column flex-sm-row gap-2" method="post">
+          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+          <input type="hidden" name="do" value="request_topup">
+          <input type="text" class="form-control" name="amount" placeholder="Örn. 3.000" required>
+          <button class="btn btn-brand" type="submit">Talep Oluştur</button>
+        </form>
+      </div>
+      <div class="table-responsive">
+        <table class="table align-middle mb-0">
+          <thead><tr><th>Tarih</th><th>Tutar</th><th>Durum</th><th></th></tr></thead>
+          <tbody>
+            <?php if (!$topups): ?>
+              <tr><td colspan="4" class="text-center text-muted">Henüz bakiye yükleme talebiniz bulunmuyor.</td></tr>
+            <?php else: ?>
+              <?php foreach ($topups as $topup): ?>
+                <tr>
+                  <td><?=h(date('d.m.Y H:i', strtotime($topup['created_at'] ?? 'now')))?></td>
+                  <td><?=h(format_currency($topup['amount_cents']))?></td>
+                  <td><?=h(dealer_topup_status_label($topup['status']))?></td>
+                  <td class="text-end">
+                    <?php if ($topup['status'] === DEALER_TOPUP_STATUS_PENDING): ?>
+                      <form method="post" class="d-inline">
+                        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                        <input type="hidden" name="do" value="cancel_topup">
+                        <input type="hidden" name="topup_id" value="<?= (int)$topup['id'] ?>">
+                        <button class="btn btn-sm btn-outline-brand" type="submit">İptal Et</button>
+                      </form>
+                    <?php else: ?>
+                      <span class="text-muted small">—</span>
+                    <?php endif; ?>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            <?php endif; ?>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="card-lite p-4 p-lg-5 mb-4">
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h5 class="section-title mb-0">Paket Seçenekleri</h5>
+        <span class="muted">Bakiyeniz: <?=h(format_currency($balance))?></span>
+      </div>
+      <?php if (!$packages): ?>
+        <p class="text-muted mb-0">Henüz tanımlanmış paket yok. Lütfen yönetici ile iletişime geçin.</p>
+      <?php else: ?>
+        <div class="package-grid">
+          <?php foreach ($packages as $package): ?>
+            <?php
+              $canBuy = $balance >= $package['price_cents'];
+              $quotaText = $package['event_quota'] === null ? 'Sınırsız etkinlik' : ($package['event_quota'].' etkinlik hakkı');
+              $durationText = $package['duration_days'] ? ($package['duration_days'].' gün geçerli') : 'Süre sınırı yok';
+              $cashbackText = $package['cashback_rate'] > 0 ? ('Tekli satışlarda %'.number_format($package['cashback_rate'] * 100, 0).' cashback') : null;
+            ?>
+            <div class="package-card">
+              <div>
+                <h6><?=h($package['name'])?></h6>
+                <div class="price"><?=h(format_currency($package['price_cents']))?></div>
+              </div>
+              <?php if (!empty($package['description'])): ?>
+                <p class="muted mb-0"><?=h($package['description'])?></p>
+              <?php endif; ?>
+              <ul class="mb-0">
+                <li><?=h($quotaText)?></li>
+                <li><?=h($durationText)?></li>
+                <?php if ($cashbackText): ?><li><?=h($cashbackText)?></li><?php endif; ?>
+              </ul>
+              <div class="mt-auto">
+                <?php if ($canBuy): ?>
+                  <form method="post">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="buy_package">
+                    <input type="hidden" name="package_id" value="<?= (int)$package['id'] ?>">
+                    <button class="btn btn-brand w-100" type="submit">Satın Al</button>
+                  </form>
+                <?php else: ?>
+                  <button class="btn btn-outline-brand w-100" type="button" disabled>Bakiyeniz yetersiz</button>
+                <?php endif; ?>
+              </div>
+            </div>
+          <?php endforeach; ?>
+        </div>
+      <?php endif; ?>
+    </section>
+
+    <section class="card-lite p-4 p-lg-5 mb-4">
+      <h5 class="section-title mb-3">Paket Satın Alma Geçmişi</h5>
+      <div class="table-responsive">
+        <table class="table align-middle mb-0">
+          <thead><tr><th>Paket</th><th>Durum</th><th>Tutar</th><th>Satın Alma</th><th>Cashback</th></tr></thead>
+          <tbody>
+            <?php if (!$purchaseHistory): ?>
+              <tr><td colspan="5" class="text-center text-muted">Henüz paket satın almadınız.</td></tr>
+            <?php else: ?>
+              <?php foreach (array_slice($purchaseHistory, 0, 12) as $purchase): ?>
+                <?php
+                  $statusLabel = dealer_purchase_status_label($purchase['status']);
+                  $cashbackLabel = dealer_cashback_status_label($purchase['cashback_status']);
+                  $cashbackAmount = $purchase['cashback_amount'] > 0 ? format_currency($purchase['cashback_amount']) : '—';
+                ?>
+                <tr>
+                  <td>
+                    <div class="fw-semibold"><?=h($purchase['package_name'])?></div>
+                    <?php if (!empty($purchase['package_description'])): ?><div class="small text-muted"><?=h($purchase['package_description'])?></div><?php endif; ?>
+                  </td>
+                  <td><?=h($statusLabel)?></td>
+                  <td><?=h(format_currency($purchase['price_cents']))?></td>
+                  <td><?=h(date('d.m.Y H:i', strtotime($purchase['created_at'] ?? 'now')))?></td>
+                  <td><?=h($cashbackLabel)?><?php if ($purchase['cashback_status'] === DEALER_CASHBACK_PENDING): ?> • <?=h($cashbackAmount)?><?php endif; ?></td>
+                </tr>
+              <?php endforeach; ?>
+            <?php endif; ?>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="wallet" class="card-lite p-4 p-lg-5">
+      <h5 class="section-title mb-3">Cari Hareketleri</h5>
+      <div class="table-responsive">
+        <table class="table align-middle mb-0">
+          <thead><tr><th>Tarih</th><th>İşlem</th><th>Tutar</th><th>Son Bakiye</th></tr></thead>
+          <tbody>
+            <?php if (!$walletTransactions): ?>
+              <tr><td colspan="4" class="text-center text-muted">Henüz hareket kaydı bulunmuyor.</td></tr>
+            <?php else: ?>
+              <?php foreach ($walletTransactions as $movement): ?>
+                <tr>
+                  <td><?=h(date('d.m.Y H:i', strtotime($movement['created_at'] ?? 'now')))?></td>
+                  <td>
+                    <div class="fw-semibold"><?=h(dealer_wallet_type_label($movement['type']))?></div>
+                    <?php if (!empty($movement['description'])): ?><div class="small text-muted"><?=h($movement['description'])?></div><?php endif; ?>
+                  </td>
+                  <td><?=h(format_currency($movement['amount_cents']))?></td>
+                  <td><?=h(format_currency($movement['balance_after']))?></td>
+                </tr>
+              <?php endforeach; ?>
+            <?php endif; ?>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+  </div>
+</main>
+</body>
+</html>

--- a/dealer/dashboard.php
+++ b/dealer/dashboard.php
@@ -20,7 +20,11 @@ dealer_refresh_session((int)$dealer['id']);
 $venues  = dealer_fetch_venues((int)$dealer['id']);
 $events  = dealer_allowed_events((int)$dealer['id']);
 $warning = dealer_license_warning($dealer);
-$canCreate = dealer_can_manage_events($dealer);
+$creationStatus = dealer_event_creation_status($dealer);
+$canCreate = $creationStatus['allowed'];
+$quotaSummary = $creationStatus['summary'];
+$balance = dealer_get_balance((int)$dealer['id']);
+$activeNav = 'dashboard';
 
 $totalVenues  = count($venues);
 $activeVenues = count(array_filter($venues, fn($v) => !empty($v['is_active'])));
@@ -61,16 +65,22 @@ $nextEvent = $upcoming[0] ?? null;
   }
   body{background:var(--bg);font-family:'Inter',sans-serif;color:var(--text);}
   a{color:var(--brand);} a:hover{color:var(--brand-dark);}
-  .topbar{background:#fff;border-bottom:1px solid rgba(15,23,42,.05);box-shadow:0 10px 20px rgba(15,23,42,.04);}
-  .hero{padding:2.5rem 0;}
-  .hero h1{font-size:1.75rem;font-weight:700;margin-bottom:.5rem;}
-  .hero p{color:var(--muted);max-width:560px;}
-  .card-lite{border:1px solid rgba(15,23,42,.06);border-radius:18px;background:#fff;box-shadow:0 15px 35px rgba(15,23,42,.07);}
-  .stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1.2rem;}
+  .dealer-topnav{background:#fff;border-bottom:1px solid rgba(15,23,42,.08);box-shadow:0 12px 30px rgba(15,23,42,.06);}
+  .dealer-topnav .navbar-brand{font-weight:700;color:var(--text);}
+  .dealer-topnav .nav-link{color:var(--muted);font-weight:600;border-radius:12px;padding:.45rem .95rem;}
+  .dealer-topnav .nav-link:hover{color:var(--brand-dark);background:rgba(14,165,181,.08);}
+  .dealer-topnav .nav-link.active{color:var(--brand);background:rgba(14,165,181,.16);}
+  .dealer-topnav .badge-soft{background:rgba(14,165,181,.12);color:var(--brand-dark);border-radius:999px;padding:.3rem .85rem;font-weight:600;font-size:.85rem;}
+  .dealer-hero{padding:2.6rem 0 2rem;}
+  .dealer-hero h1{font-size:1.8rem;font-weight:700;margin-bottom:.6rem;}
+  .dealer-hero p{color:var(--muted);max-width:620px;}
+  .hero-actions{gap:.75rem;}
+  .card-lite{border:1px solid rgba(15,23,42,.06);border-radius:20px;background:#fff;box-shadow:0 18px 40px rgba(15,23,42,.07);}
+  .stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:1.2rem;}
   .stat-card{padding:1.4rem;border-radius:16px;background:linear-gradient(145deg,#fff,rgba(14,165,181,.08));position:relative;overflow:hidden;}
-  .stat-card h6{font-size:.85rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:.35rem;}
-  .stat-card strong{font-size:1.8rem;display:block;}
-  .stat-card span{color:var(--muted);font-size:.85rem;}
+  .stat-card h6{font-size:.8rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:.35rem;}
+  .stat-card strong{font-size:1.7rem;display:block;}
+  .stat-card span{color:var(--muted);font-size:.82rem;}
   .table thead th{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);}
   .badge-soft{background:rgba(14,165,181,.12);color:var(--brand);border-radius:999px;padding:.35rem .75rem;font-weight:600;font-size:.8rem;}
   .empty-state{padding:2.5rem;text-align:center;color:var(--muted);}
@@ -82,53 +92,141 @@ $nextEvent = $upcoming[0] ?? null;
 </style>
 </head>
 <body>
-<nav class="topbar py-3">
-  <div class="container d-flex justify-content-between align-items-center">
-    <span class="fw-semibold"><?=h(APP_NAME)?> — Bayi Paneli</span>
-    <div class="d-flex align-items-center gap-3 small">
-      <span><?=h($dealer['name'])?></span>
-      <span>•</span>
-      <a class="text-decoration-none" href="login.php?logout=1">Çıkış</a>
-    </div>
-  </div>
-</nav>
-<div class="container py-4">
-  <?php flash_box(); ?>
-  <section class="hero">
-    <div class="card-lite p-4 p-lg-5">
-      <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-4">
-        <div>
-          <h1>Merhaba <?=h($dealer['name'])?> 👋</h1>
-          <p>Bayi panelinizde atanmış salonlarınızı yönetin, etkinliklerinizi takip edin ve <?=h(APP_NAME)?> ekibinin sunduğu kampanyalardan haberdar olun.</p>
-          <div class="d-flex flex-wrap gap-3 mt-3">
-            <span class="badge-soft">Lisans Bitiş: <?=h(dealer_license_label($dealer))?></span>
-            <?php if ($warning): ?>
-              <span class="badge bg-warning-subtle text-warning-emphasis fw-semibold"><?=h($warning)?></span>
-            <?php else: ?>
-              <span class="badge-soft">Durum: <?= dealer_has_valid_license($dealer) ? 'Geçerli' : 'Geçersiz' ?></span>
-            <?php endif; ?>
-          </div>
-        </div>
-        <div class="stat-grid flex-grow-1">
-          <div class="stat-card">
-            <h6>Salon</h6>
-            <strong><?=$totalVenues?></strong>
-            <span><?=$activeVenues?> aktif</span>
-          </div>
-          <div class="stat-card">
-            <h6>Etkinlik</h6>
-            <strong><?=$totalEvents?></strong>
-            <span><?=count($upcoming)?> yaklaşan</span>
-          </div>
-          <div class="stat-card">
-            <h6>Son Giriş</h6>
-            <strong><?=h($dealer['last_login_at'] ? date('d.m.Y', strtotime($dealer['last_login_at'])) : '—')?></strong>
-            <span><?=h($dealer['last_login_at'] ? date('H:i', strtotime($dealer['last_login_at'])).' • '.APP_NAME : 'İlk girişinizi yapın')?></span>
-          </div>
+<header class="dealer-header">
+  <nav class="dealer-topnav navbar navbar-expand-lg py-3">
+    <div class="container">
+      <a class="navbar-brand" href="dashboard.php"><?=h(APP_NAME)?> — Bayi Paneli</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#dealerNav" aria-controls="dealerNav" aria-expanded="false" aria-label="Menü">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="dealerNav">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item"><a class="nav-link<?= $activeNav === 'dashboard' ? ' active' : '' ?>" href="dashboard.php">Genel Bakış</a></li>
+          <li class="nav-item"><a class="nav-link<?= $activeNav === 'venues' ? ' active' : '' ?>" href="#venues">Salonlar</a></li>
+          <li class="nav-item"><a class="nav-link<?= $activeNav === 'billing' ? ' active' : '' ?>" href="billing.php">Bakiye & Paketler</a></li>
+        </ul>
+        <div class="d-flex align-items-center gap-3 mb-2 mb-lg-0">
+          <span class="badge-soft"><?=h($dealer['name'])?></span>
+          <a class="text-decoration-none fw-semibold" href="login.php?logout=1">Çıkış</a>
         </div>
       </div>
     </div>
-  </section>
+  </nav>
+</header>
+<main class="dealer-main">
+  <div class="container py-4">
+    <?php flash_box(); ?>
+    <section class="dealer-hero">
+      <div class="card-lite p-4 p-lg-5">
+        <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-4">
+          <div>
+            <h1>Merhaba <?=h($dealer['name'])?> 👋</h1>
+            <p>Bayi panelinizde atanmış salonlarınızı yönetin, etkinliklerinizi takip edin ve <?=h(APP_NAME)?> ekibinin sunduğu kampanyalardan haberdar olun.</p>
+            <div class="d-flex flex-wrap hero-actions mt-3">
+              <span class="badge-soft">Lisans Bitiş: <?=h(dealer_license_label($dealer))?></span>
+              <?php if ($warning): ?>
+                <span class="badge bg-warning-subtle text-warning-emphasis fw-semibold"><?=h($warning)?></span>
+              <?php else: ?>
+                <span class="badge-soft">Durum: <?= dealer_has_valid_license($dealer) ? 'Geçerli' : 'Geçersiz' ?></span>
+              <?php endif; ?>
+              <a class="btn btn-brand btn-sm" href="billing.php">Bakiye & Paketler</a>
+            </div>
+          </div>
+          <div class="stat-grid flex-grow-1">
+            <div class="stat-card">
+              <h6>Salon</h6>
+              <strong><?=$totalVenues?></strong>
+              <span><?=$activeVenues?> aktif</span>
+            </div>
+            <div class="stat-card">
+              <h6>Etkinlik</h6>
+              <strong><?=$totalEvents?></strong>
+              <span><?=count($upcoming)?> yaklaşan</span>
+            </div>
+            <div class="stat-card">
+              <h6>Bakiye</h6>
+              <strong><?=h(format_currency($balance))?></strong>
+              <span>Bakiye hareketlerini takip edin</span>
+            </div>
+            <?php
+              $quotaLabel = $quotaSummary['has_unlimited'] ? 'Sınırsız' : (string)$quotaSummary['remaining_events'];
+              $quotaHint  = $quotaSummary['has_unlimited']
+                ? ($quotaSummary['unlimited_until'] ? 'Süre bitişi: '.date('d.m.Y', strtotime($quotaSummary['unlimited_until'])) : 'Süre sınırı yok')
+                : 'Kalan etkinlik hakkı';
+            ?>
+            <div class="stat-card">
+              <h6>Etkinlik Hakkı</h6>
+              <strong><?=h($quotaLabel)?></strong>
+              <span><?=h($quotaHint)?></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <?php if (!$creationStatus['allowed'] && $creationStatus['reason'] && $quotaSummary['has_credit']): ?>
+      <div class="alert alert-warning mb-4">
+        <?=h($creationStatus['reason'])?>
+      </div>
+    <?php endif; ?>
+
+    <?php if (!$quotaSummary['has_credit']): ?>
+      <div class="alert alert-warning d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
+        <div>Yeni etkinlik oluşturmak için aktif bir paket veya bakiye yüklemesine ihtiyacınız var.</div>
+        <a class="btn btn-sm btn-outline-brand" href="billing.php">Paketleri Gör</a>
+      </div>
+    <?php endif; ?>
+
+    <?php if ($quotaSummary['cashback_waiting'] > 0): ?>
+      <div class="alert alert-info d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
+        <div><strong><?=$quotaSummary['cashback_waiting']?></strong> paket için cashback ödemesi bekliyor (<?=h(format_currency($quotaSummary['cashback_pending_amount']))?>).</div>
+        <a class="btn btn-sm btn-outline-brand" href="billing.php#wallet">Hareketleri Gör</a>
+      </div>
+    <?php endif; ?>
+
+    <div class="card-lite p-4 mb-4">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h5 class="mb-0">Aktif Paketleriniz</h5>
+        <a class="btn btn-sm btn-outline-brand" href="billing.php">Paket Yönetimi</a>
+      </div>
+      <?php if (empty($quotaSummary['active'])): ?>
+        <p class="text-muted mb-0">Aktif paket bulunmuyor. Yeni paket satın almak için <a href="billing.php">Bakiye &amp; Paketler</a> sayfasını ziyaret edin.</p>
+      <?php else: ?>
+        <div class="table-responsive">
+          <table class="table align-middle">
+            <thead><tr><th>Paket</th><th>Kalan</th><th>Bitiş</th><th>Cashback</th></tr></thead>
+            <tbody>
+              <?php foreach ($quotaSummary['active'] as $package): ?>
+                <?php
+                  $quota = $package['event_quota'];
+                  $used = $package['events_used'];
+                  $remaining = $quota === null ? 'Sınırsız' : max(0, $quota - $used).' / '.$quota;
+                  $expiry = $package['expires_at'] ? date('d.m.Y', strtotime($package['expires_at'])) : 'Süresiz';
+                  $cashbackLabel = dealer_cashback_status_label($package['cashback_status']);
+                  $cashbackAmount = $package['cashback_amount'] > 0 ? format_currency($package['cashback_amount']) : '';
+                ?>
+                <tr>
+                  <td>
+                    <div class="fw-semibold"><?=h($package['package_name'])?></div>
+                    <?php if (!empty($package['package_description'])): ?>
+                      <div class="small text-muted"><?=h($package['package_description'])?></div>
+                    <?php endif; ?>
+                  </td>
+                  <td><?=h($remaining)?></td>
+                  <td><?=h($expiry)?></td>
+                  <td>
+                    <?=h($cashbackLabel)?>
+                    <?php if ($package['cashback_status'] === DEALER_CASHBACK_PENDING && $cashbackAmount): ?>
+                      <span class="text-muted small">• <?=h($cashbackAmount)?></span>
+                    <?php endif; ?>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php endif; ?>
+    </div>
 
   <?php if ($nextEvent): ?>
     <div class="card-lite p-4 mb-4">
@@ -147,7 +245,7 @@ $nextEvent = $upcoming[0] ?? null;
     </div>
   <?php endif; ?>
 
-  <div class="card-lite p-4 mb-4">
+    <div id="venues" class="card-lite p-4 mb-4">
       <div class="d-flex justify-content-between align-items-center mb-3">
         <h5 class="mb-0">Salonlarınız</h5>
         <a class="btn btn-sm btn-outline-brand" href="mailto:<?=h(MAIL_FROM ?? 'info@localhost')?>?subject=Bayi%20Salon%20Talebi">Yeni salon talep et</a>
@@ -177,31 +275,32 @@ $nextEvent = $upcoming[0] ?? null;
         </table>
       </div>
     <?php endif; ?>
-  </div>
+    </div>
 
-  <div class="card-lite p-4">
-    <h5 class="mb-3">Panel İpuçları</h5>
-    <div class="row g-3">
-      <div class="col-md-4">
-        <div class="p-3 border rounded-4 h-100">
-          <h6 class="fw-semibold">Kalıcı QR Yönetimi</h6>
-          <p class="text-muted small mb-0">Her salon için kalıcı QR kodlarını <strong>Etkinlikleri Yönet</strong> sayfasından görebilir, davetlilerinizle paylaşabilirsiniz.</p>
+    <div class="card-lite p-4">
+      <h5 class="mb-3">Panel İpuçları</h5>
+      <div class="row g-3">
+        <div class="col-md-4">
+          <div class="p-3 border rounded-4 h-100">
+            <h6 class="fw-semibold">Kalıcı QR Yönetimi</h6>
+            <p class="text-muted small mb-0">Her salon için kalıcı QR kodlarını <strong>Etkinlikleri Yönet</strong> sayfasından görüntüleyip davetlilerinizle paylaşabilirsiniz.</p>
+          </div>
         </div>
-      </div>
-      <div class="col-md-4">
-        <div class="p-3 border rounded-4 h-100">
-          <h6 class="fw-semibold">Etkinlik Kampanyaları</h6>
-          <p class="text-muted small mb-0">Yönetici ekibinin yayınladığı kampanyalar etkinlik panelinde otomatik görünür. Ek avantajlar için yöneticinizle iletişime geçin.</p>
+        <div class="col-md-4">
+          <div class="p-3 border rounded-4 h-100">
+            <h6 class="fw-semibold">Cari &amp; Paket Yönetimi</h6>
+            <p class="text-muted small mb-0"><strong>Bakiye &amp; Paketler</strong> alanından bakiyenizi takip edin, paket satın alın ve geçmiş hareketlerinizi görüntüleyin.</p>
+          </div>
         </div>
-      </div>
-      <div class="col-md-4">
-        <div class="p-3 border rounded-4 h-100">
-          <h6 class="fw-semibold">Destek</h6>
-          <p class="text-muted small mb-0">Sorularınız için <a href="mailto:<?=h(MAIL_FROM ?? 'destek@localhost')?>"><?=h(MAIL_FROM ?? 'destek@localhost')?></a> adresine yazabilirsiniz.</p>
+        <div class="col-md-4">
+          <div class="p-3 border rounded-4 h-100">
+            <h6 class="fw-semibold">Cashback Avantajı</h6>
+            <p class="text-muted small mb-0">Tekli paketlerinizde gerçekleşen satışlar için %50 cashback talebinizi aynı sayfadan takip edebilirsiniz.</p>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
+</main>
 </body>
 </html>

--- a/dealer/dashboard.php
+++ b/dealer/dashboard.php
@@ -16,6 +16,7 @@ if (!$dealer) {
 }
 
 dealer_refresh_session((int)$dealer['id']);
+$refCode = $dealer['code'] ?: dealer_ensure_identifier((int)$dealer['id']);
 
 $venues  = dealer_fetch_venues((int)$dealer['id']);
 $events  = dealer_allowed_events((int)$dealer['id']);
@@ -24,6 +25,7 @@ $creationStatus = dealer_event_creation_status($dealer);
 $canCreate = $creationStatus['allowed'];
 $quotaSummary = $creationStatus['summary'];
 $balance = dealer_get_balance((int)$dealer['id']);
+$totalCashback = dealer_total_cashback((int)$dealer['id']);
 $activeNav = 'dashboard';
 
 $totalVenues  = count($venues);
@@ -124,6 +126,7 @@ $nextEvent = $upcoming[0] ?? null;
             <p>Bayi panelinizde atanmış salonlarınızı yönetin, etkinliklerinizi takip edin ve <?=h(APP_NAME)?> ekibinin sunduğu kampanyalardan haberdar olun.</p>
             <div class="d-flex flex-wrap hero-actions mt-3">
               <span class="badge-soft">Lisans Bitiş: <?=h(dealer_license_label($dealer))?></span>
+              <span class="badge-soft">Referans Kodu: <?=h($refCode)?></span>
               <?php if ($warning): ?>
                 <span class="badge bg-warning-subtle text-warning-emphasis fw-semibold"><?=h($warning)?></span>
               <?php else: ?>
@@ -147,6 +150,11 @@ $nextEvent = $upcoming[0] ?? null;
               <h6>Bakiye</h6>
               <strong><?=h(format_currency($balance))?></strong>
               <span>Bakiye hareketlerini takip edin</span>
+            </div>
+            <div class="stat-card">
+              <h6>Web Cashback</h6>
+              <strong><?=h(format_currency($totalCashback))?></strong>
+              <span>Referans satışlarından toplam kazanç</span>
             </div>
             <?php
               $quotaLabel = $quotaSummary['has_unlimited'] ? 'Sınırsız' : (string)$quotaSummary['remaining_events'];
@@ -177,12 +185,13 @@ $nextEvent = $upcoming[0] ?? null;
       </div>
     <?php endif; ?>
 
-    <?php if ($quotaSummary['cashback_waiting'] > 0): ?>
-      <div class="alert alert-info d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
-        <div><strong><?=$quotaSummary['cashback_waiting']?></strong> paket için cashback ödemesi bekliyor (<?=h(format_currency($quotaSummary['cashback_pending_amount']))?>).</div>
-        <a class="btn btn-sm btn-outline-brand" href="billing.php#wallet">Hareketleri Gör</a>
+    <div class="alert alert-info d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
+      <div>
+        Web üzerinden gelen referans satışlarınız otomatik olarak bakiyenize <strong>%20 cashback</strong> olarak işlenir.
+        <?php if ($totalCashback > 0): ?>Bugüne kadar <strong><?=h(format_currency($totalCashback))?></strong> kazandınız.<?php endif; ?>
       </div>
-    <?php endif; ?>
+      <a class="btn btn-sm btn-outline-brand" href="billing.php#wallet">Hareketleri Gör</a>
+    </div>
 
     <div class="card-lite p-4 mb-4">
       <div class="d-flex justify-content-between align-items-center mb-3">

--- a/dealer/dashboard.php
+++ b/dealer/dashboard.php
@@ -17,27 +17,32 @@ if (!$dealer) {
 
 dealer_refresh_session((int)$dealer['id']);
 
-$action = $_POST['do'] ?? '';
-if ($action) {
-  csrf_or_die();
-  if ($action === 'assign_static') {
-    $eventId = (int)($_POST['event_id'] ?? 0);
-    if ($eventId > 0 && !dealer_event_belongs_to_dealer((int)$dealer['id'], $eventId)) {
-      flash('err', 'Bu etkinliği yönetme yetkiniz yok.');
-    } else {
-      dealer_set_code_target((int)$dealer['id'], DEALER_CODE_STATIC, $eventId > 0 ? $eventId : null);
-      flash('ok', 'Kalıcı QR yönlendirmesi güncellendi.');
-    }
-    redirect($_SERVER['PHP_SELF'].'#qr');
-  }
-}
-
-$codes   = dealer_sync_codes((int)$dealer['id']);
-$staticCode = $codes[DEALER_CODE_STATIC] ?? null;
 $venues  = dealer_fetch_venues((int)$dealer['id']);
 $events  = dealer_allowed_events((int)$dealer['id']);
 $warning = dealer_license_warning($dealer);
 $canCreate = dealer_can_manage_events($dealer);
+
+$totalVenues  = count($venues);
+$activeVenues = count(array_filter($venues, fn($v) => !empty($v['is_active'])));
+$totalEvents  = count($events);
+$today = new DateTimeImmutable('today');
+$upcoming = array_values(array_filter($events, function ($ev) use ($today) {
+  if (empty($ev['event_date'])) {
+    return false;
+  }
+  try {
+    $date = new DateTimeImmutable($ev['event_date']);
+  } catch (Exception $e) {
+    return false;
+  }
+  return $date >= $today;
+}));
+usort($upcoming, function ($a, $b) {
+  $da = $a['event_date'] ? strtotime($a['event_date']) : 0;
+  $db = $b['event_date'] ? strtotime($b['event_date']) : 0;
+  return $da <=> $db;
+});
+$nextEvent = $upcoming[0] ?? null;
 ?>
 <!doctype html>
 <html lang="tr">
@@ -47,10 +52,33 @@ $canCreate = dealer_can_manage_events($dealer);
 <title><?=h(APP_NAME)?> — Bayi Paneli</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <style>
-  body{background:linear-gradient(180deg,#f4f9fb,#fff) no-repeat;font-family:'Inter',sans-serif;}
-  .topbar{background:#fff;border-bottom:1px solid #e5e7eb;}
-  .card-lite{border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.08);}
-  .code-pill{font-family:'Fira Code',monospace;font-size:1.1rem;padding:.35rem .8rem;border-radius:10px;background:#f1f5f9;display:inline-block;}
+  :root{
+    --brand:#0ea5b5;
+    --brand-dark:#0b8692;
+    --bg:#f4f7fb;
+    --text:#0f172a;
+    --muted:#6b7280;
+  }
+  body{background:var(--bg);font-family:'Inter',sans-serif;color:var(--text);}
+  a{color:var(--brand);} a:hover{color:var(--brand-dark);}
+  .topbar{background:#fff;border-bottom:1px solid rgba(15,23,42,.05);box-shadow:0 10px 20px rgba(15,23,42,.04);}
+  .hero{padding:2.5rem 0;}
+  .hero h1{font-size:1.75rem;font-weight:700;margin-bottom:.5rem;}
+  .hero p{color:var(--muted);max-width:560px;}
+  .card-lite{border:1px solid rgba(15,23,42,.06);border-radius:18px;background:#fff;box-shadow:0 15px 35px rgba(15,23,42,.07);}
+  .stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1.2rem;}
+  .stat-card{padding:1.4rem;border-radius:16px;background:linear-gradient(145deg,#fff,rgba(14,165,181,.08));position:relative;overflow:hidden;}
+  .stat-card h6{font-size:.85rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:.35rem;}
+  .stat-card strong{font-size:1.8rem;display:block;}
+  .stat-card span{color:var(--muted);font-size:.85rem;}
+  .table thead th{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);}
+  .badge-soft{background:rgba(14,165,181,.12);color:var(--brand);border-radius:999px;padding:.35rem .75rem;font-weight:600;font-size:.8rem;}
+  .empty-state{padding:2.5rem;text-align:center;color:var(--muted);}
+  .btn-brand{background:var(--brand);border:none;color:#fff;border-radius:14px;padding:.65rem 1.4rem;font-weight:600;box-shadow:0 8px 18px rgba(14,165,181,.25);}
+  .btn-brand:hover{background:var(--brand-dark);color:#fff;}
+  .btn-outline-brand{background:#fff;border:1px solid rgba(14,165,181,.5);color:var(--brand);border-radius:14px;padding:.65rem 1.4rem;font-weight:600;}
+  .btn-outline-brand:hover{background:rgba(14,165,181,.08);color:var(--brand-dark);}
+  .btn-brand.btn-sm,.btn-outline-brand.btn-sm{padding:.45rem .9rem;border-radius:12px;font-size:.85rem;}
 </style>
 </head>
 <body>
@@ -66,68 +94,68 @@ $canCreate = dealer_can_manage_events($dealer);
 </nav>
 <div class="container py-4">
   <?php flash_box(); ?>
-  <div class="row g-4">
-    <div class="col-lg-4">
-      <div class="card-lite p-4 h-100">
-        <h5 class="mb-3">Lisans Durumu</h5>
-        <p class="mb-1"><strong>Bitiş:</strong> <?=h(dealer_license_label($dealer))?></p>
-        <p class="text-muted small">Durum: <?= dealer_has_valid_license($dealer) ? 'Geçerli' : 'Geçersiz' ?></p>
-        <?php if ($warning): ?>
-          <div class="alert alert-warning small mb-0"><?=h($warning)?></div>
-        <?php endif; ?>
-      </div>
-    </div>
-    <div class="col-lg-8">
-      <div class="card-lite p-4" id="qr">
-        <h5 class="mb-3">Kalıcı QR Kodunuz</h5>
-        <?php if (!$staticCode): ?>
-          <p class="text-muted mb-0">Kalıcı kod oluşturulamadı. Lütfen yönetici ile iletişime geçin.</p>
-        <?php else: ?>
-          <?php $staticUrl = BASE_URL.'/qr.php?code='.urlencode($staticCode['code']); ?>
-          <div class="row g-4 align-items-start">
-            <div class="col-md-6">
-              <div class="border rounded-3 p-3 h-100">
-                <div class="text-uppercase small text-muted fw-semibold mb-1">Kod</div>
-                <div class="code-pill mb-3"><?=h($staticCode['code'])?></div>
-                <p class="small text-muted mb-1">Bu kod sabittir ve tek bir kez atanmıştır.</p>
-                <p class="small text-muted mb-0"><a href="<?=h($staticUrl)?>" target="_blank">Kalıcı QR bağlantısını aç</a></p>
-              </div>
-            </div>
-            <div class="col-md-6">
-              <div class="border rounded-3 p-3 h-100">
-                <h6 class="fw-semibold mb-2">Yönlendirme</h6>
-                <p class="small text-muted">Kod okutulduğunda misafirler seçtiğiniz etkinliğe yönlendirilir.</p>
-                <form method="post" class="vstack gap-2">
-                  <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-                  <input type="hidden" name="do" value="assign_static">
-                  <label class="form-label small mb-1">Bağlı etkinlik</label>
-                  <select class="form-select form-select-sm" name="event_id">
-                    <option value="0">— Seçili değil —</option>
-                    <?php foreach ($events as $ev): ?>
-                      <?php
-                        $selected = ($staticCode['target_event_id'] ?? null) == $ev['id'] ? 'selected' : '';
-                        $dateLabel = $ev['event_date'] ? date('d.m.Y', strtotime($ev['event_date'])) : 'Tarihsiz';
-                      ?>
-                      <option value="<?= (int)$ev['id'] ?>" <?=$selected?>><?=h($dateLabel.' • '.$ev['title'])?></option>
-                    <?php endforeach; ?>
-                  </select>
-                  <button class="btn btn-sm btn-primary" type="submit">Yönlendirmeyi Kaydet</button>
-                </form>
-              </div>
-            </div>
+  <section class="hero">
+    <div class="card-lite p-4 p-lg-5">
+      <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-4">
+        <div>
+          <h1>Merhaba <?=h($dealer['name'])?> 👋</h1>
+          <p>Bayi panelinizde atanmış salonlarınızı yönetin, etkinliklerinizi takip edin ve <?=h(APP_NAME)?> ekibinin sunduğu kampanyalardan haberdar olun.</p>
+          <div class="d-flex flex-wrap gap-3 mt-3">
+            <span class="badge-soft">Lisans Bitiş: <?=h(dealer_license_label($dealer))?></span>
+            <?php if ($warning): ?>
+              <span class="badge bg-warning-subtle text-warning-emphasis fw-semibold"><?=h($warning)?></span>
+            <?php else: ?>
+              <span class="badge-soft">Durum: <?= dealer_has_valid_license($dealer) ? 'Geçerli' : 'Geçersiz' ?></span>
+            <?php endif; ?>
           </div>
-        <?php endif; ?>
+        </div>
+        <div class="stat-grid flex-grow-1">
+          <div class="stat-card">
+            <h6>Salon</h6>
+            <strong><?=$totalVenues?></strong>
+            <span><?=$activeVenues?> aktif</span>
+          </div>
+          <div class="stat-card">
+            <h6>Etkinlik</h6>
+            <strong><?=$totalEvents?></strong>
+            <span><?=count($upcoming)?> yaklaşan</span>
+          </div>
+          <div class="stat-card">
+            <h6>Son Giriş</h6>
+            <strong><?=h($dealer['last_login_at'] ? date('d.m.Y', strtotime($dealer['last_login_at'])) : '—')?></strong>
+            <span><?=h($dealer['last_login_at'] ? date('H:i', strtotime($dealer['last_login_at'])).' • '.APP_NAME : 'İlk girişinizi yapın')?></span>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
+  </section>
 
-  <div class="card-lite p-4 mt-4">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-      <h5 class="mb-0">Salonlarınız</h5>
-      <a class="btn btn-sm btn-outline-primary" href="mailto:<?=h(MAIL_FROM ?? 'info@localhost')?>?subject=Bayi%20Salon%20Talebi">Yeni salon talep et</a>
+  <?php if ($nextEvent): ?>
+    <div class="card-lite p-4 mb-4">
+      <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+        <div>
+          <h5 class="mb-1">Sıradaki Etkinliğiniz</h5>
+          <div class="text-muted"><?=h(date('d.m.Y', strtotime($nextEvent['event_date'] ?? 'now'))).' • '.h($nextEvent['title'] ?? 'Etkinlik')?></div>
+        </div>
+        <div class="d-flex gap-2">
+          <a class="btn btn-outline-brand" href="venue_events.php?venue_id=<?= (int)$nextEvent['venue_id'] ?>">Detayları Gör</a>
+          <?php if ($canCreate): ?>
+            <a class="btn btn-brand" href="venue_events.php?venue_id=<?= (int)$nextEvent['venue_id'] ?>#create">Yeni Etkinlik Oluştur</a>
+          <?php endif; ?>
+        </div>
+      </div>
     </div>
+  <?php endif; ?>
+
+  <div class="card-lite p-4 mb-4">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h5 class="mb-0">Salonlarınız</h5>
+        <a class="btn btn-sm btn-outline-brand" href="mailto:<?=h(MAIL_FROM ?? 'info@localhost')?>?subject=Bayi%20Salon%20Talebi">Yeni salon talep et</a>
+      </div>
     <?php if (!$venues): ?>
-      <p class="text-muted">Henüz size atanmış salon bulunmuyor. Lütfen yönetici ile iletişime geçin.</p>
+      <div class="empty-state">
+        Henüz size atanmış salon bulunmuyor. Lütfen yönetici ile iletişime geçin.
+      </div>
     <?php else: ?>
       <div class="table-responsive">
         <table class="table align-middle">
@@ -139,9 +167,9 @@ $canCreate = dealer_can_manage_events($dealer);
                   <div class="fw-semibold"><?=h($v['name'])?></div>
                   <div class="small text-muted">Slug: <?=h($v['slug'])?></div>
                 </td>
-                <td><?= $v['is_active'] ? 'Aktif' : 'Pasif' ?></td>
+                <td><?= $v['is_active'] ? '<span class="badge-soft">Aktif</span>' : '<span class="badge bg-secondary-subtle text-secondary-emphasis fw-semibold">Pasif</span>' ?></td>
                 <td class="text-end">
-                  <a class="btn btn-sm btn-primary" href="venue_events.php?venue_id=<?= (int)$v['id'] ?>">Etkinlikleri Yönet</a>
+                  <a class="btn btn-sm btn-brand" href="venue_events.php?venue_id=<?= (int)$v['id'] ?>">Etkinlikleri Yönet</a>
                 </td>
               </tr>
             <?php endforeach; ?>
@@ -149,6 +177,30 @@ $canCreate = dealer_can_manage_events($dealer);
         </table>
       </div>
     <?php endif; ?>
+  </div>
+
+  <div class="card-lite p-4">
+    <h5 class="mb-3">Panel İpuçları</h5>
+    <div class="row g-3">
+      <div class="col-md-4">
+        <div class="p-3 border rounded-4 h-100">
+          <h6 class="fw-semibold">Kalıcı QR Yönetimi</h6>
+          <p class="text-muted small mb-0">Her salon için kalıcı QR kodlarını <strong>Etkinlikleri Yönet</strong> sayfasından görebilir, davetlilerinizle paylaşabilirsiniz.</p>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="p-3 border rounded-4 h-100">
+          <h6 class="fw-semibold">Etkinlik Kampanyaları</h6>
+          <p class="text-muted small mb-0">Yönetici ekibinin yayınladığı kampanyalar etkinlik panelinde otomatik görünür. Ek avantajlar için yöneticinizle iletişime geçin.</p>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="p-3 border rounded-4 h-100">
+          <h6 class="fw-semibold">Destek</h6>
+          <p class="text-muted small mb-0">Sorularınız için <a href="mailto:<?=h(MAIL_FROM ?? 'destek@localhost')?>"><?=h(MAIL_FROM ?? 'destek@localhost')?></a> adresine yazabilirsiniz.</p>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 </body>

--- a/dealer/dashboard.php
+++ b/dealer/dashboard.php
@@ -4,6 +4,7 @@ require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/dealers.php';
 require_once __DIR__.'/../includes/dealer_auth.php';
+require_once __DIR__.'/partials/ui.php';
 
 install_schema();
 
@@ -32,7 +33,6 @@ $pendingCashbackAmount = 0;
 foreach ($cashbackPending as $row) {
   $pendingCashbackAmount += max(0, (int)$row['cashback_amount']);
 }
-$activeNav = 'dashboard';
 
 $totalVenues  = count($venues);
 $activeVenues = count(array_filter($venues, fn($v) => !empty($v['is_active'])));
@@ -55,267 +55,243 @@ usort($upcoming, function ($a, $b) {
   return $da <=> $db;
 });
 $nextEvent = $upcoming[0] ?? null;
-?>
-<!doctype html>
-<html lang="tr">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title><?=h(APP_NAME)?> — Bayi Paneli</title>
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+
+$licenseLabel = dealer_license_label($dealer);
+$quotaLabel = $quotaSummary['has_unlimited'] ? 'Sınırsız' : (string)$quotaSummary['remaining_events'];
+$quotaHint  = $quotaSummary['has_unlimited']
+  ? ($quotaSummary['unlimited_until'] ? 'Süre bitişi: '.date('d.m.Y', strtotime($quotaSummary['unlimited_until'])) : 'Süre sınırı yok')
+  : 'Kalan etkinlik hakkı';
+
+$pageStyles = <<<'CSS'
 <style>
-  :root{
-    --brand:#0ea5b5;
-    --brand-dark:#0b8692;
-    --bg:#f4f7fb;
-    --text:#0f172a;
-    --muted:#6b7280;
-  }
-  body{background:var(--bg);font-family:'Inter',sans-serif;color:var(--text);}
-  a{color:var(--brand);} a:hover{color:var(--brand-dark);}
-  .dealer-topnav{background:#fff;border-bottom:1px solid rgba(15,23,42,.08);box-shadow:0 12px 30px rgba(15,23,42,.06);}
-  .dealer-topnav .navbar-brand{font-weight:700;color:var(--text);}
-  .dealer-topnav .nav-link{color:var(--muted);font-weight:600;border-radius:12px;padding:.45rem .95rem;}
-  .dealer-topnav .nav-link:hover{color:var(--brand-dark);background:rgba(14,165,181,.08);}
-  .dealer-topnav .nav-link.active{color:var(--brand);background:rgba(14,165,181,.16);}
-  .dealer-topnav .badge-soft{background:rgba(14,165,181,.12);color:var(--brand-dark);border-radius:999px;padding:.3rem .85rem;font-weight:600;font-size:.85rem;}
-  .dealer-hero{padding:2.6rem 0 2rem;}
-  .dealer-hero h1{font-size:1.8rem;font-weight:700;margin-bottom:.6rem;}
-  .dealer-hero p{color:var(--muted);max-width:620px;}
-  .hero-actions{gap:.75rem;}
-  .card-lite{border:1px solid rgba(15,23,42,.06);border-radius:20px;background:#fff;box-shadow:0 18px 40px rgba(15,23,42,.07);}
+  .dashboard-badges{display:flex;flex-wrap:wrap;gap:.65rem;margin-bottom:1.25rem;}
+  .dashboard-badges .badge-soft{background:rgba(14,165,181,.12);color:#0b8b98;border-radius:999px;padding:.4rem .9rem;font-weight:600;font-size:.85rem;display:inline-flex;align-items:center;gap:.4rem;}
+  .dashboard-badges .badge-soft i{font-size:1rem;}
+  .card-lite{border:1px solid rgba(15,23,42,.05);border-radius:22px;background:#fff;box-shadow:0 24px 50px -34px rgba(15,23,42,.45);}
   .stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:1.2rem;}
-  .stat-card{padding:1.4rem;border-radius:16px;background:linear-gradient(145deg,#fff,rgba(14,165,181,.08));position:relative;overflow:hidden;}
-  .stat-card h6{font-size:.8rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:.35rem;}
+  .stat-card{padding:1.45rem;border-radius:18px;background:linear-gradient(150deg,#fff,rgba(14,165,181,.1));position:relative;overflow:hidden;}
+  .stat-card h6{font-size:.78rem;text-transform:uppercase;letter-spacing:.08em;color:#64748b;margin-bottom:.35rem;}
   .stat-card strong{font-size:1.7rem;display:block;}
-  .stat-card span{color:var(--muted);font-size:.82rem;}
-  .table thead th{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);}
-  .badge-soft{background:rgba(14,165,181,.12);color:var(--brand);border-radius:999px;padding:.35rem .75rem;font-weight:600;font-size:.8rem;}
-  .empty-state{padding:2.5rem;text-align:center;color:var(--muted);}
-  .btn-brand{background:var(--brand);border:none;color:#fff;border-radius:14px;padding:.65rem 1.4rem;font-weight:600;box-shadow:0 8px 18px rgba(14,165,181,.25);}
-  .btn-brand:hover{background:var(--brand-dark);color:#fff;}
-  .btn-outline-brand{background:#fff;border:1px solid rgba(14,165,181,.5);color:var(--brand);border-radius:14px;padding:.65rem 1.4rem;font-weight:600;}
-  .btn-outline-brand:hover{background:rgba(14,165,181,.08);color:var(--brand-dark);}
-  .btn-brand.btn-sm,.btn-outline-brand.btn-sm{padding:.45rem .9rem;border-radius:12px;font-size:.85rem;}
+  .stat-card span{color:#64748b;font-size:.82rem;}
+  .btn-brand{background:#0ea5b5;border:none;color:#fff;border-radius:14px;padding:.6rem 1.35rem;font-weight:600;box-shadow:0 12px 22px -14px rgba(14,165,181,.65);} 
+  .btn-brand:hover{background:#0b8b98;color:#fff;}
+  .btn-outline-brand{background:#fff;border:1px solid rgba(14,165,181,.45);color:#0ea5b5;border-radius:14px;padding:.6rem 1.35rem;font-weight:600;}
+  .btn-outline-brand:hover{background:rgba(14,165,181,.08);color:#0b8b98;}
+  .status-table{border-radius:22px;background:#fff;border:1px solid rgba(15,23,42,.06);padding:1.8rem;box-shadow:0 24px 50px -34px rgba(15,23,42,.4);}
+  .status-table h5{font-weight:700;margin-bottom:1.2rem;}
+  .status-table .empty{padding:2rem;text-align:center;color:#64748b;border:1px dashed rgba(148,163,184,.5);border-radius:16px;}
+  .timeline-card{border-radius:22px;background:#fff;border:1px solid rgba(15,23,42,.05);padding:1.9rem;box-shadow:0 24px 50px -36px rgba(15,23,42,.4);}
+  .timeline-card h5{font-weight:700;margin-bottom:1.2rem;}
+  .timeline-card .empty{padding:1.6rem;text-align:center;color:#64748b;border-radius:16px;border:1px dashed rgba(148,163,184,.45);}
+  .timeline{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:1rem;}
+  .timeline li{display:flex;gap:1rem;align-items:flex-start;}
+  .timeline .dot{width:38px;height:38px;border-radius:12px;background:linear-gradient(145deg,rgba(14,165,181,.2),rgba(14,165,181,.45));display:flex;align-items:center;justify-content:center;color:#0b8b98;font-weight:700;}
+  .timeline .content{flex:1;}
+  .timeline .content strong{display:block;font-weight:700;}
+  .timeline .content span{display:block;color:#64748b;font-size:.85rem;}
+  .info-card{border:1px solid rgba(148,163,184,.35);border-radius:18px;padding:1.3rem;background:linear-gradient(140deg,#fff,rgba(14,165,181,.06));height:100%;}
+  .info-card h6{font-weight:700;margin-bottom:.35rem;}
+  .info-card p{color:#64748b;font-size:.86rem;}
+  .badge-soft{background:rgba(14,165,181,.12);color:#0ea5b5;border-radius:999px;padding:.35rem .75rem;font-weight:600;font-size:.82rem;display:inline-flex;align-items:center;}
+  @media (max-width: 991px){
+    .status-table,.timeline-card{padding:1.4rem;}
+  }
 </style>
-</head>
-<body>
-<header class="dealer-header">
-  <nav class="dealer-topnav navbar navbar-expand-lg py-3">
-    <div class="container">
-      <a class="navbar-brand" href="dashboard.php"><?=h(APP_NAME)?> — Bayi Paneli</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#dealerNav" aria-controls="dealerNav" aria-expanded="false" aria-label="Menü">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="dealerNav">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          <li class="nav-item"><a class="nav-link<?= $activeNav === 'dashboard' ? ' active' : '' ?>" href="dashboard.php">Genel Bakış</a></li>
-          <li class="nav-item"><a class="nav-link<?= $activeNav === 'venues' ? ' active' : '' ?>" href="#venues">Salonlar</a></li>
-          <li class="nav-item"><a class="nav-link<?= $activeNav === 'billing' ? ' active' : '' ?>" href="billing.php">Bakiye & Paketler</a></li>
-        </ul>
-        <div class="d-flex align-items-center gap-3 mb-2 mb-lg-0">
-          <span class="badge-soft"><?=h($dealer['name'])?></span>
-          <a class="text-decoration-none fw-semibold" href="login.php?logout=1">Çıkış</a>
-        </div>
-      </div>
-    </div>
-  </nav>
-</header>
-<main class="dealer-main">
-  <div class="container py-4">
-    <?php flash_box(); ?>
-    <section class="dealer-hero">
-      <div class="card-lite p-4 p-lg-5">
-        <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-4">
-          <div>
-            <h1>Merhaba <?=h($dealer['name'])?> 👋</h1>
-            <p>Bayi panelinizde atanmış salonlarınızı yönetin, etkinliklerinizi takip edin ve <?=h(APP_NAME)?> ekibinin sunduğu kampanyalardan haberdar olun.</p>
-            <div class="d-flex flex-wrap hero-actions mt-3">
-              <span class="badge-soft">Lisans Bitiş: <?=h(dealer_license_label($dealer))?></span>
-              <span class="badge-soft">Referans Kodu: <?=h($refCode)?></span>
-              <?php if ($warning): ?>
-                <span class="badge bg-warning-subtle text-warning-emphasis fw-semibold"><?=h($warning)?></span>
-              <?php else: ?>
-                <span class="badge-soft">Durum: <?= dealer_has_valid_license($dealer) ? 'Geçerli' : 'Geçersiz' ?></span>
-              <?php endif; ?>
-              <a class="btn btn-brand btn-sm" href="billing.php">Bakiye & Paketler</a>
-            </div>
-          </div>
-          <div class="stat-grid flex-grow-1">
-            <div class="stat-card">
-              <h6>Salon</h6>
-              <strong><?=$totalVenues?></strong>
-              <span><?=$activeVenues?> aktif</span>
-            </div>
-            <div class="stat-card">
-              <h6>Etkinlik</h6>
-              <strong><?=$totalEvents?></strong>
-              <span><?=count($upcoming)?> yaklaşan</span>
-            </div>
-            <div class="stat-card">
-              <h6>Bakiye</h6>
-              <strong><?=h(format_currency($balance))?></strong>
-              <span>Bakiye hareketlerini takip edin</span>
-            </div>
-            <div class="stat-card">
-              <h6>Web Cashback</h6>
-              <strong><?=h(format_currency($totalCashback))?></strong>
-              <span>Referans satışlarından toplam kazanç</span>
-            </div>
-            <?php
-              $quotaLabel = $quotaSummary['has_unlimited'] ? 'Sınırsız' : (string)$quotaSummary['remaining_events'];
-              $quotaHint  = $quotaSummary['has_unlimited']
-                ? ($quotaSummary['unlimited_until'] ? 'Süre bitişi: '.date('d.m.Y', strtotime($quotaSummary['unlimited_until'])) : 'Süre sınırı yok')
-                : 'Kalan etkinlik hakkı';
-            ?>
-            <div class="stat-card">
-              <h6>Etkinlik Hakkı</h6>
-              <strong><?=h($quotaLabel)?></strong>
-              <span><?=h($quotaHint)?></span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
+CSS;
 
-    <?php if (!$creationStatus['allowed'] && $creationStatus['reason'] && $quotaSummary['has_credit']): ?>
-      <div class="alert alert-warning mb-4">
-        <?=h($creationStatus['reason'])?>
-      </div>
-    <?php endif; ?>
-
-    <?php if (!$quotaSummary['has_credit']): ?>
-      <div class="alert alert-warning d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
-        <div>Yeni etkinlik oluşturmak için aktif bir paket veya bakiye yüklemesine ihtiyacınız var.</div>
-        <a class="btn btn-sm btn-outline-brand" href="billing.php">Paketleri Gör</a>
-      </div>
-    <?php endif; ?>
-
-    <div class="alert alert-info d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
-      <div>
-        Web üzerinden gelen referans satışlarınız <strong>%20 cashback</strong> kazandırır ve finans onayı sonrasında bakiyenize eklenir.
-        <?php if ($pendingCashbackCount): ?>Şu anda onay bekleyen <strong><?=h($pendingCashbackCount)?></strong> ödeme var (<?=h(format_currency($pendingCashbackAmount))?>).<?php elseif ($totalCashback > 0): ?>Bugüne kadar <strong><?=h(format_currency($totalCashback))?></strong> kazandınız.<?php endif; ?>
-      </div>
-      <a class="btn btn-sm btn-outline-brand" href="billing.php#wallet">Hareketleri Gör</a>
-    </div>
-
-    <div class="card-lite p-4 mb-4">
-      <div class="d-flex justify-content-between align-items-center mb-3">
-        <h5 class="mb-0">Aktif Paketleriniz</h5>
-        <a class="btn btn-sm btn-outline-brand" href="billing.php">Paket Yönetimi</a>
-      </div>
-      <?php if (empty($quotaSummary['active'])): ?>
-        <p class="text-muted mb-0">Aktif paket bulunmuyor. Yeni paket satın almak için <a href="billing.php">Bakiye &amp; Paketler</a> sayfasını ziyaret edin.</p>
-      <?php else: ?>
-        <div class="table-responsive">
-          <table class="table align-middle">
-            <thead><tr><th>Paket</th><th>Kalan</th><th>Bitiş</th><th>Cashback</th></tr></thead>
-            <tbody>
-              <?php foreach ($quotaSummary['active'] as $package): ?>
-                <?php
-                  $quota = $package['event_quota'];
-                  $used = $package['events_used'];
-                  $remaining = $quota === null ? 'Sınırsız' : max(0, $quota - $used).' / '.$quota;
-                  $expiry = $package['expires_at'] ? date('d.m.Y', strtotime($package['expires_at'])) : 'Süresiz';
-                  $cashbackLabel = dealer_cashback_status_label($package['cashback_status']);
-                  $cashbackAmount = $package['cashback_amount'] > 0 ? format_currency($package['cashback_amount']) : '';
-                ?>
-                <tr>
-                  <td>
-                    <div class="fw-semibold"><?=h($package['package_name'])?></div>
-                    <?php if (!empty($package['package_description'])): ?>
-                      <div class="small text-muted"><?=h($package['package_description'])?></div>
-                    <?php endif; ?>
-                  </td>
-                  <td><?=h($remaining)?></td>
-                  <td><?=h($expiry)?></td>
-                  <td>
-                    <?=h($cashbackLabel)?>
-                    <?php if ($package['cashback_status'] === DEALER_CASHBACK_PENDING && $cashbackAmount): ?>
-                      <span class="text-muted small">• <?=h($cashbackAmount)?></span>
-                    <?php endif; ?>
-                  </td>
-                </tr>
-              <?php endforeach; ?>
-            </tbody>
-          </table>
-        </div>
-      <?php endif; ?>
-    </div>
-
-  <?php if ($nextEvent): ?>
-    <div class="card-lite p-4 mb-4">
-      <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
-        <div>
-          <h5 class="mb-1">Sıradaki Etkinliğiniz</h5>
-          <div class="text-muted"><?=h(date('d.m.Y', strtotime($nextEvent['event_date'] ?? 'now'))).' • '.h($nextEvent['title'] ?? 'Etkinlik')?></div>
-        </div>
-        <div class="d-flex gap-2">
-          <a class="btn btn-outline-brand" href="venue_events.php?venue_id=<?= (int)$nextEvent['venue_id'] ?>">Detayları Gör</a>
-          <?php if ($canCreate): ?>
-            <a class="btn btn-brand" href="venue_events.php?venue_id=<?= (int)$nextEvent['venue_id'] ?>#create">Yeni Etkinlik Oluştur</a>
+dealer_layout_start('dashboard', [
+  'page_title'   => APP_NAME.' — Bayi Paneli',
+  'title'        => 'Merhaba '.$dealer['name'].' 👋',
+  'subtitle'     => 'Atanmış salonlarınızı yönetin, etkinlikleri takip edin ve BİKARE avantajlarını keşfedin.',
+  'dealer'       => $dealer,
+  'venues'       => $venues,
+  'balance_text' => format_currency($balance),
+  'license_text' => $licenseLabel,
+  'ref_code'     => $refCode,
+  'extra_head'   => $pageStyles,
+]);
+?>
+<section class="mb-5">
+  <div class="card-lite p-4 p-lg-5">
+    <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-4">
+      <div class="flex-grow-1">
+        <div class="dashboard-badges">
+          <span class="badge-soft"><i class="bi bi-shield-check"></i>Lisans: <?=h($licenseLabel)?></span>
+          <span class="badge-soft"><i class="bi bi-upc-scan"></i>Kod: <?=h($refCode)?></span>
+          <?php if ($warning): ?>
+            <span class="badge bg-warning-subtle text-warning-emphasis fw-semibold"><i class="bi bi-exclamation-triangle"></i><?=h($warning)?></span>
+          <?php else: ?>
+            <span class="badge-soft"><i class="bi bi-check-circle"></i><?= dealer_has_valid_license($dealer) ? 'Lisansınız aktif' : 'Lisans süreniz dolmak üzere' ?></span>
           <?php endif; ?>
+          <a class="btn btn-brand btn-sm" href="billing.php"><i class="bi bi-wallet2 me-1"></i>Bakiye &amp; Paketler</a>
         </div>
+        <p class="text-muted mb-0">Panelinizi kullanarak etkinliklerinizi yönetebilir, QR kodlarınıza erişebilir ve müşterilerinize anında bilgi gönderebilirsiniz.</p>
       </div>
-    </div>
-  <?php endif; ?>
-
-    <div id="venues" class="card-lite p-4 mb-4">
-      <div class="d-flex justify-content-between align-items-center mb-3">
-        <h5 class="mb-0">Salonlarınız</h5>
-        <a class="btn btn-sm btn-outline-brand" href="mailto:<?=h(MAIL_FROM ?? 'info@localhost')?>?subject=Bayi%20Salon%20Talebi">Yeni salon talep et</a>
-      </div>
-    <?php if (!$venues): ?>
-      <div class="empty-state">
-        Henüz size atanmış salon bulunmuyor. Lütfen yönetici ile iletişime geçin.
-      </div>
-    <?php else: ?>
-      <div class="table-responsive">
-        <table class="table align-middle">
-          <thead><tr><th>Salon</th><th>Durum</th><th></th></tr></thead>
-          <tbody>
-            <?php foreach ($venues as $v): ?>
-              <tr>
-                <td>
-                  <div class="fw-semibold"><?=h($v['name'])?></div>
-                  <div class="small text-muted">Slug: <?=h($v['slug'])?></div>
-                </td>
-                <td><?= $v['is_active'] ? '<span class="badge-soft">Aktif</span>' : '<span class="badge bg-secondary-subtle text-secondary-emphasis fw-semibold">Pasif</span>' ?></td>
-                <td class="text-end">
-                  <a class="btn btn-sm btn-brand" href="venue_events.php?venue_id=<?= (int)$v['id'] ?>">Etkinlikleri Yönet</a>
-                </td>
-              </tr>
-            <?php endforeach; ?>
-          </tbody>
-        </table>
-      </div>
-    <?php endif; ?>
-    </div>
-
-    <div class="card-lite p-4">
-      <h5 class="mb-3">Panel İpuçları</h5>
-      <div class="row g-3">
-        <div class="col-md-4">
-          <div class="p-3 border rounded-4 h-100">
-            <h6 class="fw-semibold">Kalıcı QR Yönetimi</h6>
-            <p class="text-muted small mb-0">Her salon için kalıcı QR kodlarını <strong>Etkinlikleri Yönet</strong> sayfasından görüntüleyip davetlilerinizle paylaşabilirsiniz.</p>
-          </div>
+      <div class="stat-grid flex-grow-1">
+        <div class="stat-card">
+          <h6>Salon</h6>
+          <strong><?=$totalVenues?></strong>
+          <span><?=$activeVenues?> aktif</span>
         </div>
-        <div class="col-md-4">
-          <div class="p-3 border rounded-4 h-100">
-            <h6 class="fw-semibold">Cari &amp; Paket Yönetimi</h6>
-            <p class="text-muted small mb-0"><strong>Bakiye &amp; Paketler</strong> alanından bakiyenizi takip edin, paket satın alın ve geçmiş hareketlerinizi görüntüleyin.</p>
-          </div>
+        <div class="stat-card">
+          <h6>Etkinlik</h6>
+          <strong><?=$totalEvents?></strong>
+          <span><?=count($upcoming)?> yaklaşan</span>
         </div>
-        <div class="col-md-4">
-          <div class="p-3 border rounded-4 h-100">
-            <h6 class="fw-semibold">Cashback Avantajı</h6>
-            <p class="text-muted small mb-0">Tekli paketlerinizde gerçekleşen satışlar için %50 cashback talebinizi aynı sayfadan takip edebilirsiniz.</p>
-          </div>
+        <div class="stat-card">
+          <h6>Bakiye</h6>
+          <strong><?=h(format_currency($balance))?></strong>
+          <span>Finansal hareketlerinizi takip edin</span>
+        </div>
+        <div class="stat-card">
+          <h6>Cashback</h6>
+          <strong><?=h(format_currency($totalCashback))?></strong>
+          <span><?=$pendingCashbackCount?> bekleyen onay</span>
+        </div>
+        <div class="stat-card">
+          <h6>Etkinlik Hakkı</h6>
+          <strong><?=h($quotaLabel)?></strong>
+          <span><?=h($quotaHint)?></span>
         </div>
       </div>
     </div>
   </div>
-</main>
-</body>
-</html>
+</section>
+
+<?php if (!$creationStatus['allowed'] && $creationStatus['reason'] && $quotaSummary['has_credit']): ?>
+  <div class="alert alert-warning mb-4">
+    <?=h($creationStatus['reason'])?>
+  </div>
+<?php endif; ?>
+
+<?php if (!$quotaSummary['has_credit']): ?>
+  <div class="alert alert-warning d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
+    <div>Yeni etkinlik oluşturmak için aktif bir paket veya bakiye yüklemesine ihtiyacınız var.</div>
+    <a class="btn btn-sm btn-outline-brand" href="billing.php">Paketleri Gör</a>
+  </div>
+<?php endif; ?>
+
+<div class="alert alert-info d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
+  <div>
+    Web üzerinden gelen referans satışlarınız <strong>%20 cashback</strong> kazandırır ve finans onayı sonrasında bakiyenize eklenir.
+    <?php if ($pendingCashbackCount): ?>Şu anda onay bekleyen <strong><?=h($pendingCashbackCount)?></strong> ödeme var (<?=h(format_currency($pendingCashbackAmount))?>).<?php elseif ($totalCashback > 0): ?>Bugüne kadar <strong><?=h(format_currency($totalCashback))?></strong> kazandınız.<?php endif; ?>
+  </div>
+  <a class="btn btn-sm btn-outline-brand" href="billing.php#wallet">Hareketleri Gör</a>
+</div>
+
+<div class="card-lite p-4 mb-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h5 class="mb-0">Aktif Paketleriniz</h5>
+    <a class="btn btn-sm btn-outline-brand" href="billing.php">Paket Yönetimi</a>
+  </div>
+  <?php if (empty($quotaSummary['active'])): ?>
+    <p class="text-muted mb-0">Aktif paket bulunmuyor. Yeni paket satın almak için <a href="billing.php">Bakiye &amp; Paketler</a> sayfasını ziyaret edin.</p>
+  <?php else: ?>
+    <div class="table-responsive">
+      <table class="table align-middle">
+        <thead><tr><th>Paket</th><th>Kalan</th><th>Bitiş</th><th>Cashback</th></tr></thead>
+        <tbody>
+          <?php foreach ($quotaSummary['active'] as $package): ?>
+            <?php
+              $quota = $package['event_quota'];
+              $used = $package['events_used'];
+              $remaining = $quota === null ? 'Sınırsız' : max(0, $quota - $used).' / '.$quota;
+              $expiry = $package['expires_at'] ? date('d.m.Y', strtotime($package['expires_at'])) : 'Süresiz';
+              $cashbackLabel = dealer_cashback_status_label($package['cashback_status']);
+              $cashbackAmount = $package['cashback_amount'] > 0 ? format_currency($package['cashback_amount']) : '';
+            ?>
+            <tr>
+              <td>
+                <div class="fw-semibold"><?=h($package['package_name'])?></div>
+                <?php if (!empty($package['package_description'])): ?>
+                  <div class="small text-muted"><?=h($package['package_description'])?></div>
+                <?php endif; ?>
+              </td>
+              <td><?=h($remaining)?></td>
+              <td><?=h($expiry)?></td>
+              <td>
+                <?=h($cashbackLabel)?>
+                <?php if ($package['cashback_status'] === DEALER_CASHBACK_PENDING && $cashbackAmount): ?>
+                  <span class="text-muted small">• <?=h($cashbackAmount)?></span>
+                <?php endif; ?>
+              </td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  <?php endif; ?>
+</div>
+
+<?php if ($nextEvent): ?>
+  <div class="card-lite p-4 mb-4">
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+      <div>
+        <h5 class="mb-1">Sıradaki Etkinliğiniz</h5>
+        <div class="text-muted"><?=h(date('d.m.Y', strtotime($nextEvent['event_date'] ?? 'now'))).' • '.h($nextEvent['title'] ?? 'Etkinlik')?></div>
+      </div>
+      <div class="d-flex gap-2">
+        <a class="btn btn-outline-brand" href="venue_events.php?venue_id=<?= (int)$nextEvent['venue_id'] ?>">Detayları Gör</a>
+        <?php if ($canCreate): ?>
+          <a class="btn btn-brand" href="venue_events.php?venue_id=<?= (int)$nextEvent['venue_id'] ?>#create">Yeni Etkinlik Oluştur</a>
+        <?php endif; ?>
+      </div>
+    </div>
+  </div>
+<?php endif; ?>
+
+<div id="venues" class="card-lite p-4 mb-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h5 class="mb-0">Salonlarınız</h5>
+    <a class="btn btn-sm btn-outline-brand" href="mailto:<?=h(MAIL_FROM ?? 'info@localhost')?>?subject=Bayi%20Salon%20Talebi">Yeni salon talep et</a>
+  </div>
+  <?php if (!$venues): ?>
+    <div class="status-table empty">Henüz size atanmış salon bulunmuyor. Lütfen yönetici ile iletişime geçin.</div>
+  <?php else: ?>
+    <div class="table-responsive">
+      <table class="table align-middle">
+        <thead><tr><th>Salon</th><th>Durum</th><th></th></tr></thead>
+        <tbody>
+          <?php foreach ($venues as $v): ?>
+            <tr>
+              <td>
+                <div class="fw-semibold"><?=h($v['name'])?></div>
+                <div class="small text-muted">Slug: <?=h($v['slug'])?></div>
+              </td>
+              <td><?= $v['is_active'] ? '<span class="badge-soft">Aktif</span>' : '<span class="badge bg-secondary-subtle text-secondary-emphasis fw-semibold">Pasif</span>' ?></td>
+              <td class="text-end">
+                <a class="btn btn-sm btn-brand" href="venue_events.php?venue_id=<?= (int)$v['id'] ?>">Etkinlikleri Yönet</a>
+              </td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  <?php endif; ?>
+</div>
+
+<div class="card-lite p-4 mb-4">
+  <h5 class="mb-3">Panel İpuçları</h5>
+  <div class="row g-3">
+    <div class="col-md-4">
+      <div class="info-card">
+        <h6>Kalıcı QR Yönetimi</h6>
+        <p class="mb-0">Her salon için kalıcı QR kodlarını <strong>Etkinlikleri Yönet</strong> sayfasından görüntüleyip davetlilerinizle paylaşabilirsiniz.</p>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="info-card">
+        <h6>Cari &amp; Paket Takibi</h6>
+        <p class="mb-0"><strong>Bakiye &amp; Paketler</strong> alanından bakiyenizi takip edin, paket satın alın ve geçmiş hareketlerinizi inceleyin.</p>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="info-card">
+        <h6>Cashback Avantajı</h6>
+        <p class="mb-0">Tekli paketlerinizde gerçekleşen satışlar için %50 cashback talebinizi aynı sayfadan takip edebilirsiniz.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<?php dealer_layout_end();

--- a/dealer/dashboard.php
+++ b/dealer/dashboard.php
@@ -26,6 +26,12 @@ $canCreate = $creationStatus['allowed'];
 $quotaSummary = $creationStatus['summary'];
 $balance = dealer_get_balance((int)$dealer['id']);
 $totalCashback = dealer_total_cashback((int)$dealer['id']);
+$cashbackPending = dealer_cashback_candidates((int)$dealer['id'], DEALER_CASHBACK_PENDING);
+$pendingCashbackCount = count($cashbackPending);
+$pendingCashbackAmount = 0;
+foreach ($cashbackPending as $row) {
+  $pendingCashbackAmount += max(0, (int)$row['cashback_amount']);
+}
 $activeNav = 'dashboard';
 
 $totalVenues  = count($venues);
@@ -187,8 +193,8 @@ $nextEvent = $upcoming[0] ?? null;
 
     <div class="alert alert-info d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
       <div>
-        Web üzerinden gelen referans satışlarınız otomatik olarak bakiyenize <strong>%20 cashback</strong> olarak işlenir.
-        <?php if ($totalCashback > 0): ?>Bugüne kadar <strong><?=h(format_currency($totalCashback))?></strong> kazandınız.<?php endif; ?>
+        Web üzerinden gelen referans satışlarınız <strong>%20 cashback</strong> kazandırır ve finans onayı sonrasında bakiyenize eklenir.
+        <?php if ($pendingCashbackCount): ?>Şu anda onay bekleyen <strong><?=h($pendingCashbackCount)?></strong> ödeme var (<?=h(format_currency($pendingCashbackAmount))?>).<?php elseif ($totalCashback > 0): ?>Bugüne kadar <strong><?=h(format_currency($totalCashback))?></strong> kazandınız.<?php endif; ?>
       </div>
       <a class="btn btn-sm btn-outline-brand" href="billing.php#wallet">Hareketleri Gör</a>
     </div>

--- a/dealer/dashboard.php
+++ b/dealer/dashboard.php
@@ -1,0 +1,167 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+
+install_schema();
+
+dealer_require_login();
+$sessionDealer = dealer_user();
+$dealer = dealer_get((int)$sessionDealer['id']);
+if (!$dealer) {
+  dealer_logout();
+  redirect('login.php');
+}
+
+dealer_refresh_session((int)$dealer['id']);
+
+$action = $_POST['do'] ?? '';
+if ($action) {
+  csrf_or_die();
+  if ($action === 'set_code') {
+    $type = $_POST['type'] ?? DEALER_CODE_STATIC;
+    $eventId = (int)($_POST['event_id'] ?? 0);
+    if ($eventId > 0 && !dealer_event_belongs_to_dealer((int)$dealer['id'], $eventId)) {
+      flash('err', 'Bu etkinliği yönetme yetkiniz yok.');
+    } else {
+      dealer_set_code_target((int)$dealer['id'], $type, $eventId > 0 ? $eventId : null);
+      flash('ok', 'Kod bağlantısı güncellendi.');
+    }
+    redirect($_SERVER['PHP_SELF']);
+  }
+  if ($action === 'refresh_trial') {
+    dealer_regenerate_code((int)$dealer['id'], DEALER_CODE_TRIAL);
+    flash('ok', 'Deneme kodu yenilendi.');
+    redirect($_SERVER['PHP_SELF']);
+  }
+}
+
+$codes   = dealer_sync_codes((int)$dealer['id']);
+$venues  = dealer_fetch_venues((int)$dealer['id']);
+$events  = dealer_allowed_events((int)$dealer['id']);
+$warning = dealer_license_warning($dealer);
+$canCreate = dealer_can_manage_events($dealer);
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Paneli</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:linear-gradient(180deg,#f4f9fb,#fff) no-repeat;font-family:'Inter',sans-serif;}
+  .topbar{background:#fff;border-bottom:1px solid #e5e7eb;}
+  .card-lite{border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.08);}
+  .code-pill{font-family:'Fira Code',monospace;font-size:1.1rem;padding:.35rem .8rem;border-radius:10px;background:#f1f5f9;display:inline-block;}
+</style>
+</head>
+<body>
+<nav class="topbar py-3">
+  <div class="container d-flex justify-content-between align-items-center">
+    <span class="fw-semibold"><?=h(APP_NAME)?> — Bayi Paneli</span>
+    <div class="d-flex align-items-center gap-3 small">
+      <span><?=h($dealer['name'])?></span>
+      <span>•</span>
+      <a class="text-decoration-none" href="login.php?logout=1">Çıkış</a>
+    </div>
+  </div>
+</nav>
+<div class="container py-4">
+  <?php flash_box(); ?>
+  <div class="row g-4">
+    <div class="col-lg-4">
+      <div class="card-lite p-4 h-100">
+        <h5 class="mb-3">Lisans Durumu</h5>
+        <p class="mb-1"><strong>Bitiş:</strong> <?=h(dealer_license_label($dealer))?></p>
+        <p class="text-muted small">Durum: <?= dealer_has_valid_license($dealer) ? 'Geçerli' : 'Geçersiz' ?></p>
+        <?php if ($warning): ?>
+          <div class="alert alert-warning small mb-0"><?=h($warning)?></div>
+        <?php endif; ?>
+      </div>
+    </div>
+    <div class="col-lg-8">
+      <div class="card-lite p-4">
+        <h5 class="mb-3">Kalıcı & Deneme Kodları</h5>
+        <div class="row g-4">
+          <?php foreach ([DEALER_CODE_STATIC=>'Kalıcı Kod', DEALER_CODE_TRIAL=>'Deneme Kodu'] as $type=>$label):
+            $code = $codes[$type] ?? null;
+            $url = $code ? BASE_URL.'/qr.php?code='.urlencode($code['code']) : '';
+          ?>
+          <div class="col-md-6">
+            <div class="border rounded-3 p-3 h-100">
+              <div class="d-flex justify-content-between align-items-center mb-2">
+                <h6 class="mb-0"><?=h($label)?></h6>
+                <?php if ($type === DEALER_CODE_TRIAL): ?>
+                  <form method="post" class="m-0">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="refresh_trial">
+                    <button class="btn btn-sm btn-outline-secondary">Yenile</button>
+                  </form>
+                <?php endif; ?>
+              </div>
+              <?php if ($code): ?>
+                <div class="code-pill mb-2"><?=h($code['code'])?></div>
+                <p class="small text-muted mb-2"><a href="<?=h($url)?>" target="_blank">QR bağlantısı</a></p>
+                <form method="post" class="vstack gap-2">
+                  <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                  <input type="hidden" name="do" value="set_code">
+                  <input type="hidden" name="type" value="<?=h($type)?>">
+                  <label class="form-label small mb-1">Bağlı düğün</label>
+                  <select class="form-select form-select-sm" name="event_id">
+                    <option value="0">— Seçili değil —</option>
+                    <?php foreach ($events as $ev): ?>
+                      <?php
+                        $selected = ($code['target_event_id'] ?? null) == $ev['id'] ? 'selected' : '';
+                        $dateLabel = $ev['event_date'] ? date('d.m.Y', strtotime($ev['event_date'])) : 'Tarihsiz';
+                      ?>
+                      <option value="<?= (int)$ev['id'] ?>" <?=$selected?>><?=h($dateLabel.' • '.$ev['title'])?></option>
+                    <?php endforeach; ?>
+                  </select>
+                  <button class="btn btn-sm btn-primary" type="submit">Kaydet</button>
+                </form>
+              <?php else: ?>
+                <p class="text-muted small">Kod oluşturulamadı.</p>
+              <?php endif; ?>
+            </div>
+          </div>
+          <?php endforeach; ?>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card-lite p-4 mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h5 class="mb-0">Salonlarınız</h5>
+      <a class="btn btn-sm btn-outline-primary" href="mailto:<?=h(MAIL_FROM ?? 'info@localhost')?>?subject=Bayi%20Salon%20Talebi">Yeni salon talep et</a>
+    </div>
+    <?php if (!$venues): ?>
+      <p class="text-muted">Henüz size atanmış salon bulunmuyor. Lütfen yönetici ile iletişime geçin.</p>
+    <?php else: ?>
+      <div class="table-responsive">
+        <table class="table align-middle">
+          <thead><tr><th>Salon</th><th>Durum</th><th></th></tr></thead>
+          <tbody>
+            <?php foreach ($venues as $v): ?>
+              <tr>
+                <td>
+                  <div class="fw-semibold"><?=h($v['name'])?></div>
+                  <div class="small text-muted">Slug: <?=h($v['slug'])?></div>
+                </td>
+                <td><?= $v['is_active'] ? 'Aktif' : 'Pasif' ?></td>
+                <td class="text-end">
+                  <a class="btn btn-sm btn-primary" href="venue_events.php?venue_id=<?= (int)$v['id'] ?>">Düğünleri Yönet</a>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php endif; ?>
+  </div>
+</div>
+</body>
+</html>

--- a/dealer/login.php
+++ b/dealer/login.php
@@ -1,0 +1,63 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+require_once __DIR__.'/../includes/dealers.php';
+
+install_schema();
+
+if (isset($_GET['logout'])) {
+  dealer_logout();
+  flash('ok', 'Oturum kapatıldı.');
+}
+
+if (dealer_user()) {
+  redirect('dashboard.php');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $email = trim($_POST['email'] ?? '');
+  $pass  = (string)($_POST['password'] ?? '');
+  if (dealer_login($email, $pass)) {
+    $next = $_GET['next'] ?? 'dashboard.php';
+    redirect($next);
+  } else {
+    flash('err', 'Giriş başarısız. Bilgilerinizi kontrol edin.');
+  }
+}
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — Bayi Girişi</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:#f4f6fb;}
+  .login-card{max-width:420px;margin:80px auto;padding:32px;border-radius:16px;background:#fff;box-shadow:0 12px 40px rgba(15,23,42,.12);}
+</style>
+</head>
+<body>
+<div class="login-card">
+  <h2 class="h4 mb-3 text-center">Bayi Paneli</h2>
+  <p class="text-muted small text-center mb-4">Bayi kodlarınızı ve düğünlerinizi buradan yönetin.</p>
+  <?php flash_box(); ?>
+  <form method="post" class="vstack gap-3">
+    <div>
+      <label class="form-label">E-posta</label>
+      <input type="email" name="email" class="form-control" required>
+    </div>
+    <div>
+      <label class="form-label">Şifre</label>
+      <input type="password" name="password" class="form-control" required>
+    </div>
+    <button class="btn btn-primary w-100" type="submit">Giriş Yap</button>
+  </form>
+  <div class="text-center mt-3">
+    <a class="small" href="apply.php">Bayi olmak için başvurun</a>
+  </div>
+</div>
+</body>
+</html>

--- a/dealer/login.php
+++ b/dealer/login.php
@@ -30,34 +30,82 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <!doctype html>
 <html lang="tr">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title><?=h(APP_NAME)?> — Bayi Girişi</title>
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<style>
-  body{background:#f4f6fb;}
-  .login-card{max-width:420px;margin:80px auto;padding:32px;border-radius:16px;background:#fff;box-shadow:0 12px 40px rgba(15,23,42,.12);}
-</style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title><?=h(APP_NAME)?> — Bayi Girişi</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    :root{ --brand:#0ea5b5; --brand-dark:#0b8b98; --ink:#0f172a; --muted:#5f6c7b; }
+    *{box-sizing:border-box;}
+    body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:2.5rem;background:radial-gradient(circle at 20% 20%,rgba(14,165,181,.18),rgba(14,165,181,.04) 60%,#f8fafc);font-family:'Inter','Segoe UI',system-ui,-apple-system,sans-serif;color:var(--ink);}
+    .auth-shell{width:100%;max-width:1100px;background:#fff;border-radius:30px;box-shadow:0 48px 120px -60px rgba(15,23,42,.55);display:flex;overflow:hidden;border:1px solid rgba(148,163,184,.18);}
+    .auth-visual{flex:1.05;position:relative;padding:3.2rem;background:linear-gradient(140deg,rgba(15,118,110,.92),rgba(14,165,181,.75)),url('https://images.unsplash.com/photo-1530023367847-a683933f4177?auto=format&fit=crop&w=1200&q=80') center/cover;color:#fff;display:flex;flex-direction:column;justify-content:space-between;}
+    .auth-visual::after{content:"";position:absolute;inset:0;background:linear-gradient(155deg,rgba(12,74,110,.25),rgba(15,23,42,.45));mix-blend-mode:soft-light;}
+    .auth-visual > *{position:relative;z-index:1;}
+    .badge{display:inline-flex;align-items:center;gap:.6rem;padding:.45rem 1.2rem;border-radius:999px;background:rgba(255,255,255,.18);font-weight:600;letter-spacing:.08em;text-transform:uppercase;font-size:.78rem;}
+    .visual-title{font-size:2.1rem;font-weight:800;line-height:1.2;margin:1.6rem 0 1rem;max-width:420px;}
+    .visual-text{font-size:1.02rem;line-height:1.7;color:rgba(255,255,255,.86);max-width:440px;}
+    .feature-list{list-style:none;padding:0;margin:1.8rem 0 0;display:flex;flex-direction:column;gap:1rem;}
+    .feature-list li{display:flex;align-items:flex-start;gap:.75rem;font-weight:600;color:rgba(255,255,255,.9);}
+    .feature-list span{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:50%;background:rgba(255,255,255,.18);font-size:1rem;}
+    .visual-footer{font-size:.84rem;color:rgba(255,255,255,.75);max-width:340px;margin-top:2.8rem;}
+    .auth-form{flex:.95;padding:3rem 3.2rem;display:flex;flex-direction:column;justify-content:center;gap:1.8rem;}
+    .brand{font-weight:800;font-size:1.7rem;letter-spacing:.18rem;margin-bottom:.2rem;}
+    .brand span{display:block;font-size:.95rem;font-weight:600;color:var(--muted);margin-top:.35rem;letter-spacing:0;}
+    .form-note{color:var(--muted);font-size:.94rem;line-height:1.6;}
+    .form-control{border-radius:14px;border:1px solid rgba(148,163,184,.32);padding:.75rem 1rem;font-size:1rem;}
+    .form-control:focus{border-color:var(--brand);box-shadow:0 0 0 .25rem rgba(14,165,181,.18);}
+    .btn-brand{background:var(--brand);color:#fff;border:none;border-radius:14px;padding:.85rem 1rem;font-weight:700;font-size:1rem;transition:transform .2s ease,box-shadow .2s ease;background-image:linear-gradient(135deg,#0ea5b5,#0b8b98);}
+    .btn-brand:hover{transform:translateY(-1px);box-shadow:0 18px 32px -20px rgba(14,165,181,.6);color:#fff;}
+    .apply-box{display:flex;align-items:center;justify-content:space-between;gap:1rem;padding:1.1rem 1.4rem;border-radius:16px;background:#f1fbfc;border:1px solid rgba(14,165,181,.16);}
+    .apply-box strong{color:var(--ink);}
+    .apply-link{font-weight:700;color:var(--brand);text-decoration:none;}
+    .apply-link:hover{text-decoration:underline;color:var(--brand-dark);}
+    .alert{border-radius:14px;font-weight:500;}
+    @media(max-width:992px){body{padding:1.5rem;} .auth-shell{flex-direction:column;} .auth-visual{padding:2.6rem;} .auth-form{padding:2.4rem;}}
+    @media(max-width:576px){.auth-form{padding:2rem;} .visual-title{font-size:1.7rem;}}
+  </style>
 </head>
 <body>
-<div class="login-card">
-  <h2 class="h4 mb-3 text-center">Bayi Paneli</h2>
-  <p class="text-muted small text-center mb-4">Bayi kodlarınızı ve düğünlerinizi buradan yönetin.</p>
-  <?php flash_box(); ?>
-  <form method="post" class="vstack gap-3">
-    <div>
-      <label class="form-label">E-posta</label>
-      <input type="email" name="email" class="form-control" required>
-    </div>
-    <div>
-      <label class="form-label">Şifre</label>
-      <input type="password" name="password" class="form-control" required>
-    </div>
-    <button class="btn btn-primary w-100" type="submit">Giriş Yap</button>
-  </form>
-  <div class="text-center mt-3">
-    <a class="small" href="apply.php">Bayi olmak için başvurun</a>
+  <div class="auth-shell">
+    <aside class="auth-visual">
+      <div>
+        <span class="badge">Bayi Platformu</span>
+        <h1 class="visual-title">Yerel iş ortaklıklarını BİKARE ile büyütün.</h1>
+        <p class="visual-text">Etkinlik sahiplerine değer katan salonlar ve ajanslar, BİKARE bayi paneli sayesinde QR yönetiminden kampanya yayınlarına kadar tüm süreci uçtan uca takip eder.</p>
+        <ul class="feature-list">
+          <li><span>✓</span>Etkinlik kredilerinizi ve cari bakiyenizi tek bakışta görün</li>
+          <li><span>✓</span>Salonlarınızdaki tüm etkinlikleri yönetin ve QR paylaşımlarını üretin</li>
+          <li><span>✓</span>Yeni paketler satın alarak kapasitenizi dakikalar içinde artırın</li>
+        </ul>
+      </div>
+      <p class="visual-footer">Zerosoft güvencesiyle geliştirilen BİKARE, bayiler için sürdürülebilir bir gelir modeli sunar.</p>
+    </aside>
+    <section class="auth-form">
+      <div>
+        <div class="brand">BİKARE <span>Bayi Paneli</span></div>
+        <p class="form-note">Bayi kodunuz ve size özel şifrenizle giriş yapın. Panel üzerinden etkinlik oluşturabilir, müşterilerinizin yüklemelerini takip edebilir ve finansal hareketlerinizi yönetebilirsiniz.</p>
+      </div>
+      <?php flash_box(); ?>
+      <form method="post" class="vstack gap-3">
+        <div>
+          <label class="form-label">E-posta</label>
+          <input type="email" name="email" class="form-control" required placeholder="ornek@bikarebayi.com">
+        </div>
+        <div>
+          <label class="form-label">Şifre</label>
+          <input type="password" name="password" class="form-control" required placeholder="Şifrenizi yazın">
+        </div>
+        <button class="btn-brand" type="submit">Bayi Paneline Giriş Yap</button>
+      </form>
+      <div class="apply-box">
+        <div>
+          <strong>Bayi ağımıza katılmak ister misiniz?</strong>
+          <div class="text-muted small">Başvuru formunu doldurun, ekibimiz en kısa sürede sizi arayarak detayları paylaşsın.</div>
+        </div>
+        <a class="apply-link" href="apply.php">Başvuru Formu →</a>
+      </div>
+    </section>
   </div>
-</div>
 </body>
 </html>

--- a/dealer/partials/ui.php
+++ b/dealer/partials/ui.php
@@ -1,0 +1,480 @@
+<?php
+if (!function_exists('dealer_base_styles')) {
+  function dealer_base_styles(): string {
+    return <<<'CSS'
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+      @import url('https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css');
+
+      :root {
+        --dealer-brand:#0ea5b5;
+        --dealer-brand-dark:#0b8b98;
+        --dealer-ink:#0f172a;
+        --dealer-muted:#64748b;
+        --dealer-bg:#eef2f9;
+        --dealer-surface:#ffffff;
+        --dealer-sidebar:#0ea5b5;
+        --dealer-sidebar-accent:#0b8b98;
+      }
+
+      body.dealer-body {
+        background:var(--dealer-bg);
+        color:var(--dealer-ink);
+        min-height:100vh;
+        font-family:'Inter','Segoe UI',system-ui,-apple-system,sans-serif;
+        margin:0;
+      }
+
+      .dealer-app {
+        min-height:100vh;
+        display:flex;
+        background:var(--dealer-bg);
+      }
+
+      .dealer-sidebar {
+        width:280px;
+        background:linear-gradient(165deg,var(--dealer-sidebar) 0%,var(--dealer-sidebar-accent) 95%);
+        color:#f0fdfd;
+        display:flex;
+        flex-direction:column;
+        padding:28px 22px 32px;
+        position:relative;
+        z-index:1030;
+        transition:transform .3s ease,width .3s ease,padding .3s ease;
+      }
+
+      .dealer-sidebar .sidebar-brand {
+        display:flex;
+        align-items:center;
+        justify-content:space-between;
+        gap:12px;
+        margin-bottom:2.2rem;
+      }
+
+      .dealer-sidebar .sidebar-brand .brand-mark {
+        display:flex;
+        align-items:center;
+        gap:12px;
+      }
+
+      .dealer-sidebar .sidebar-brand .brand-mark span {
+        width:40px;
+        height:40px;
+        border-radius:12px;
+        background:rgba(255,255,255,.16);
+        display:inline-flex;
+        align-items:center;
+        justify-content:center;
+        font-weight:700;
+        font-size:1.05rem;
+      }
+
+      .dealer-sidebar .sidebar-brand .brand-mark strong {
+        font-size:1.05rem;
+        letter-spacing:.3px;
+      }
+
+      .dealer-sidebar .sidebar-toggle-min {
+        border:none;
+        background:rgba(255,255,255,.14);
+        color:#fff;
+        width:38px;
+        height:38px;
+        border-radius:12px;
+        display:inline-flex;
+        align-items:center;
+        justify-content:center;
+      }
+
+      .dealer-sidebar .sidebar-summary {
+        border-radius:16px;
+        background:rgba(255,255,255,.12);
+        padding:16px;
+        margin-bottom:1.8rem;
+        box-shadow:0 18px 30px -24px rgba(0,0,0,.6);
+      }
+
+      .dealer-sidebar .sidebar-summary strong {
+        display:block;
+        font-size:1rem;
+        margin-bottom:.15rem;
+      }
+
+      .dealer-sidebar .sidebar-summary span {
+        display:block;
+        font-size:.9rem;
+        color:rgba(255,255,255,.75);
+      }
+
+      .dealer-sidebar .sidebar-summary .balance {
+        margin-top:1rem;
+        padding:10px 12px;
+        border-radius:14px;
+        background:rgba(255,255,255,.18);
+        display:flex;
+        align-items:center;
+        gap:8px;
+        font-weight:600;
+      }
+
+      .dealer-sidebar .sidebar-summary .balance i {
+        font-size:1.1rem;
+      }
+
+      .dealer-sidebar .sidebar-nav {
+        display:flex;
+        flex-direction:column;
+        gap:8px;
+      }
+
+      .dealer-sidebar .sidebar-heading {
+        font-size:.75rem;
+        text-transform:uppercase;
+        letter-spacing:.12em;
+        color:rgba(255,255,255,.7);
+        margin-top:1.4rem;
+        margin-bottom:.4rem;
+      }
+
+      .dealer-sidebar .sidebar-link {
+        display:flex;
+        align-items:center;
+        gap:12px;
+        padding:10px 12px;
+        border-radius:12px;
+        color:rgba(255,255,255,.82);
+        font-weight:500;
+        text-decoration:none;
+        transition:all .2s ease;
+      }
+
+      .dealer-sidebar .sidebar-link i {
+        font-size:1.05rem;
+      }
+
+      .dealer-sidebar .sidebar-link:hover,
+      .dealer-sidebar .sidebar-link:focus {
+        color:#fff;
+        background:rgba(255,255,255,.14);
+        text-decoration:none;
+      }
+
+      .dealer-sidebar .sidebar-link.active {
+        background:rgba(255,255,255,.24);
+        color:#fff;
+        box-shadow:0 16px 34px -26px rgba(0,0,0,.5);
+      }
+
+      .dealer-sidebar .sidebar-footer {
+        margin-top:auto;
+        padding:14px 16px;
+        border-radius:14px;
+        background:rgba(255,255,255,.16);
+        font-size:.82rem;
+        line-height:1.45;
+      }
+
+      .dealer-workspace {
+        flex:1;
+        display:flex;
+        flex-direction:column;
+        position:relative;
+      }
+
+      .dealer-toolbar {
+        display:flex;
+        align-items:center;
+        justify-content:space-between;
+        gap:16px;
+        padding:22px 32px 18px;
+      }
+
+      .dealer-toolbar .toolbar-left {
+        display:flex;
+        align-items:center;
+        gap:16px;
+        flex:1;
+      }
+
+      .dealer-toolbar .sidebar-toggle {
+        border:none;
+        background:#fff;
+        color:var(--dealer-ink);
+        border-radius:12px;
+        width:46px;
+        height:46px;
+        display:inline-flex;
+        align-items:center;
+        justify-content:center;
+        box-shadow:0 10px 25px -15px rgba(15,23,42,.35);
+      }
+
+      .dealer-toolbar .toolbar-pill {
+        background:#fff;
+        border-radius:14px;
+        padding:10px 16px;
+        display:flex;
+        align-items:center;
+        gap:10px;
+        box-shadow:0 18px 40px -24px rgba(15,23,42,.45);
+        font-weight:500;
+        color:var(--dealer-muted);
+      }
+
+      .dealer-toolbar .toolbar-right {
+        display:flex;
+        align-items:center;
+        gap:14px;
+      }
+
+      .dealer-toolbar .toolbar-user {
+        display:flex;
+        align-items:center;
+        gap:10px;
+        background:#fff;
+        border-radius:16px;
+        padding:10px 14px;
+        box-shadow:0 22px 45px -32px rgba(15,23,42,.4);
+      }
+
+      .dealer-toolbar .toolbar-user .avatar {
+        width:40px;
+        height:40px;
+        border-radius:12px;
+        background:linear-gradient(145deg,rgba(14,165,181,.28),rgba(14,165,181,.6));
+        display:flex;
+        align-items:center;
+        justify-content:center;
+        font-weight:700;
+        color:var(--dealer-ink);
+      }
+
+      .dealer-toolbar .toolbar-user span {
+        display:flex;
+        flex-direction:column;
+        line-height:1.2;
+      }
+
+      .dealer-toolbar .toolbar-user span strong {
+        font-size:.95rem;
+      }
+
+      .dealer-toolbar .toolbar-user span small {
+        color:var(--dealer-muted);
+        font-size:.78rem;
+      }
+
+      .dealer-hero {
+        padding:0 32px 12px;
+      }
+
+      .dealer-hero-card {
+        border-radius:24px;
+        background:linear-gradient(130deg,#fff 0%,rgba(14,165,181,.08) 100%);
+        padding:32px;
+        box-shadow:0 25px 60px -40px rgba(15,23,42,.55);
+      }
+
+      .dealer-hero-card h1 {
+        font-size:1.85rem;
+        margin-bottom:.4rem;
+      }
+
+      .dealer-hero-card p {
+        color:var(--dealer-muted);
+        max-width:720px;
+      }
+
+      .dealer-main {
+        flex:1;
+      }
+
+      .dealer-main-inner {
+        padding:0 32px 48px;
+      }
+
+      .dealer-main-inner .flash-box {
+        margin-bottom:1.4rem;
+      }
+
+      body.sidebar-collapsed .dealer-sidebar {
+        width:96px;
+        padding:28px 16px;
+      }
+
+      body.sidebar-collapsed .dealer-sidebar .brand-mark strong,
+      body.sidebar-collapsed .dealer-sidebar .sidebar-summary span,
+      body.sidebar-collapsed .dealer-sidebar .sidebar-summary .balance span,
+      body.sidebar-collapsed .dealer-sidebar .sidebar-summary strong,
+      body.sidebar-collapsed .dealer-sidebar .sidebar-heading,
+      body.sidebar-collapsed .dealer-sidebar .sidebar-link .sidebar-label,
+      body.sidebar-collapsed .dealer-sidebar .sidebar-footer {
+        display:none;
+      }
+
+      body.sidebar-collapsed .dealer-sidebar .sidebar-link {
+        justify-content:center;
+        padding:12px;
+      }
+
+      body.sidebar-open .dealer-sidebar {
+        transform:translateX(0);
+      }
+
+      @media (max-width: 991px) {
+        .dealer-sidebar {
+          position:fixed;
+          top:0;
+          bottom:0;
+          transform:translateX(-100%);
+          box-shadow:24px 0 60px -34px rgba(15,23,42,.55);
+        }
+        body.sidebar-open {
+          overflow:hidden;
+        }
+        body.sidebar-open .dealer-sidebar {
+          transform:translateX(0);
+        }
+        .dealer-main-inner {
+          padding:0 20px 32px;
+        }
+        .dealer-toolbar {
+          padding:20px 20px 16px;
+        }
+        .dealer-hero {
+          padding:0 20px 8px;
+        }
+        .dealer-hero-card {
+          padding:24px;
+        }
+      }
+    </style>
+CSS;
+  }
+
+  function dealer_layout_start(string $active = '', array $options = []): void {
+    $pageTitle   = $options['page_title'] ?? (APP_NAME.' — Bayi Paneli');
+    $heroTitle   = $options['title'] ?? '';
+    $heroSubtitle= $options['subtitle'] ?? '';
+    $dealer      = $options['dealer'] ?? null;
+    $venues      = $options['venues'] ?? [];
+    $activeVenue = $options['active_venue_id'] ?? null;
+    $balanceText = $options['balance_text'] ?? null;
+    $licenseText = $options['license_text'] ?? null;
+    $refCode     = $options['ref_code'] ?? null;
+    $extraHead   = $options['extra_head'] ?? '';
+
+    $dealerName  = $dealer['name'] ?? ($dealer['email'] ?? 'Bayi');
+    $initial     = $dealerName ? mb_strtoupper(mb_substr($dealerName, 0, 1, 'UTF-8'), 'UTF-8') : 'B';
+
+    echo '<!doctype html>';
+    echo '<html lang="tr">';
+    echo '<head>';
+    echo '<meta charset="utf-8">';
+    echo '<meta name="viewport" content="width=device-width, initial-scale=1">';
+    echo '<title>'.h($pageTitle).'</title>';
+    echo '<link rel="preconnect" href="https://fonts.googleapis.com">';
+    echo '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>';
+    echo '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">';
+    echo dealer_base_styles();
+    if ($extraHead) {
+      echo $extraHead;
+    }
+    echo '</head>';
+    echo '<body class="dealer-body">';
+    echo '<div class="dealer-app">';
+    echo '<aside class="dealer-sidebar" id="dealerSidebar">';
+    echo '<div class="sidebar-brand">';
+    echo '<div class="brand-mark"><span>'.mb_strtoupper(mb_substr(APP_NAME, 0, 2, 'UTF-8')).'</span><strong>'.h(APP_NAME).' Bayi</strong></div>';
+    echo '<button class="dealer-sidebar-toggle dealer-sidebar-min sidebar-toggle-min" type="button" data-sidebar-toggle aria-label="Menüyü daralt"><i class="bi bi-chevron-double-left"></i></button>';
+    echo '</div>';
+
+    if ($dealer) {
+      echo '<div class="sidebar-summary">';
+      echo '<strong>'.h($dealerName).'</strong>';
+      if ($refCode) {
+        echo '<span>Referans Kodu: '.h($refCode).'</span>';
+      }
+      if ($licenseText) {
+        echo '<span>Lisans: '.h($licenseText).'</span>';
+      }
+      if ($balanceText !== null) {
+        echo '<div class="balance"><i class="bi bi-wallet2"></i><span>'.h($balanceText).'</span></div>';
+      }
+      echo '</div>';
+    }
+
+    $links = [
+      'dashboard' => ['href' => BASE_URL.'/dealer/dashboard.php', 'label' => 'Genel Bakış', 'icon' => 'bi-speedometer2'],
+      'billing'   => ['href' => BASE_URL.'/dealer/billing.php', 'label' => 'Bakiye & Paketler', 'icon' => 'bi-wallet2'],
+    ];
+
+    echo '<nav class="sidebar-nav">';
+    foreach ($links as $key => $link) {
+      $cls = 'sidebar-link'.($active === $key ? ' active' : '');
+      echo '<a class="'.$cls.'" href="'.h($link['href']).'"><i class="bi '.$link['icon'].'"></i><span class="sidebar-label">'.h($link['label']).'</span></a>';
+    }
+    if ($venues) {
+      echo '<div class="sidebar-heading">Salonlarım</div>';
+      foreach ($venues as $venue) {
+        $vid = (int)($venue['id'] ?? 0);
+        $cls = 'sidebar-link'.($activeVenue && $vid === (int)$activeVenue ? ' active' : '');
+        echo '<a class="'.$cls.'" href="'.h(BASE_URL.'/dealer/venue_events.php?venue_id='.$vid).'"><i class="bi bi-building"></i><span class="sidebar-label">'.h($venue['name'] ?? 'Salon').'</span></a>';
+      }
+    }
+    echo '</nav>';
+
+    $supportEmail = defined('SITE_SUPPORT_EMAIL') && SITE_SUPPORT_EMAIL ? SITE_SUPPORT_EMAIL : 'destek@zerosoft.com.tr';
+    echo '<div class="sidebar-footer">';
+    echo '<strong>Destek</strong> Sorularınız için <a class="text-white text-decoration-none fw-semibold" href="mailto:'.h($supportEmail).'">'.h($supportEmail).'</a> adresine ulaşabilirsiniz.';
+    echo '</div>';
+
+    echo '</aside>';
+
+    echo '<div class="dealer-workspace">';
+    echo '<header class="dealer-toolbar">';
+    echo '<div class="toolbar-left">';
+    echo '<button class="sidebar-toggle" type="button" data-sidebar-toggle aria-label="Menüyü aç/kapat"><i class="bi bi-list"></i></button>';
+    echo '<div class="toolbar-pill"><i class="bi bi-calendar3"></i>'.date('d.m.Y').'</div>';
+    echo '</div>';
+    echo '<div class="toolbar-right">';
+    if ($balanceText !== null) {
+      echo '<div class="toolbar-pill"><i class="bi bi-cash-stack"></i>'.$balanceText.'</div>';
+    }
+    echo '<div class="toolbar-user">';
+    echo '<div class="avatar">'.h($initial).'</div>';
+    echo '<span><strong>'.h($dealerName).'</strong><small>Bayi Yetkilisi</small></span>';
+    echo '<a class="ms-1 text-decoration-none text-danger" href="'.h(BASE_URL.'/dealer/login.php?logout=1').'" title="Çıkış Yap"><i class="bi bi-box-arrow-right"></i></a>';
+    echo '</div>';
+    echo '</div>';
+    echo '</header>';
+
+    if ($heroTitle !== '') {
+      echo '<section class="dealer-hero">';
+      echo '<div class="dealer-hero-card">';
+      echo '<h1>'.h($heroTitle).'</h1>';
+      if ($heroSubtitle !== '') {
+        echo '<p>'.h($heroSubtitle).'</p>';
+      }
+      echo '</div>';
+      echo '</section>';
+    }
+
+    echo '<main class="dealer-main">';
+    echo '<div class="dealer-main-inner">';
+    if (function_exists('flash_box')) {
+      flash_box();
+    }
+  }
+
+  function dealer_layout_end(): void {
+    echo '</div>';
+    echo '</main>';
+    echo '</div>';
+    echo '</div>';
+    echo '<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>';
+    echo '<script>(function(){var body=document.body;var sidebar=document.getElementById("dealerSidebar");var collapseBtn=sidebar?sidebar.querySelector(".dealer-sidebar-min"):null;var collapseIcon=collapseBtn?collapseBtn.querySelector("i"):null;var mql=window.matchMedia("(max-width: 991px)");var key="dealerSidebarCollapsed";function isMobile(){return mql.matches;}function updateIcon(state){if(!collapseIcon)return;if(state){collapseIcon.classList.remove("bi-chevron-double-left");collapseIcon.classList.add("bi-chevron-double-right");}else{collapseIcon.classList.add("bi-chevron-double-left");collapseIcon.classList.remove("bi-chevron-double-right");}}function setCollapsed(state){if(state){body.classList.add("sidebar-collapsed");localStorage.setItem(key,"1");}else{body.classList.remove("sidebar-collapsed");localStorage.removeItem(key);}updateIcon(state);}function toggle(){if(isMobile()){body.classList.toggle("sidebar-open");return;}setCollapsed(!body.classList.contains("sidebar-collapsed"));}document.querySelectorAll("[data-sidebar-toggle]").forEach(function(btn){btn.addEventListener("click",function(ev){ev.preventDefault();toggle();});});document.addEventListener("click",function(ev){if(!body.classList.contains("sidebar-open"))return;if(sidebar && sidebar.contains(ev.target))return;var toggleBtn=ev.target.closest("[data-sidebar-toggle]");if(toggleBtn)return;body.classList.remove("sidebar-open");});function applyStored(){if(isMobile()){body.classList.remove("sidebar-collapsed");updateIcon(false);return;}var stored=localStorage.getItem(key)==="1";setCollapsed(stored);}applyStored();if(mql.addEventListener){mql.addEventListener("change",function(){applyStored();body.classList.remove("sidebar-open");});}else if(mql.addListener){mql.addListener(function(){applyStored();body.classList.remove("sidebar-open");});}})();</script>';
+    echo '</body>';
+    echo '</html>';
+  }
+}

--- a/dealer/paytr_fail.php
+++ b/dealer/paytr_fail.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+
+$sessionDealer = dealer_user();
+$loggedIn = (bool)$sessionDealer;
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ödeme Başarısız — <?=h(APP_NAME)?></title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:#fff5f5;color:#111827;font-family:'Inter','Segoe UI',system-ui,sans-serif;min-height:100vh;display:grid;place-items:center;padding:24px;}
+  .card-lite{max-width:520px;width:100%;background:#fff;border-radius:20px;padding:32px;border:1px solid rgba(248,113,113,.35);box-shadow:0 30px 60px -38px rgba(220,38,38,.55);text-align:center;}
+  .icon{width:64px;height:64px;border-radius:999px;background:rgba(248,113,113,.15);display:grid;place-items:center;margin:0 auto 16px;}
+  .icon svg{width:32px;height:32px;color:#ef4444;}
+  .btn-brand{background:#ef4444;border:none;color:#fff;border-radius:14px;padding:.65rem 1.4rem;font-weight:600;}
+  .btn-brand:hover{background:#dc2626;color:#fff;}
+  .muted{color:#6b7280;}
+</style>
+</head>
+<body>
+  <div class="card-lite">
+    <div class="icon">
+      <svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="11" stroke="currentColor" stroke-width="2"/><path d="M12 7v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><circle cx="12" cy="16" r="1.5" fill="currentColor"/></svg>
+    </div>
+    <h3 class="fw-bold mb-2">Ödeme Tamamlanamadı</h3>
+    <p class="muted mb-4">Kart provizyonu sırasında bir sorun oluştu. Lütfen kart bilgilerinizi kontrol edip tekrar deneyin. Sorun devam ederse yöneticinizle iletişime geçebilirsiniz.</p>
+    <div class="d-flex gap-2 justify-content-center flex-wrap">
+      <?php if ($loggedIn): ?>
+        <a class="btn btn-brand" href="billing.php#topup">Tekrar Dene</a>
+      <?php else: ?>
+        <a class="btn btn-brand" href="login.php">Bayi Paneline Dön</a>
+      <?php endif; ?>
+    </div>
+  </div>
+</body>
+</html>

--- a/dealer/paytr_ok.php
+++ b/dealer/paytr_ok.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+
+$sessionDealer = dealer_user();
+$loggedIn = (bool)$sessionDealer;
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ödeme Alındı — <?=h(APP_NAME)?></title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:#f5f7fb;color:#0f172a;font-family:'Inter','Segoe UI',system-ui,sans-serif;min-height:100vh;display:grid;place-items:center;padding:24px;}
+  .card-lite{max-width:520px;width:100%;background:#fff;border-radius:20px;padding:32px;border:1px solid rgba(148,163,184,.2);box-shadow:0 30px 60px -35px rgba(15,23,42,.55);text-align:center;}
+  .icon{width:64px;height:64px;border-radius:999px;background:rgba(14,165,181,.15);display:grid;place-items:center;margin:0 auto 16px;}
+  .icon svg{width:32px;height:32px;color:#0ea5b5;}
+  .btn-brand{background:#0ea5b5;border:none;color:#fff;border-radius:14px;padding:.65rem 1.4rem;font-weight:600;}
+  .btn-brand:hover{background:#0b8b98;color:#fff;}
+  .muted{color:#64748b;}
+</style>
+</head>
+<body>
+  <div class="card-lite">
+    <div class="icon">
+      <svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="11" stroke="currentColor" stroke-width="2"/><path d="M7.5 12.5l3 3 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    </div>
+    <h3 class="fw-bold mb-2">Ödeme Talebiniz Alındı</h3>
+    <p class="muted mb-4">Kart işleminiz PayTR tarafından başarıyla alındı. Finans ekibimiz kısa süre içinde onaylayarak bakiyenize yansıtacaktır.</p>
+    <div class="d-flex gap-2 justify-content-center flex-wrap">
+      <?php if ($loggedIn): ?>
+        <a class="btn btn-brand" href="billing.php#topup">Bakiye Ekranına Dön</a>
+      <?php else: ?>
+        <a class="btn btn-brand" href="login.php">Bayi Paneline Giriş Yap</a>
+      <?php endif; ?>
+    </div>
+  </div>
+</body>
+</html>

--- a/dealer/topup_paytr.php
+++ b/dealer/topup_paytr.php
@@ -1,0 +1,173 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+
+install_schema();
+
+dealer_require_login();
+$sessionDealer = dealer_user();
+$dealerId = (int)($sessionDealer['id'] ?? 0);
+if ($dealerId <= 0) {
+  redirect('login.php');
+}
+
+dealer_refresh_session($dealerId);
+$topupId = (int)($_GET['topup_id'] ?? 0);
+if ($topupId <= 0) {
+  flash('err', 'Geçersiz yükleme talebi.');
+  redirect('billing.php#topup');
+}
+$topup = dealer_topup_get($topupId);
+if (!$topup || (int)$topup['dealer_id'] !== $dealerId) {
+  flash('err', 'Yükleme talebi bulunamadı.');
+  redirect('billing.php#topup');
+}
+$status = $topup['status'];
+if ($status === DEALER_TOPUP_STATUS_CANCELLED) {
+  flash('err', 'Bu yükleme talebi iptal edildi.');
+  redirect('billing.php#topup');
+}
+if ($status === DEALER_TOPUP_STATUS_COMPLETED) {
+  flash('ok', 'Yükleme zaten tamamlanmış.');
+  redirect('billing.php#topup');
+}
+if ($status === DEALER_TOPUP_STATUS_AWAITING_REVIEW) {
+  flash('ok', 'Ödeme alındı, yönetici onayı bekleniyor.');
+  redirect('billing.php#topup');
+}
+$token = $topup['paytr_token'] ?? null;
+if (!$token) {
+  flash('err', 'Ödeme formu hazırlanamadı. Lütfen yeni bir talep oluşturun.');
+  redirect('billing.php#topup');
+}
+$amountTL = format_currency($topup['amount_cents']);
+$createdAt = $topup['created_at'] ?? null;
+$createdLabel = $createdAt ? date('d.m.Y H:i', strtotime($createdAt)) : date('d.m.Y H:i');
+$reference = $topup['merchant_oid'] ?: '—';
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h(APP_NAME)?> — PayTR Ödeme</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<script src="https://www.paytr.com/js/iframeResizer.min.js"></script>
+<style>
+  :root{
+    --brand:#0ea5b5;
+    --brand-dark:#0b8b98;
+    --ink:#0f172a;
+    --muted:#64748b;
+    --soft:#f1f7fb;
+  }
+  body{background:var(--soft);color:var(--ink);font-family:'Inter','Segoe UI',system-ui,sans-serif;min-height:100vh;}
+  a{color:var(--brand);} a:hover{color:var(--brand-dark);}
+  .dealer-topnav{background:#fff;border-bottom:1px solid rgba(148,163,184,.22);box-shadow:0 12px 30px rgba(15,23,42,.05);}
+  .dealer-topnav .navbar-brand{font-weight:700;color:var(--ink);}
+  .dealer-topnav .nav-link{color:var(--muted);font-weight:600;border-radius:12px;padding:.45rem .95rem;}
+  .dealer-topnav .nav-link:hover{color:var(--brand-dark);background:rgba(14,165,181,.1);}
+  .dealer-topnav .nav-link.active{color:var(--brand);background:rgba(14,165,181,.18);}
+  .dealer-topnav .badge-soft{background:rgba(14,165,181,.12);color:var(--brand-dark);border-radius:999px;padding:.3rem .85rem;font-weight:600;font-size:.85rem;}
+  .payment-hero{padding:2.4rem 0 1.8rem;}
+  .card-lite{border-radius:20px;background:#fff;border:1px solid rgba(148,163,184,.16);box-shadow:0 22px 45px -28px rgba(15,23,42,.45);}
+  .meta-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;}
+  .meta-card{padding:1.25rem;border-radius:16px;background:linear-gradient(150deg,#fff,rgba(14,165,181,.08));}
+  .meta-card h6{font-size:.8rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:.35rem;}
+  .meta-card strong{font-size:1.4rem;display:block;}
+  .meta-card span{color:var(--muted);font-size:.85rem;}
+  .iframe-wrap{position:relative;overflow:hidden;border-radius:18px;border:1px solid rgba(148,163,184,.22);background:#fff;}
+  .skeleton{position:absolute;inset:0;display:grid;place-items:center;background:linear-gradient(90deg,#f2f5f9 25%,#e8edf4 37%,#f2f5f9 63%);background-size:400% 100%;animation:shimmer 1.2s infinite;}
+  @keyframes shimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}
+  .btn-brand{background:var(--brand);border:none;color:#fff;border-radius:14px;padding:.6rem 1.3rem;font-weight:600;}
+  .btn-brand:hover{background:var(--brand-dark);color:#fff;}
+  .lead-muted{color:var(--muted);}
+</style>
+</head>
+<body>
+<header class="dealer-header">
+  <nav class="dealer-topnav navbar navbar-expand-lg py-3">
+    <div class="container">
+      <a class="navbar-brand" href="dashboard.php"><?=h(APP_NAME)?> — Bayi Paneli</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#dealerNav" aria-controls="dealerNav" aria-expanded="false" aria-label="Menü">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="dealerNav">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item"><a class="nav-link" href="dashboard.php">Genel Bakış</a></li>
+          <li class="nav-item"><a class="nav-link" href="dashboard.php#venues">Salonlar</a></li>
+          <li class="nav-item"><a class="nav-link active" href="billing.php">Bakiye & Paketler</a></li>
+        </ul>
+        <div class="d-flex align-items-center gap-3 mb-2 mb-lg-0">
+          <span class="badge-soft"><?=h($sessionDealer['name'] ?? '')?></span>
+          <a class="text-decoration-none fw-semibold" href="login.php?logout=1">Çıkış</a>
+        </div>
+      </div>
+    </div>
+  </nav>
+</header>
+<main class="payment-main">
+  <div class="container py-4">
+    <?php flash_box(); ?>
+    <section class="payment-hero mb-4">
+      <div class="card-lite p-4 p-lg-5 mb-4">
+        <div class="meta-grid">
+          <div class="meta-card">
+            <h6>Yükleme Tutarı</h6>
+            <strong><?=h($amountTL)?></strong>
+            <span><?=h($createdLabel)?> tarihinde oluşturuldu</span>
+          </div>
+          <div class="meta-card">
+            <h6>Talep No</h6>
+            <strong><?=h($reference)?></strong>
+            <span>PayTR üzerinden ödeme tamamlandığında yönetici onayına düşer.</span>
+          </div>
+          <div class="meta-card">
+            <h6>Durum</h6>
+            <strong><?=h(dealer_topup_status_label($status))?></strong>
+            <span>Ödeme formunu doldurarak işlemi tamamlayın.</span>
+          </div>
+        </div>
+      </div>
+      <div class="card-lite p-4 p-lg-5">
+        <div class="mb-3">
+          <h5 class="mb-1">Kart ile Ödeme</h5>
+          <p class="lead-muted mb-0">Ödeme PayTR güvencesiyle alınır. 3D Secure doğrulaması gerekebilir.</p>
+        </div>
+        <div class="iframe-wrap mb-3">
+          <div class="skeleton" id="skeleton">
+            <div class="text-center">
+              <div class="spinner-border text-info" role="status" style="--bs-spinner-width:2.2rem;--bs-spinner-height:2.2rem"></div>
+              <div class="mt-2 lead-muted">Ödeme formu yükleniyor…</div>
+            </div>
+          </div>
+          <iframe
+            src="https://www.paytr.com/odeme/guvenli/<?=h($token)?>"
+            id="paytriframe"
+            frameborder="0"
+            scrolling="no"
+            style="width:100%;min-height:680px;border:0;border-radius:18px;">
+          </iframe>
+        </div>
+        <div class="d-flex gap-2 flex-wrap justify-content-between align-items-center">
+          <div class="lead-muted">Ödeme sonrası bu sayfayı kapatarak bakiye ekranına dönebilirsiniz.</div>
+          <div class="d-flex gap-2">
+            <a class="btn btn-outline-secondary" href="billing.php#topup">Bakiye Ekranına Dön</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const iframe = document.getElementById('paytriframe');
+  const skel = document.getElementById('skeleton');
+  iframe.addEventListener('load', ()=>{ if(skel){ skel.style.display='none'; } });
+  iFrameResize({}, '#paytriframe');
+</script>
+</body>
+</html>

--- a/dealer/topup_paytr.php
+++ b/dealer/topup_paytr.php
@@ -35,7 +35,11 @@ if ($status === DEALER_TOPUP_STATUS_COMPLETED) {
   redirect('billing.php#topup');
 }
 if ($status === DEALER_TOPUP_STATUS_AWAITING_REVIEW) {
-  flash('ok', 'Ödeme alındı, yönetici onayı bekleniyor.');
+  $msg = 'Ödeme alındı, yönetici onayı bekleniyor.';
+  if (paytr_is_test_mode()) {
+    $msg = 'Test modunda ödeme otomatik alındı, yönetici onayı bekleniyor.';
+  }
+  flash('ok', $msg);
   redirect('billing.php#topup');
 }
 $token = $topup['paytr_token'] ?? null;

--- a/dealer/venue_events.php
+++ b/dealer/venue_events.php
@@ -1,0 +1,219 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/dealer_auth.php';
+
+install_schema();
+
+dealer_require_login();
+$sessionDealer = dealer_user();
+$dealer = dealer_get((int)$sessionDealer['id']);
+if (!$dealer) {
+  dealer_logout();
+  redirect('login.php');
+}
+
+$venueId = (int)($_GET['venue_id'] ?? 0);
+if ($venueId <= 0) {
+  flash('err', 'Salon seçilmedi.');
+  redirect('dashboard.php');
+}
+
+$st = pdo()->prepare("SELECT v.* FROM venues v INNER JOIN dealer_venues dv ON dv.venue_id=v.id WHERE dv.dealer_id=? AND v.id=? LIMIT 1");
+$st->execute([(int)$dealer['id'], $venueId]);
+$venue = $st->fetch();
+if (!$venue) {
+  flash('err', 'Bu salona erişiminiz yok.');
+  redirect('dashboard.php');
+}
+
+$canManage = dealer_can_manage_events($dealer);
+
+$action = $_POST['do'] ?? '';
+if ($action === 'create_event') {
+  csrf_or_die();
+  if (!$canManage) {
+    flash('err', 'Lisans süreniz dolduğu için yeni düğün oluşturamazsınız.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+
+  $title = trim($_POST['title'] ?? '');
+  $date  = trim($_POST['event_date'] ?? '');
+  $email = trim($_POST['couple_email'] ?? '');
+  $pass  = (string)($_POST['couple_pass'] ?? '');
+
+  if ($title === '' || $email === '' || $pass === '') {
+    flash('err', 'Başlık, e-posta ve şifre alanları zorunlu.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+  if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    flash('err', 'Geçerli bir e-posta girin.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+  if (strlen($pass) < 6) {
+    flash('err', 'Geçici şifre en az 6 karakter olmalı.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+
+  $slug = slugify($title);
+  if ($slug === '') $slug = 'event-'.bin2hex(random_bytes(3));
+  $base = $slug; $i = 1;
+  while (true) {
+    $chk = pdo()->prepare("SELECT id FROM events WHERE venue_id=? AND slug=? LIMIT 1");
+    $chk->execute([$venueId, $slug]);
+    if (!$chk->fetch()) break;
+    $slug = $base.'-'.$i++;
+  }
+
+  $same = pdo()->prepare("SELECT id FROM events WHERE couple_username=? LIMIT 1");
+  $same->execute([$email]);
+  if ($same->fetch()) {
+    flash('err', 'Bu e-posta farklı bir düğün için kullanılıyor.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+  }
+
+  $key  = bin2hex(random_bytes(16));
+  $hash = password_hash($pass, PASSWORD_DEFAULT);
+  $primary = '#0ea5b5';
+  $accent  = '#e0f7fb';
+
+  $sql = "INSERT INTO events (venue_id,dealer_id,user_id,title,slug,couple_panel_key,theme_primary,theme_accent,event_date,created_at,couple_username,couple_password_hash,couple_force_reset,contact_email) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+  pdo()->prepare($sql)->execute([
+    $venueId,
+    (int)$dealer['id'],
+    null,
+    $title,
+    $slug,
+    $key,
+    $primary,
+    $accent,
+    $date ?: null,
+    now(),
+    $email,
+    $hash,
+    1,
+    $email,
+  ]);
+
+  $eventId = (int)pdo()->lastInsertId();
+  $loginUrl = BASE_URL.'/couple/login.php?event='.$eventId;
+  $html = '<h3>'.h(APP_NAME).' Çift Paneli</h3>'
+        . '<p>Düğün paneliniz oluşturuldu.</p>'
+        . '<p><strong>Kullanıcı adı:</strong> '.h($email).'<br>'
+        . '<strong>Geçici şifre:</strong> '.h($pass).'</p>'
+        . '<p><a href="'.h($loginUrl).'">Panele giriş yapın</a> ve ilk girişte şifrenizi değiştirin.</p>';
+  send_mail_simple($email, 'Çift paneliniz hazır', $html);
+
+  flash('ok', 'Düğün oluşturuldu ve bilgiler çifte e-posta ile gönderildi.');
+  redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+}
+
+if ($action === 'toggle' && isset($_POST['event_id'])) {
+  csrf_or_die();
+  $eventId = (int)$_POST['event_id'];
+  if (!dealer_event_belongs_to_dealer((int)$dealer['id'], $eventId)) {
+    flash('err', 'Bu düğünü yönetme yetkiniz yok.');
+  } else {
+    pdo()->prepare("UPDATE events SET is_active=1-is_active WHERE id=? AND venue_id=?")
+        ->execute([$eventId, $venueId]);
+    flash('ok', 'Durum güncellendi.');
+  }
+  redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
+}
+
+$events = [];
+$st = pdo()->prepare("SELECT * FROM events WHERE venue_id=? ORDER BY event_date DESC, id DESC");
+$st->execute([$venueId]);
+$events = $st->fetchAll();
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h($venue['name'])?> — Düğünler</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:#f4f6fb;}
+  .card-lite{border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.06);}
+</style>
+</head>
+<body>
+<nav class="navbar bg-white border-bottom mb-4">
+  <div class="container d-flex justify-content-between align-items-center py-2">
+    <div>
+      <a class="navbar-brand fw-semibold" href="dashboard.php">← Bayi Paneli</a>
+      <span class="ms-2 text-muted">Salon: <?=h($venue['name'])?></span>
+    </div>
+    <a class="text-decoration-none" href="login.php?logout=1">Çıkış</a>
+  </div>
+</nav>
+<div class="container pb-5">
+  <?php flash_box(); ?>
+  <div class="card-lite p-4 mb-4">
+    <h5 class="mb-3">Yeni Düğün Oluştur</h5>
+    <?php if (!$canManage): ?>
+      <div class="alert alert-warning">Lisans süreniz geçersiz olduğu için yeni düğün oluşturamazsınız. Lütfen yönetici ile iletişime geçin.</div>
+    <?php endif; ?>
+    <form method="post" class="row g-3" autocomplete="off">
+      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+      <input type="hidden" name="do" value="create_event">
+      <div class="col-md-6">
+        <label class="form-label">Düğün Başlığı</label>
+        <input class="form-control" name="title" required <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Düğün Tarihi</label>
+        <input type="date" class="form-control" name="event_date" <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Çift E-postası</label>
+        <input type="email" class="form-control" name="couple_email" required <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Geçici Şifre</label>
+        <input type="text" class="form-control" name="couple_pass" minlength="6" required <?= $canManage ? '' : 'disabled' ?>>
+      </div>
+      <div class="col-md-9 d-flex align-items-end">
+        <button class="btn btn-primary" type="submit" <?= $canManage ? '' : 'disabled' ?>>Düğünü Oluştur</button>
+      </div>
+    </form>
+  </div>
+
+  <div class="card-lite p-4">
+    <h5 class="mb-3">Düğün Listesi</h5>
+    <?php if (!$events): ?>
+      <p class="text-muted">Bu salona ait düğün bulunmuyor.</p>
+    <?php else: ?>
+      <div class="table-responsive">
+        <table class="table align-middle">
+          <thead><tr><th>Başlık</th><th>Tarih</th><th>Durum</th><th></th></tr></thead>
+          <tbody>
+            <?php foreach ($events as $ev): ?>
+              <tr>
+                <td>
+                  <div class="fw-semibold"><?=h($ev['title'])?></div>
+                  <div class="small text-muted">Çift e-postası: <?=h($ev['couple_username'] ?? $ev['contact_email'])?></div>
+                </td>
+                <td><?= $ev['event_date'] ? h(date('d.m.Y', strtotime($ev['event_date']))) : '—' ?></td>
+                <td><?= $ev['is_active'] ? 'Aktif' : 'Pasif' ?></td>
+                <td class="text-end">
+                  <form method="post" class="d-inline">
+                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="toggle">
+                    <input type="hidden" name="event_id" value="<?= (int)$ev['id'] ?>">
+                    <button class="btn btn-sm btn-outline-secondary" type="submit">Durumu Değiştir</button>
+                  </form>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php endif; ?>
+  </div>
+</div>
+</body>
+</html>

--- a/dealer/venue_events.php
+++ b/dealer/venue_events.php
@@ -4,6 +4,7 @@ require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/dealers.php';
 require_once __DIR__.'/../includes/dealer_auth.php';
+require_once __DIR__.'/partials/ui.php';
 
 install_schema();
 
@@ -15,6 +16,7 @@ if (!$dealer) {
   redirect('login.php');
 }
 
+$dealerId = (int)$dealer['id'];
 $venueId = (int)($_GET['venue_id'] ?? 0);
 if ($venueId <= 0) {
   flash('err', 'Salon seçilmedi.');
@@ -22,7 +24,7 @@ if ($venueId <= 0) {
 }
 
 $st = pdo()->prepare("SELECT v.* FROM venues v INNER JOIN dealer_venues dv ON dv.venue_id=v.id WHERE dv.dealer_id=? AND v.id=? LIMIT 1");
-$st->execute([(int)$dealer['id'], $venueId]);
+$st->execute([$dealerId, $venueId]);
 $venue = $st->fetch();
 if (!$venue) {
   flash('err', 'Bu salona erişiminiz yok.');
@@ -32,7 +34,6 @@ if (!$venue) {
 $creationStatus = dealer_event_creation_status($dealer);
 $canManage = $creationStatus['allowed'];
 $quotaSummary = $creationStatus['summary'];
-$activeNav = 'venues';
 
 $action = $_POST['do'] ?? '';
 if ($action === 'create_event') {
@@ -76,7 +77,7 @@ if ($action === 'create_event') {
   $sql = "INSERT INTO events (venue_id,dealer_id,user_id,title,slug,couple_panel_key,theme_primary,theme_accent,event_date,created_at,couple_username,couple_password_hash,couple_force_reset,contact_email) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
   pdo()->prepare($sql)->execute([
     $venueId,
-    (int)$dealer['id'],
+    $dealerId,
     null,
     $title,
     $slug,
@@ -103,7 +104,7 @@ if ($action === 'create_event') {
 if ($action === 'toggle' && isset($_POST['event_id'])) {
   csrf_or_die();
   $eventId = (int)$_POST['event_id'];
-  if (!dealer_event_belongs_to_dealer((int)$dealer['id'], $eventId)) {
+  if (!dealer_event_belongs_to_dealer($dealerId, $eventId)) {
     flash('err', 'Bu etkinliği yönetme yetkiniz yok.');
   } else {
     pdo()->prepare("UPDATE events SET is_active=1-is_active WHERE id=? AND venue_id=?")
@@ -119,349 +120,294 @@ if ($action === 'create_qr') {
     flash('err', 'Lisans süreniz geçersiz olduğu için QR oluşturamazsınız.');
     redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
   }
+
   $code = trim($_POST['code'] ?? '');
   if ($code === '') {
-    $code = 'qr-'.bin2hex(random_bytes(3));
-  }
-  $code = preg_replace('~[^a-zA-Z0-9_-]+~', '', $code);
-  if ($code === '') {
-    flash('err', 'Geçerli bir kod girin.');
+    flash('err', 'Kod alanı boş olamaz.');
     redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
   }
-  try {
-    pdo()->prepare("INSERT INTO qr_codes (venue_id, code, created_at) VALUES (?,?,?)")
-        ->execute([$venueId, $code, now()]);
-    flash('ok', 'Kalıcı QR kodu oluşturuldu.');
-  } catch (Throwable $e) {
-    flash('err', 'Bu kod zaten kullanılıyor.');
-  }
+
+  $insert = pdo()->prepare("INSERT INTO dealer_qr_codes (dealer_id, venue_id, code, created_at) VALUES (?,?,?,?)");
+  $insert->execute([$dealerId, $venueId, $code, now()]);
+  flash('ok', 'Kalıcı QR kod oluşturuldu.');
   redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
 }
 
 if ($action === 'bind_qr') {
   csrf_or_die();
   $qrId = (int)($_POST['qr_id'] ?? 0);
-  $eventId = (int)($_POST['event_id'] ?? 0);
-  $st = pdo()->prepare("SELECT id FROM qr_codes WHERE id=? AND venue_id=? LIMIT 1");
-  $st->execute([$qrId, $venueId]);
+  $eventBind = (int)($_POST['event_id'] ?? 0) ?: null;
+
+  $st = pdo()->prepare("SELECT id FROM dealer_qr_codes WHERE id=? AND dealer_id=? AND venue_id=? LIMIT 1");
+  $st->execute([$qrId, $dealerId, $venueId]);
   if (!$st->fetch()) {
-    flash('err', 'QR kaydı bulunamadı.');
+    flash('err', 'QR kod bulunamadı.');
     redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
   }
-  if ($eventId > 0) {
-    $eventCheck = pdo()->prepare("SELECT id FROM events WHERE id=? AND venue_id=? LIMIT 1");
-    $eventCheck->execute([$eventId, $venueId]);
-    if (!$eventCheck->fetch()) {
-      flash('err', 'Seçilen etkinlik bu salona ait değil.');
-      redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
-    }
-  }
-  pdo()->prepare("UPDATE qr_codes SET target_event_id=?, updated_at=? WHERE id=?")
-      ->execute([$eventId ?: null, now(), $qrId]);
-  flash('ok', 'QR yönlendirmesi güncellendi.');
+
+  pdo()->prepare("UPDATE dealer_qr_codes SET target_event_id=? WHERE id=?")
+      ->execute([$eventBind, $qrId]);
+  flash('ok', 'QR kod yönlendirmesi güncellendi.');
   redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
 }
 
 $events = [];
-$st = pdo()->prepare("SELECT * FROM events WHERE venue_id=? ORDER BY event_date DESC, id DESC");
-$st->execute([$venueId]);
-$events = $st->fetchAll();
-
 $activeEvents = [];
 $passiveEvents = [];
-$todayTs = strtotime('today');
-foreach ($events as $ev) {
-  $eventTs = null;
-  if (!empty($ev['event_date'])) {
-    $eventTs = strtotime($ev['event_date']);
-  }
-  $isPast = $eventTs !== null && $eventTs < $todayTs;
-  if (!empty($ev['is_active']) && !$isPast) {
+$st = pdo()->prepare("SELECT * FROM events WHERE venue_id=? ORDER BY event_date IS NULL DESC, event_date ASC, created_at DESC");
+$st->execute([$venueId]);
+foreach ($st->fetchAll() as $ev) {
+  $events[] = $ev;
+  if (!empty($ev['is_active'])) {
     $activeEvents[] = $ev;
   } else {
     $passiveEvents[] = $ev;
   }
 }
 
-$qrCodes = pdo()->prepare("SELECT q.*, e.title AS event_title, e.event_date FROM qr_codes q LEFT JOIN events e ON e.id=q.target_event_id WHERE q.venue_id=? ORDER BY q.id DESC");
-$qrCodes->execute([$venueId]);
-$qrCodes = $qrCodes->fetchAll();
-?>
-<!doctype html>
-<html lang="tr">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title><?=h($venue['name'])?> — Etkinlik Yönetimi</title>
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+$qrCodes = [];
+$st = pdo()->prepare(
+  "SELECT q.*, e.title AS event_title, e.event_date, e.id AS event_id
+     FROM dealer_qr_codes q
+     LEFT JOIN events e ON e.id = q.target_event_id
+    WHERE q.dealer_id=? AND q.venue_id=?
+    ORDER BY q.created_at DESC"
+);
+$st->execute([$dealerId, $venueId]);
+$qrCodes = $st->fetchAll();
+
+$balance = dealer_get_balance($dealerId);
+$venuesNav = dealer_fetch_venues($dealerId);
+$refCode = $dealer['code'] ?: dealer_ensure_identifier($dealerId);
+$licenseLabel = dealer_license_label($dealer);
+
+$pageStyles = <<<'CSS'
 <style>
-  :root{
-    --brand:#0ea5b5;
-    --brand-dark:#0b8b98;
-    --ink:#0f172a;
-    --muted:#64748b;
-    --surface:#ffffff;
-    --soft:#f1f7fb;
-  }
-  body{background:var(--soft);color:var(--ink);font-family:'Inter','Segoe UI',system-ui,sans-serif;min-height:100vh;}
-  .dealer-topnav{background:var(--surface);border-bottom:1px solid rgba(148,163,184,.22);box-shadow:0 12px 30px rgba(15,23,42,.05);}
-  .dealer-topnav .navbar-brand{font-weight:700;color:var(--ink);}
-  .dealer-topnav .nav-link{color:var(--muted);font-weight:600;}
-  .dealer-topnav .nav-link:hover{color:var(--brand-dark);}
-  .dealer-hero{background:linear-gradient(120deg,rgba(14,165,181,.18),rgba(14,165,181,.04));padding:2rem 0 1.5rem;margin-bottom:2rem;}
-  .dealer-hero h1{font-weight:700;margin-bottom:.4rem;}
-  .dealer-hero p{margin:0;color:var(--muted);max-width:720px;}
-  .dealer-main{padding-bottom:4rem;}
-  .card-lite{border-radius:20px;background:var(--surface);border:1px solid rgba(148,163,184,.18);box-shadow:0 26px 48px -30px rgba(15,23,42,.45);}
+  .card-lite{border-radius:22px;background:#fff;border:1px solid rgba(148,163,184,.16);box-shadow:0 24px 48px -32px rgba(15,23,42,.45);}
   .card-section{padding:1.6rem 1.5rem;}
-  .btn-brand{background:var(--brand);border:none;color:#fff;border-radius:12px;font-weight:600;padding:.6rem 1.2rem;}
-  .btn-brand:hover{background:var(--brand-dark);color:#fff;}
-  .btn-brand-outline{background:#fff;border:1px solid rgba(14,165,181,.6);color:var(--brand);border-radius:12px;font-weight:600;padding:.55rem 1.2rem;}
-  .badge-soft{background:rgba(14,165,181,.12);color:var(--brand-dark);border-radius:999px;padding:.35rem .75rem;font-size:.75rem;font-weight:600;}
+  .btn-brand{background:#0ea5b5;border:none;color:#fff;border-radius:12px;font-weight:600;padding:.6rem 1.2rem;}
+  .btn-brand:hover{background:#0b8b98;color:#fff;}
+  .btn-brand-outline{background:#fff;border:1px solid rgba(14,165,181,.6);color:#0ea5b5;border-radius:12px;font-weight:600;padding:.55rem 1.2rem;}
+  .badge-soft{background:rgba(14,165,181,.12);color:#0b8b98;border-radius:999px;padding:.35rem .75rem;font-size:.78rem;font-weight:600;display:inline-flex;align-items:center;gap:.35rem;}
   .form-control,.form-select{border-radius:12px;border:1px solid rgba(148,163,184,.45);padding:.6rem .75rem;}
-  .form-control:focus,.form-select:focus{border-color:var(--brand);box-shadow:0 0 0 .2rem rgba(14,165,181,.15);}
-  .table thead th{color:var(--muted);font-weight:600;text-transform:uppercase;font-size:.75rem;letter-spacing:.05em;border-bottom:1px solid rgba(148,163,184,.3);}
+  .form-control:focus,.form-select:focus{border-color:#0ea5b5;box-shadow:0 0 0 .2rem rgba(14,165,181,.15);}
+  .table thead th{color:#64748b;font-weight:600;text-transform:uppercase;font-size:.75rem;letter-spacing:.05em;border-bottom:1px solid rgba(148,163,184,.3);}
   .table tbody td{vertical-align:middle;}
   .status-pill{display:inline-flex;align-items:center;gap:.4rem;border-radius:999px;padding:.35rem .85rem;font-weight:600;font-size:.8rem;}
   .status-pill.active{background:rgba(34,197,94,.15);color:#166534;}
   .status-pill.passive{background:rgba(248,113,113,.16);color:#b91c1c;}
   .qr-thumb{width:120px;height:120px;border-radius:12px;border:1px solid rgba(148,163,184,.3);object-fit:cover;}
-  @media(max-width:767px){
-    .dealer-hero{padding:1.6rem 0 1.2rem;margin-bottom:1.2rem;}
-  }
 </style>
-</head>
-<body>
-<header class="dealer-header">
-  <nav class="dealer-topnav navbar navbar-expand-lg">
-    <div class="container">
-      <a class="navbar-brand" href="dashboard.php"><?=h(APP_NAME)?> — Bayi Paneli</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#dealerNav" aria-controls="dealerNav" aria-expanded="false" aria-label="Menü">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="dealerNav">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          <li class="nav-item"><a class="nav-link<?= $activeNav === 'dashboard' ? ' active' : '' ?>" href="dashboard.php">Genel Bakış</a></li>
-          <li class="nav-item"><a class="nav-link<?= $activeNav === 'venues' ? ' active' : '' ?>" href="dashboard.php#venues">Salonlar</a></li>
-          <li class="nav-item"><a class="nav-link<?= $activeNav === 'billing' ? ' active' : '' ?>" href="billing.php">Bakiye & Paketler</a></li>
-        </ul>
-        <div class="d-flex align-items-center gap-3 mb-2 mb-lg-0">
-          <span class="badge-soft"><?=h($dealer['name'])?></span>
-          <a class="text-decoration-none fw-semibold" href="login.php?logout=1">Çıkış</a>
-        </div>
-      </div>
+CSS;
+
+dealer_layout_start('venues', [
+  'page_title'      => h($venue['name']).' — Etkinlik Yönetimi',
+  'title'           => $venue['name'].' • Etkinlik Yönetimi',
+  'subtitle'        => 'Atandığınız salon için etkinlik oluşturun, QR kodları yönetin ve davetli akışını kontrol edin.',
+  'dealer'          => $dealer,
+  'venues'          => $venuesNav,
+  'active_venue_id' => $venueId,
+  'balance_text'    => format_currency($balance),
+  'license_text'    => $licenseLabel,
+  'ref_code'        => $refCode,
+  'extra_head'      => $pageStyles,
+]);
+?>
+<section class="card-lite card-section mb-4" id="create">
+  <div class="d-flex justify-content-between flex-wrap gap-3 align-items-start mb-3">
+    <div>
+      <h5 class="mb-1">Yeni Etkinlik Oluştur</h5>
+      <p class="text-muted mb-0">Çift e-postasını yazın, giriş bilgileri otomatik olarak gönderilsin.</p>
     </div>
-  </nav>
-  <div class="dealer-hero">
-    <div class="container">
-      <h1><?=h($venue['name'])?></h1>
-      <p>Atandığınız salon için etkinlik oluşturun, QR kodlarınızı yönetin ve davetli akışını yönlendirin.</p>
+    <div class="d-flex flex-column align-items-end gap-2">
+      <span class="badge-soft"><i class="bi bi-shield-check"></i><?= dealer_has_valid_license($dealer) ? 'Lisans geçerli' : 'Lisans süresi doldu' ?></span>
+      <?php $remainingEvents = $quotaSummary['has_unlimited'] ? 'Sınırsız' : $quotaSummary['remaining_events']; ?>
+      <span class="badge-soft"><i class="bi bi-calendar2-check"></i>Kalan Hak: <?=h($remainingEvents)?></span>
     </div>
   </div>
-</header>
+  <?php if (!$canManage && !empty($creationStatus['reason'])): ?>
+    <div class="alert alert-warning"><?=h($creationStatus['reason'])?></div>
+  <?php endif; ?>
+  <?php if (!$canManage): ?>
+    <div class="alert alert-warning">Lisans süreniz geçersiz olduğu için yeni etkinlik oluşturamazsınız. Lütfen yönetici ile iletişime geçin.</div>
+  <?php endif; ?>
+  <form method="post" class="row g-3" autocomplete="off">
+    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+    <input type="hidden" name="do" value="create_event">
+    <div class="col-md-5">
+      <label class="form-label">Etkinlik Başlığı</label>
+      <input class="form-control" name="title" required <?= $canManage ? '' : 'disabled' ?>>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Etkinlik Tarihi</label>
+      <input type="date" class="form-control" name="event_date" value="<?=h(date('Y-m-d'))?>" <?= $canManage ? '' : 'disabled' ?>>
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Çift E-postası</label>
+      <input type="email" class="form-control" name="couple_email" required <?= $canManage ? '' : 'disabled' ?>>
+    </div>
+    <div class="col-12 d-grid d-md-flex justify-content-md-end">
+      <button class="btn btn-brand" type="submit" <?= $canManage ? '' : 'disabled' ?>>Etkinliği Oluştur</button>
+    </div>
+  </form>
+</section>
 
-<main class="dealer-main">
-  <div class="container">
-    <?php flash_box(); ?>
-
-    <section class="card-lite card-section mb-4" id="create">
-      <div class="d-flex justify-content-between flex-wrap gap-3 align-items-start mb-3">
-        <div>
-          <h5 class="mb-1">Yeni Etkinlik Oluştur</h5>
-          <p class="text-muted mb-0">Çift e-postasını yazın, giriş bilgileri otomatik olarak gönderilsin.</p>
-        </div>
-        <div class="d-flex flex-column align-items-end gap-2">
-          <span class="badge-soft">Lisans: <?= dealer_has_valid_license($dealer) ? 'Geçerli' : 'Süresi Doldu' ?></span>
-          <?php $remainingEvents = $quotaSummary['has_unlimited'] ? 'Sınırsız' : $quotaSummary['remaining_events']; ?>
-          <span class="badge-soft">Kalan Hak: <?=h($remainingEvents)?></span>
-        </div>
-      </div>
-      <?php if (!$canManage && !empty($creationStatus['reason'])): ?>
-        <div class="alert alert-warning"><?=h($creationStatus['reason'])?></div>
-      <?php endif; ?>
-      <?php if (!$canManage): ?>
-        <div class="alert alert-warning">Lisans süreniz geçersiz olduğu için yeni etkinlik oluşturamazsınız. Lütfen yönetici ile iletişime geçin.</div>
-      <?php endif; ?>
-      <form method="post" class="row g-3" autocomplete="off">
-        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-        <input type="hidden" name="do" value="create_event">
-        <div class="col-md-5">
-          <label class="form-label">Etkinlik Başlığı</label>
-          <input class="form-control" name="title" required <?= $canManage ? '' : 'disabled' ?>>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Etkinlik Tarihi</label>
-          <input type="date" class="form-control" name="event_date" value="<?=h(date('Y-m-d'))?>" <?= $canManage ? '' : 'disabled' ?>>
-        </div>
-        <div class="col-md-4">
-          <label class="form-label">Çift E-postası</label>
-          <input type="email" class="form-control" name="couple_email" required <?= $canManage ? '' : 'disabled' ?>>
-        </div>
-        <div class="col-12 d-grid d-md-flex justify-content-md-end">
-          <button class="btn btn-brand" type="submit" <?= $canManage ? '' : 'disabled' ?>>Etkinliği Oluştur</button>
-        </div>
-      </form>
-    </section>
-
-    <section class="card-lite card-section mb-4" id="events">
-      <div class="d-flex justify-content-between align-items-start mb-3 flex-column flex-md-row">
-        <div>
-          <h5 class="mb-1">Etkinlik Listesi</h5>
-          <span class="text-muted small">Toplam <?=count($events)?> etkinlik</span>
-        </div>
-        <div class="d-flex gap-2 flex-wrap">
-          <span class="badge-soft">Aktif: <?=count($activeEvents)?></span>
-          <span class="badge-soft">Pasif / Geçmiş: <?=count($passiveEvents)?></span>
-        </div>
-      </div>
-      <?php if (!$events): ?>
-        <p class="text-muted mb-0">Bu salona ait etkinlik bulunmuyor.</p>
-      <?php else: ?>
-        <?php
-          $renderEventTable = function(array $list) {
-            ob_start();
-        ?>
-        <div class="table-responsive mb-3">
-          <table class="table align-middle">
-            <thead>
-              <tr>
-                <th>Başlık</th>
-                <th>Tarih</th>
-                <th>Bağlantılar</th>
-                <th>Durum</th>
-                <th class="text-end">İşlem</th>
-              </tr>
-            </thead>
-            <tbody>
-              <?php foreach ($list as $ev):
-                $guestLink = public_upload_url($ev['id']);
-                $coupleLink = BASE_URL.'/couple/index.php?event='.$ev['id'].'&key='.$ev['couple_panel_key'];
-                $qrImage = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data='.urlencode($guestLink);
-              ?>
-              <tr>
-                <td>
-                  <div class="fw-semibold mb-1"><?=h($ev['title'])?></div>
-                  <div class="small text-muted">Çift e-postası: <?=h($ev['couple_username'] ?? $ev['contact_email'])?></div>
-                </td>
-                <td class="small">
-                  <?= $ev['event_date'] ? h(date('d.m.Y', strtotime($ev['event_date']))) : '—' ?>
-                </td>
-                <td class="small">
-                  <a class="badge-soft text-decoration-none me-1" target="_blank" href="<?=h($guestLink)?>">Misafir Sayfası</a>
-                  <a class="badge-soft text-decoration-none" target="_blank" href="<?=h($coupleLink)?>">Etkinlik Paneli</a>
-                </td>
-                <td>
-                  <span class="status-pill <?= $ev['is_active'] ? 'active' : 'passive' ?>"><?= $ev['is_active'] ? 'Aktif' : 'Pasif' ?></span>
-                </td>
-                <td class="text-end">
-                  <div class="d-flex flex-column flex-sm-row gap-2 justify-content-end">
-                    <a class="btn btn-sm btn-brand-outline" target="_blank" href="<?=h($qrImage)?>">Anlık QR</a>
-                    <form method="post">
-                      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-                      <input type="hidden" name="do" value="toggle">
-                      <input type="hidden" name="event_id" value="<?= (int)$ev['id'] ?>">
-                      <button class="btn btn-sm btn-outline-secondary" type="submit">Durumu Değiştir</button>
-                    </form>
-                  </div>
-                </td>
-              </tr>
-              <?php endforeach; ?>
-            </tbody>
-          </table>
-        </div>
-        <?php
-            return ob_get_clean();
-          };
-        ?>
-
-        <h6 class="text-uppercase small fw-semibold text-muted">Aktif Etkinlikler</h6>
-        <?php if ($activeEvents): ?>
-          <?= $renderEventTable($activeEvents) ?>
-        <?php else: ?>
-          <p class="text-muted fst-italic mb-4">Aktif etkinlik bulunmuyor.</p>
-        <?php endif; ?>
-
-        <h6 class="text-uppercase small fw-semibold text-muted mt-3">Pasif / Geçmiş Etkinlikler</h6>
-        <?php if ($passiveEvents): ?>
-          <?= $renderEventTable($passiveEvents) ?>
-        <?php else: ?>
-          <p class="text-muted fst-italic mb-0">Pasif veya geçmiş etkinlik bulunmuyor.</p>
-        <?php endif; ?>
-      <?php endif; ?>
-    </section>
-
-    <section class="card-lite card-section" id="qr">
-      <div class="d-flex justify-content-between align-items-center mb-3">
-        <div>
-          <h5 class="mb-1">Kalıcı QR Kodlar</h5>
-          <p class="text-muted mb-0">Broşür ve tabelalarınız için kalıcı kodlar oluşturun, istediğiniz etkinliğe yönlendirin.</p>
-        </div>
-        <form method="post" class="d-flex gap-2">
-          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-          <input type="hidden" name="do" value="create_qr">
-          <input class="form-control" name="code" placeholder="Örn. salon-brosur" style="max-width:220px">
-          <button class="btn btn-brand" type="submit">QR Oluştur</button>
-        </form>
-      </div>
-      <?php if (!$qrCodes): ?>
-        <p class="text-muted mb-0">Bu salona ait oluşturulmuş kalıcı QR kodu bulunmuyor.</p>
-      <?php else: ?>
-        <div class="table-responsive">
-          <table class="table align-middle">
-            <thead>
-              <tr>
-                <th>Kod</th>
-                <th>Önizleme</th>
-                <th>Bağlı Etkinlik</th>
-                <th>Yönlendirme</th>
-              </tr>
-            </thead>
-            <tbody>
-              <?php foreach ($qrCodes as $code):
-                $qrLink = BASE_URL.'/qr.php?code='.rawurlencode($code['code']).'&v='.rawurlencode($venue['slug']);
-                $img = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data='.urlencode($qrLink);
-              ?>
-              <tr>
-                <td>
-                  <div class="fw-semibold"><?=h($code['code'])?></div>
-                  <div class="small"><a target="_blank" href="<?=h($qrLink)?>">Kalıcı bağlantı</a></div>
-                </td>
-                <td><img class="qr-thumb" src="<?=h($img)?>" alt="qr"></td>
-                <td>
-                  <?php if ($code['event_title']): ?>
-                    <div class="fw-semibold mb-1"><?=h($code['event_title'])?></div>
-                    <div class="small text-muted"><?= $code['event_date'] ? h(date('d.m.Y', strtotime($code['event_date']))) : 'Tarih yok' ?></div>
-                  <?php else: ?>
-                    <span class="text-muted">Bağlı etkinlik seçilmedi.</span>
-                  <?php endif; ?>
-                </td>
-                <td style="width:320px;">
-                  <form method="post" class="row g-2 align-items-center">
-                    <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-                    <input type="hidden" name="do" value="bind_qr">
-                    <input type="hidden" name="qr_id" value="<?= (int)$code['id'] ?>">
-                    <div class="col-sm-8">
-                      <select class="form-select" name="event_id">
-                        <option value="0">— Bağlı değil —</option>
-                        <?php foreach ($events as $ev): ?>
-                          <option value="<?= (int)$ev['id'] ?>" <?= ($code['target_event_id'] ?? null) == $ev['id'] ? 'selected' : '' ?>><?=h($ev['title'])?></option>
-                        <?php endforeach; ?>
-                      </select>
-                    </div>
-                    <div class="col-sm-4 d-grid">
-                      <button class="btn btn-brand-outline" type="submit">Kaydet</button>
-                    </div>
-                  </form>
-                </td>
-              </tr>
-              <?php endforeach; ?>
-            </tbody>
-          </table>
-        </div>
-      <?php endif; ?>
-    </section>
+<section class="card-lite card-section mb-4" id="events">
+  <div class="d-flex justify-content-between align-items-start mb-3 flex-column flex-md-row">
+    <div>
+      <h5 class="mb-1">Etkinlik Listesi</h5>
+      <span class="text-muted small">Toplam <?=count($events)?> etkinlik</span>
+    </div>
+    <div class="d-flex gap-2 flex-wrap">
+      <span class="badge-soft"><i class="bi bi-lightning-charge"></i>Aktif: <?=count($activeEvents)?></span>
+      <span class="badge-soft"><i class="bi bi-clock-history"></i>Pasif / Geçmiş: <?=count($passiveEvents)?></span>
+    </div>
   </div>
-</main>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+  <?php if (!$events): ?>
+    <p class="text-muted mb-0">Bu salona ait etkinlik bulunmuyor.</p>
+  <?php else: ?>
+    <?php
+      $renderEventTable = function(array $list) {
+        ob_start();
+    ?>
+    <div class="table-responsive mb-3">
+      <table class="table align-middle">
+        <thead>
+          <tr>
+            <th>Başlık</th>
+            <th>Tarih</th>
+            <th>Bağlantılar</th>
+            <th>Durum</th>
+            <th class="text-end">İşlem</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach ($list as $ev):
+            $guestLink = public_upload_url($ev['id']);
+            $coupleLink = BASE_URL.'/couple/index.php?event='.$ev['id'].'&key='.$ev['couple_panel_key'];
+            $qrImage = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data='.urlencode($guestLink);
+          ?>
+          <tr>
+            <td>
+              <div class="fw-semibold mb-1"><?=h($ev['title'])?></div>
+              <div class="small text-muted">Çift e-postası: <?=h($ev['couple_username'] ?? $ev['contact_email'])?></div>
+            </td>
+            <td class="small">
+              <?= $ev['event_date'] ? h(date('d.m.Y', strtotime($ev['event_date']))) : '—' ?>
+            </td>
+            <td class="small">
+              <a class="badge-soft text-decoration-none me-1" target="_blank" href="<?=h($guestLink)?>">Misafir Sayfası</a>
+              <a class="badge-soft text-decoration-none" target="_blank" href="<?=h($coupleLink)?>">Etkinlik Paneli</a>
+            </td>
+            <td>
+              <span class="status-pill <?= $ev['is_active'] ? 'active' : 'passive' ?>"><?= $ev['is_active'] ? 'Aktif' : 'Pasif' ?></span>
+            </td>
+            <td class="text-end">
+              <div class="d-flex flex-column flex-sm-row gap-2 justify-content-end">
+                <a class="btn btn-sm btn-brand-outline" target="_blank" href="<?=h($qrImage)?>">Anlık QR</a>
+                <form method="post">
+                  <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                  <input type="hidden" name="do" value="toggle">
+                  <input type="hidden" name="event_id" value="<?= (int)$ev['id'] ?>">
+                  <button class="btn btn-sm btn-outline-secondary" type="submit">Durumu Değiştir</button>
+                </form>
+              </div>
+            </td>
+          </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+    <?php
+        return ob_get_clean();
+      };
+    ?>
+
+    <h6 class="text-uppercase small fw-semibold text-muted">Aktif Etkinlikler</h6>
+    <?php if ($activeEvents): ?>
+      <?= $renderEventTable($activeEvents) ?>
+    <?php else: ?>
+      <p class="text-muted fst-italic mb-4">Aktif etkinlik bulunmuyor.</p>
+    <?php endif; ?>
+
+    <h6 class="text-uppercase small fw-semibold text-muted mt-3">Pasif / Geçmiş Etkinlikler</h6>
+    <?php if ($passiveEvents): ?>
+      <?= $renderEventTable($passiveEvents) ?>
+    <?php else: ?>
+      <p class="text-muted fst-italic mb-0">Pasif veya geçmiş etkinlik bulunmuyor.</p>
+    <?php endif; ?>
+  <?php endif; ?>
+</section>
+
+<section class="card-lite card-section" id="qr">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+      <h5 class="mb-1">Kalıcı QR Kodlar</h5>
+      <p class="text-muted mb-0">Broşür ve tabelalarınız için kalıcı kodlar oluşturun, istediğiniz etkinliğe yönlendirin.</p>
+    </div>
+    <form method="post" class="d-flex gap-2">
+      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+      <input type="hidden" name="do" value="create_qr">
+      <input class="form-control" name="code" placeholder="Örn. salon-brosur" style="max-width:220px">
+      <button class="btn btn-brand" type="submit">QR Oluştur</button>
+    </form>
+  </div>
+  <?php if (!$qrCodes): ?>
+    <p class="text-muted mb-0">Bu salona ait oluşturulmuş kalıcı QR kodu bulunmuyor.</p>
+  <?php else: ?>
+    <div class="table-responsive">
+      <table class="table align-middle">
+        <thead>
+          <tr>
+            <th>Kod</th>
+            <th>Önizleme</th>
+            <th>Bağlı Etkinlik</th>
+            <th>Yönlendirme</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach ($qrCodes as $code):
+            $qrLink = BASE_URL.'/qr.php?code='.rawurlencode($code['code']).'&v='.rawurlencode($venue['slug']);
+            $img = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data='.urlencode($qrLink);
+          ?>
+          <tr>
+            <td>
+              <div class="fw-semibold"><?=h($code['code'])?></div>
+              <div class="small"><a target="_blank" href="<?=h($qrLink)?>">Kalıcı bağlantı</a></div>
+            </td>
+            <td><img class="qr-thumb" src="<?=h($img)?>" alt="qr"></td>
+            <td>
+              <?php if ($code['event_title']): ?>
+                <div class="fw-semibold mb-1"><?=h($code['event_title'])?></div>
+                <div class="small text-muted"><?= $code['event_date'] ? h(date('d.m.Y', strtotime($code['event_date']))) : 'Tarih yok' ?></div>
+              <?php else: ?>
+                <span class="text-muted">Bağlı etkinlik seçilmedi.</span>
+              <?php endif; ?>
+            </td>
+            <td style="width:320px;">
+              <form method="post" class="row g-2 align-items-center">
+                <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                <input type="hidden" name="do" value="bind_qr">
+                <input type="hidden" name="qr_id" value="<?= (int)$code['id'] ?>">
+                <div class="col-sm-8">
+                  <select class="form-select" name="event_id">
+                    <option value="0">— Bağlı değil —</option>
+                    <?php foreach ($events as $ev): ?>
+                      <option value="<?= (int)$ev['id'] ?>" <?= ($code['target_event_id'] ?? null) == $ev['id'] ? 'selected' : '' ?>><?=h($ev['title'])?></option>
+                    <?php endforeach; ?>
+                  </select>
+                </div>
+                <div class="col-sm-4 d-grid">
+                  <button class="btn btn-brand-outline" type="submit">Kaydet</button>
+                </div>
+              </form>
+            </td>
+          </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  <?php endif; ?>
+</section>
+
+<?php dealer_layout_end();

--- a/dealer/venue_events.php
+++ b/dealer/venue_events.php
@@ -115,93 +115,304 @@ if ($action === 'toggle' && isset($_POST['event_id'])) {
   redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
 }
 
+if ($action === 'create_qr') {
+  csrf_or_die();
+  if (!dealer_has_valid_license($dealer)) {
+    flash('err', 'Lisans süreniz geçersiz olduğu için QR oluşturamazsınız.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
+  }
+  $code = trim($_POST['code'] ?? '');
+  if ($code === '') {
+    $code = 'qr-'.bin2hex(random_bytes(3));
+  }
+  $code = preg_replace('~[^a-zA-Z0-9_-]+~', '', $code);
+  if ($code === '') {
+    flash('err', 'Geçerli bir kod girin.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
+  }
+  try {
+    pdo()->prepare("INSERT INTO qr_codes (venue_id, code, created_at) VALUES (?,?,?)")
+        ->execute([$venueId, $code, now()]);
+    flash('ok', 'Kalıcı QR kodu oluşturuldu.');
+  } catch (Throwable $e) {
+    flash('err', 'Bu kod zaten kullanılıyor.');
+  }
+  redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
+}
+
+if ($action === 'bind_qr') {
+  csrf_or_die();
+  $qrId = (int)($_POST['qr_id'] ?? 0);
+  $eventId = (int)($_POST['event_id'] ?? 0);
+  $st = pdo()->prepare("SELECT id FROM qr_codes WHERE id=? AND venue_id=? LIMIT 1");
+  $st->execute([$qrId, $venueId]);
+  if (!$st->fetch()) {
+    flash('err', 'QR kaydı bulunamadı.');
+    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
+  }
+  if ($eventId > 0) {
+    $eventCheck = pdo()->prepare("SELECT id FROM events WHERE id=? AND venue_id=? LIMIT 1");
+    $eventCheck->execute([$eventId, $venueId]);
+    if (!$eventCheck->fetch()) {
+      flash('err', 'Seçilen etkinlik bu salona ait değil.');
+      redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
+    }
+  }
+  pdo()->prepare("UPDATE qr_codes SET target_event_id=?, updated_at=? WHERE id=?")
+      ->execute([$eventId ?: null, now(), $qrId]);
+  flash('ok', 'QR yönlendirmesi güncellendi.');
+  redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId.'#qr');
+}
+
 $events = [];
 $st = pdo()->prepare("SELECT * FROM events WHERE venue_id=? ORDER BY event_date DESC, id DESC");
 $st->execute([$venueId]);
 $events = $st->fetchAll();
+
+$qrCodes = pdo()->prepare("SELECT q.*, e.title AS event_title, e.event_date FROM qr_codes q LEFT JOIN events e ON e.id=q.target_event_id WHERE q.venue_id=? ORDER BY q.id DESC");
+$qrCodes->execute([$venueId]);
+$qrCodes = $qrCodes->fetchAll();
 ?>
 <!doctype html>
 <html lang="tr">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title><?=h($venue['name'])?> — Etkinlikler</title>
+<title><?=h($venue['name'])?> — Etkinlik Yönetimi</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <style>
-  body{background:#f4f6fb;}
-  .card-lite{border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.06);}
+  :root{
+    --brand:#0ea5b5;
+    --brand-dark:#0b8b98;
+    --ink:#0f172a;
+    --muted:#64748b;
+    --surface:#ffffff;
+    --soft:#f1f7fb;
+  }
+  body{background:var(--soft);color:var(--ink);font-family:'Inter','Segoe UI',system-ui,sans-serif;min-height:100vh;}
+  .dealer-topnav{background:var(--surface);border-bottom:1px solid rgba(148,163,184,.22);box-shadow:0 12px 30px rgba(15,23,42,.05);}
+  .dealer-topnav .navbar-brand{font-weight:700;color:var(--ink);}
+  .dealer-topnav .nav-link{color:var(--muted);font-weight:600;}
+  .dealer-topnav .nav-link:hover{color:var(--brand-dark);}
+  .dealer-hero{background:linear-gradient(120deg,rgba(14,165,181,.18),rgba(14,165,181,.04));padding:2rem 0 1.5rem;margin-bottom:2rem;}
+  .dealer-hero h1{font-weight:700;margin-bottom:.4rem;}
+  .dealer-hero p{margin:0;color:var(--muted);max-width:720px;}
+  .dealer-main{padding-bottom:4rem;}
+  .card-lite{border-radius:20px;background:var(--surface);border:1px solid rgba(148,163,184,.18);box-shadow:0 26px 48px -30px rgba(15,23,42,.45);}
+  .card-section{padding:1.6rem 1.5rem;}
+  .btn-brand{background:var(--brand);border:none;color:#fff;border-radius:12px;font-weight:600;padding:.6rem 1.2rem;}
+  .btn-brand:hover{background:var(--brand-dark);color:#fff;}
+  .btn-brand-outline{background:#fff;border:1px solid rgba(14,165,181,.6);color:var(--brand);border-radius:12px;font-weight:600;padding:.55rem 1.2rem;}
+  .badge-soft{background:rgba(14,165,181,.12);color:var(--brand-dark);border-radius:999px;padding:.35rem .75rem;font-size:.75rem;font-weight:600;}
+  .form-control,.form-select{border-radius:12px;border:1px solid rgba(148,163,184,.45);padding:.6rem .75rem;}
+  .form-control:focus,.form-select:focus{border-color:var(--brand);box-shadow:0 0 0 .2rem rgba(14,165,181,.15);}
+  .table thead th{color:var(--muted);font-weight:600;text-transform:uppercase;font-size:.75rem;letter-spacing:.05em;border-bottom:1px solid rgba(148,163,184,.3);}
+  .table tbody td{vertical-align:middle;}
+  .status-pill{display:inline-flex;align-items:center;gap:.4rem;border-radius:999px;padding:.35rem .85rem;font-weight:600;font-size:.8rem;}
+  .status-pill.active{background:rgba(34,197,94,.15);color:#166534;}
+  .status-pill.passive{background:rgba(248,113,113,.16);color:#b91c1c;}
+  .qr-thumb{width:120px;height:120px;border-radius:12px;border:1px solid rgba(148,163,184,.3);object-fit:cover;}
+  @media(max-width:767px){
+    .dealer-hero{padding:1.6rem 0 1.2rem;margin-bottom:1.2rem;}
+  }
 </style>
 </head>
 <body>
-<nav class="navbar bg-white border-bottom mb-4">
-  <div class="container d-flex justify-content-between align-items-center py-2">
-    <div>
-      <a class="navbar-brand fw-semibold" href="dashboard.php">← Bayi Paneli</a>
-      <span class="ms-2 text-muted">Salon: <?=h($venue['name'])?></span>
+<header class="dealer-header">
+  <nav class="dealer-topnav navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="dashboard.php"><?=h(APP_NAME)?> — Bayi Paneli</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#dealerNav" aria-controls="dealerNav" aria-expanded="false" aria-label="Menü">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="dealerNav">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item"><a class="nav-link" href="dashboard.php">Genel Bakış</a></li>
+        </ul>
+        <div class="d-flex align-items-center gap-3 mb-2 mb-lg-0">
+          <span class="badge-soft"><?=h($dealer['name'])?></span>
+          <a class="text-decoration-none fw-semibold" href="login.php?logout=1">Çıkış</a>
+        </div>
+      </div>
     </div>
-    <a class="text-decoration-none" href="login.php?logout=1">Çıkış</a>
+  </nav>
+  <div class="dealer-hero">
+    <div class="container">
+      <h1><?=h($venue['name'])?></h1>
+      <p>Atandığınız salon için etkinlik oluşturun, QR kodlarınızı yönetin ve davetli akışını yönlendirin.</p>
+    </div>
   </div>
-</nav>
-<div class="container pb-5">
-  <?php flash_box(); ?>
-  <div class="card-lite p-4 mb-4">
-    <h5 class="mb-3">Yeni Etkinlik Oluştur</h5>
-    <?php if (!$canManage): ?>
-      <div class="alert alert-warning">Lisans süreniz geçersiz olduğu için yeni etkinlik oluşturamazsınız. Lütfen yönetici ile iletişime geçin.</div>
-    <?php endif; ?>
-    <form method="post" class="row g-3" autocomplete="off">
-      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-      <input type="hidden" name="do" value="create_event">
-      <div class="col-md-6">
-        <label class="form-label">Etkinlik Başlığı</label>
-        <input class="form-control" name="title" required <?= $canManage ? '' : 'disabled' ?>>
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Etkinlik Tarihi</label>
-        <input type="date" class="form-control" name="event_date" value="<?=h(date('Y-m-d'))?>" <?= $canManage ? '' : 'disabled' ?>>
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Çift E-postası</label>
-        <input type="email" class="form-control" name="couple_email" required <?= $canManage ? '' : 'disabled' ?>>
-      </div>
-      <div class="col-md-9 d-flex align-items-end">
-        <button class="btn btn-primary" type="submit" <?= $canManage ? '' : 'disabled' ?>>Etkinliği Oluştur</button>
-      </div>
-    </form>
-  </div>
+</header>
 
-  <div class="card-lite p-4">
-    <h5 class="mb-3">Etkinlik Listesi</h5>
-    <?php if (!$events): ?>
-      <p class="text-muted">Bu salona ait etkinlik bulunmuyor.</p>
-    <?php else: ?>
-      <div class="table-responsive">
-        <table class="table align-middle">
-          <thead><tr><th>Başlık</th><th>Tarih</th><th>Durum</th><th></th></tr></thead>
-          <tbody>
-            <?php foreach ($events as $ev): ?>
+<main class="dealer-main">
+  <div class="container">
+    <?php flash_box(); ?>
+
+    <section class="card-lite card-section mb-4" id="create">
+      <div class="d-flex justify-content-between flex-wrap gap-3 align-items-start mb-3">
+        <div>
+          <h5 class="mb-1">Yeni Etkinlik Oluştur</h5>
+          <p class="text-muted mb-0">Çift e-postasını yazın, giriş bilgileri otomatik olarak gönderilsin.</p>
+        </div>
+        <div class="text-end">
+          <span class="badge-soft">Lisans: <?= dealer_has_valid_license($dealer) ? 'Geçerli' : 'Süresi Doldu' ?></span>
+        </div>
+      </div>
+      <?php if (!$canManage): ?>
+        <div class="alert alert-warning">Lisans süreniz geçersiz olduğu için yeni etkinlik oluşturamazsınız. Lütfen yönetici ile iletişime geçin.</div>
+      <?php endif; ?>
+      <form method="post" class="row g-3" autocomplete="off">
+        <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+        <input type="hidden" name="do" value="create_event">
+        <div class="col-md-5">
+          <label class="form-label">Etkinlik Başlığı</label>
+          <input class="form-control" name="title" required <?= $canManage ? '' : 'disabled' ?>>
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Etkinlik Tarihi</label>
+          <input type="date" class="form-control" name="event_date" value="<?=h(date('Y-m-d'))?>" <?= $canManage ? '' : 'disabled' ?>>
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">Çift E-postası</label>
+          <input type="email" class="form-control" name="couple_email" required <?= $canManage ? '' : 'disabled' ?>>
+        </div>
+        <div class="col-12 d-grid d-md-flex justify-content-md-end">
+          <button class="btn btn-brand" type="submit" <?= $canManage ? '' : 'disabled' ?>>Etkinliği Oluştur</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="card-lite card-section mb-4" id="events">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h5 class="mb-0">Etkinlik Listesi</h5>
+        <span class="text-muted small">Toplam <?=count($events)?> etkinlik</span>
+      </div>
+      <?php if (!$events): ?>
+        <p class="text-muted mb-0">Bu salona ait etkinlik bulunmuyor.</p>
+      <?php else: ?>
+        <div class="table-responsive">
+          <table class="table align-middle">
+            <thead>
+              <tr>
+                <th>Başlık</th>
+                <th>Tarih</th>
+                <th>Bağlantılar</th>
+                <th>Durum</th>
+                <th class="text-end">İşlem</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($events as $ev):
+                $guestLink = public_upload_url($ev['id']);
+                $coupleLink = BASE_URL.'/couple/index.php?event='.$ev['id'].'&key='.$ev['couple_panel_key'];
+                $qrImage = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data='.urlencode($guestLink);
+              ?>
               <tr>
                 <td>
-                  <div class="fw-semibold"><?=h($ev['title'])?></div>
+                  <div class="fw-semibold mb-1"><?=h($ev['title'])?></div>
                   <div class="small text-muted">Çift e-postası: <?=h($ev['couple_username'] ?? $ev['contact_email'])?></div>
                 </td>
-                <td><?= $ev['event_date'] ? h(date('d.m.Y', strtotime($ev['event_date']))) : '—' ?></td>
-                <td><?= $ev['is_active'] ? 'Aktif' : 'Pasif' ?></td>
+                <td class="small">
+                  <?= $ev['event_date'] ? h(date('d.m.Y', strtotime($ev['event_date']))) : '—' ?>
+                </td>
+                <td class="small">
+                  <a class="badge-soft text-decoration-none me-1" target="_blank" href="<?=h($guestLink)?>">Misafir Sayfası</a>
+                  <a class="badge-soft text-decoration-none" target="_blank" href="<?=h($coupleLink)?>">Etkinlik Paneli</a>
+                </td>
+                <td>
+                  <span class="status-pill <?= $ev['is_active'] ? 'active' : 'passive' ?>"><?= $ev['is_active'] ? 'Aktif' : 'Pasif' ?></span>
+                </td>
                 <td class="text-end">
-                  <form method="post" class="d-inline">
+                  <div class="d-flex flex-column flex-sm-row gap-2 justify-content-end">
+                    <a class="btn btn-sm btn-brand-outline" target="_blank" href="<?=h($qrImage)?>">Anlık QR</a>
+                    <form method="post">
+                      <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+                      <input type="hidden" name="do" value="toggle">
+                      <input type="hidden" name="event_id" value="<?= (int)$ev['id'] ?>">
+                      <button class="btn btn-sm btn-outline-secondary" type="submit">Durumu Değiştir</button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php endif; ?>
+    </section>
+
+    <section class="card-lite card-section" id="qr">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+          <h5 class="mb-1">Kalıcı QR Kodlar</h5>
+          <p class="text-muted mb-0">Broşür ve tabelalarınız için kalıcı kodlar oluşturun, istediğiniz etkinliğe yönlendirin.</p>
+        </div>
+        <form method="post" class="d-flex gap-2">
+          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+          <input type="hidden" name="do" value="create_qr">
+          <input class="form-control" name="code" placeholder="Örn. salon-brosur" style="max-width:220px">
+          <button class="btn btn-brand" type="submit">QR Oluştur</button>
+        </form>
+      </div>
+      <?php if (!$qrCodes): ?>
+        <p class="text-muted mb-0">Bu salona ait oluşturulmuş kalıcı QR kodu bulunmuyor.</p>
+      <?php else: ?>
+        <div class="table-responsive">
+          <table class="table align-middle">
+            <thead>
+              <tr>
+                <th>Kod</th>
+                <th>Önizleme</th>
+                <th>Bağlı Etkinlik</th>
+                <th>Yönlendirme</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($qrCodes as $code):
+                $qrLink = BASE_URL.'/qr.php?code='.rawurlencode($code['code']).'&v='.rawurlencode($venue['slug']);
+                $img = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data='.urlencode($qrLink);
+              ?>
+              <tr>
+                <td>
+                  <div class="fw-semibold"><?=h($code['code'])?></div>
+                  <div class="small"><a target="_blank" href="<?=h($qrLink)?>">Kalıcı bağlantı</a></div>
+                </td>
+                <td><img class="qr-thumb" src="<?=h($img)?>" alt="qr"></td>
+                <td>
+                  <?php if ($code['event_title']): ?>
+                    <div class="fw-semibold mb-1"><?=h($code['event_title'])?></div>
+                    <div class="small text-muted"><?= $code['event_date'] ? h(date('d.m.Y', strtotime($code['event_date']))) : 'Tarih yok' ?></div>
+                  <?php else: ?>
+                    <span class="text-muted">Bağlı etkinlik seçilmedi.</span>
+                  <?php endif; ?>
+                </td>
+                <td style="width:320px;">
+                  <form method="post" class="row g-2 align-items-center">
                     <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
-                    <input type="hidden" name="do" value="toggle">
-                    <input type="hidden" name="event_id" value="<?= (int)$ev['id'] ?>">
-                    <button class="btn btn-sm btn-outline-secondary" type="submit">Durumu Değiştir</button>
+                    <input type="hidden" name="do" value="bind_qr">
+                    <input type="hidden" name="qr_id" value="<?= (int)$code['id'] ?>">
+                    <div class="col-sm-8">
+                      <select class="form-select" name="event_id">
+                        <option value="0">— Bağlı değil —</option>
+                        <?php foreach ($events as $ev): ?>
+                          <option value="<?= (int)$ev['id'] ?>" <?= ($code['target_event_id'] ?? null) == $ev['id'] ? 'selected' : '' ?>><?=h($ev['title'])?></option>
+                        <?php endforeach; ?>
+                      </select>
+                    </div>
+                    <div class="col-sm-4 d-grid">
+                      <button class="btn btn-brand-outline" type="submit">Kaydet</button>
+                    </div>
                   </form>
                 </td>
               </tr>
-            <?php endforeach; ?>
-          </tbody>
-        </table>
-      </div>
-    <?php endif; ?>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php endif; ?>
+    </section>
   </div>
-</div>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/dealer/venue_events.php
+++ b/dealer/venue_events.php
@@ -67,13 +67,6 @@ if ($action === 'create_event') {
     $slug = $base.'-'.$i++;
   }
 
-  $same = pdo()->prepare("SELECT id FROM events WHERE couple_username=? LIMIT 1");
-  $same->execute([$email]);
-  if ($same->fetch()) {
-    flash('err', 'Bu e-posta farklı bir etkinlik için kullanılıyor.');
-    redirect($_SERVER['PHP_SELF'].'?venue_id='.$venueId);
-  }
-
   $key  = bin2hex(random_bytes(16));
   $plain_pass = substr(bin2hex(random_bytes(8)),0,12);
   $hash = password_hash($plain_pass, PASSWORD_DEFAULT);

--- a/includes/db.php
+++ b/includes/db.php
@@ -397,7 +397,8 @@ function install_schema(){
   if (!column_exists('events','invoice_address'))     pdo()->exec("ALTER TABLE events ADD invoice_address VARCHAR(255) NULL");
   if (!column_exists('events','license_expires_at'))  pdo()->exec("ALTER TABLE events ADD license_expires_at DATETIME NULL");
 
-  try { pdo()->exec("CREATE UNIQUE INDEX uniq_events_couple_username ON events(couple_username)"); } catch(Throwable $e){}
+  try { pdo()->exec("ALTER TABLE events DROP INDEX uniq_events_couple_username"); } catch(Throwable $e){}
+  try { pdo()->exec("CREATE INDEX idx_events_couple_username ON events(couple_username)"); } catch(Throwable $e){}
   // purchases.paid_at yoksa ekle
 try {
   $col = pdo()->query("SHOW COLUMNS FROM purchases LIKE 'paid_at'")->fetch();

--- a/includes/db.php
+++ b/includes/db.php
@@ -442,6 +442,38 @@ function install_schema(){
     FOREIGN KEY (attachment_upload_id) REFERENCES uploads(id) ON DELETE SET NULL
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
+  pdo()->exec("CREATE TABLE IF NOT EXISTS guest_event_notes(
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    event_id INT NOT NULL,
+    profile_id INT NULL,
+    guest_name VARCHAR(190) NULL,
+    guest_email VARCHAR(190) NULL,
+    message TEXT NOT NULL,
+    created_at DATETIME NOT NULL,
+    INDEX idx_guest_event_notes (event_id, created_at),
+    FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id) REFERENCES guest_profiles(id) ON DELETE SET NULL
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+  pdo()->exec("CREATE TABLE IF NOT EXISTS guest_private_messages(
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    event_id INT NOT NULL,
+    sender_profile_id INT NOT NULL,
+    recipient_profile_id INT NULL,
+    recipient_upload_id BIGINT NULL,
+    recipient_email VARCHAR(190) NULL,
+    recipient_name VARCHAR(190) NULL,
+    body TEXT NOT NULL,
+    is_for_host TINYINT(1) NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL,
+    INDEX idx_guest_pm_event (event_id, created_at),
+    INDEX idx_guest_pm_recipient (recipient_profile_id),
+    FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
+    FOREIGN KEY (sender_profile_id) REFERENCES guest_profiles(id) ON DELETE CASCADE,
+    FOREIGN KEY (recipient_profile_id) REFERENCES guest_profiles(id) ON DELETE SET NULL,
+    FOREIGN KEY (recipient_upload_id) REFERENCES uploads(id) ON DELETE SET NULL
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
   /* qr_codes */
   pdo()->exec("CREATE TABLE IF NOT EXISTS qr_codes(
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/includes/db.php
+++ b/includes/db.php
@@ -112,6 +112,12 @@ function install_schema(){
     email VARCHAR(190) NOT NULL UNIQUE,
     phone VARCHAR(64) NULL,
     company VARCHAR(190) NULL,
+    billing_title VARCHAR(190) NULL,
+    billing_address TEXT NULL,
+    tax_office VARCHAR(190) NULL,
+    tax_number VARCHAR(64) NULL,
+    invoice_email VARCHAR(190) NULL,
+    tax_document_path VARCHAR(255) NULL,
     notes TEXT NULL,
     status VARCHAR(16) NOT NULL DEFAULT 'pending',
     license_expires_at DATETIME NULL,
@@ -125,6 +131,24 @@ function install_schema(){
 
   if (!column_exists('dealers', 'code')) {
     pdo()->exec("ALTER TABLE dealers ADD code VARCHAR(16) NULL AFTER id");
+  }
+  if (!column_exists('dealers', 'billing_title')) {
+    pdo()->exec("ALTER TABLE dealers ADD billing_title VARCHAR(190) NULL AFTER company");
+  }
+  if (!column_exists('dealers', 'billing_address')) {
+    pdo()->exec("ALTER TABLE dealers ADD billing_address TEXT NULL AFTER billing_title");
+  }
+  if (!column_exists('dealers', 'tax_office')) {
+    pdo()->exec("ALTER TABLE dealers ADD tax_office VARCHAR(190) NULL AFTER billing_address");
+  }
+  if (!column_exists('dealers', 'tax_number')) {
+    pdo()->exec("ALTER TABLE dealers ADD tax_number VARCHAR(64) NULL AFTER tax_office");
+  }
+  if (!column_exists('dealers', 'invoice_email')) {
+    pdo()->exec("ALTER TABLE dealers ADD invoice_email VARCHAR(190) NULL AFTER tax_number");
+  }
+  if (!column_exists('dealers', 'tax_document_path')) {
+    pdo()->exec("ALTER TABLE dealers ADD tax_document_path VARCHAR(255) NULL AFTER invoice_email");
   }
   try {
     pdo()->exec("ALTER TABLE dealers ADD UNIQUE KEY uniq_dealer_code (code)");

--- a/includes/db.php
+++ b/includes/db.php
@@ -2,7 +2,7 @@
 require_once __DIR__.'/../config.php';
 
 if (!defined('APP_SCHEMA_VERSION')) {
-  define('APP_SCHEMA_VERSION', '20240509_01');
+  define('APP_SCHEMA_VERSION', '20240509_02');
 }
 
 function pdo(): PDO {
@@ -206,6 +206,22 @@ function install_schema(){
     UNIQUE KEY uniq_code (code),
     INDEX (dealer_id, type),
     FOREIGN KEY (dealer_id) REFERENCES dealers(id) ON DELETE CASCADE,
+    FOREIGN KEY (target_event_id) REFERENCES events(id) ON DELETE SET NULL
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+  pdo()->exec("CREATE TABLE IF NOT EXISTS dealer_qr_codes(
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    dealer_id INT NOT NULL,
+    venue_id INT NOT NULL,
+    code VARCHAR(128) NOT NULL,
+    target_event_id INT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NULL,
+    UNIQUE KEY uniq_qr_code (code),
+    UNIQUE KEY uniq_dealer_venue (dealer_id, venue_id),
+    INDEX idx_qr_target (target_event_id),
+    FOREIGN KEY (dealer_id) REFERENCES dealers(id) ON DELETE CASCADE,
+    FOREIGN KEY (venue_id) REFERENCES venues(id) ON DELETE CASCADE,
     FOREIGN KEY (target_event_id) REFERENCES events(id) ON DELETE SET NULL
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 

--- a/includes/db.php
+++ b/includes/db.php
@@ -2,7 +2,7 @@
 require_once __DIR__.'/../config.php';
 
 if (!defined('APP_SCHEMA_VERSION')) {
-  define('APP_SCHEMA_VERSION', '20240506_01');
+  define('APP_SCHEMA_VERSION', '20240509_01');
 }
 
 function pdo(): PDO {
@@ -41,6 +41,12 @@ function install_schema(){
     meta_key VARCHAR(64) PRIMARY KEY,
     meta_value TEXT NULL,
     updated_at DATETIME NOT NULL
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+  $pdo->exec("CREATE TABLE IF NOT EXISTS site_settings(
+    setting_key VARCHAR(100) PRIMARY KEY,
+    setting_value MEDIUMTEXT NULL,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
   $currentVersion = null;

--- a/includes/db.php
+++ b/includes/db.php
@@ -45,6 +45,7 @@ function install_schema(){
   /* dealers */
   pdo()->exec("CREATE TABLE IF NOT EXISTS dealers(
     id INT AUTO_INCREMENT PRIMARY KEY,
+    code VARCHAR(16) NULL,
     name VARCHAR(190) NOT NULL,
     email VARCHAR(190) NOT NULL UNIQUE,
     phone VARCHAR(64) NULL,
@@ -58,6 +59,15 @@ function install_schema(){
     created_at DATETIME NOT NULL,
     updated_at DATETIME NULL
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+  if (!column_exists('dealers', 'code')) {
+    pdo()->exec("ALTER TABLE dealers ADD code VARCHAR(16) NULL AFTER id");
+  }
+  try {
+    pdo()->exec("ALTER TABLE dealers ADD UNIQUE KEY uniq_dealer_code (code)");
+  } catch (Throwable $e) {
+    // index already exists
+  }
 
   /* events */
   pdo()->exec("CREATE TABLE IF NOT EXISTS events(

--- a/includes/db.php
+++ b/includes/db.php
@@ -297,6 +297,11 @@ function install_schema(){
     display_name VARCHAR(190) NOT NULL,
     bio TEXT NULL,
     avatar_token VARCHAR(32) NULL,
+    password_hash VARCHAR(255) NULL,
+    password_set_at DATETIME NULL,
+    password_token VARCHAR(64) NULL,
+    password_token_expires_at DATETIME NULL,
+    last_login_at DATETIME NULL,
     is_verified TINYINT(1) NOT NULL DEFAULT 0,
     verify_token VARCHAR(64) NULL,
     verified_at DATETIME NULL,
@@ -309,6 +314,7 @@ function install_schema(){
     UNIQUE KEY uniq_guest_profile (event_id, email),
     INDEX idx_guest_event (event_id),
     INDEX idx_guest_verify (verify_token),
+    INDEX idx_guest_password_token (password_token),
     FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
@@ -336,6 +342,24 @@ function install_schema(){
   if (!column_exists('guest_profiles', 'verified_at')) {
     try { pdo()->exec("ALTER TABLE guest_profiles ADD verified_at DATETIME NULL AFTER verify_token"); } catch (Throwable $e) {}
   }
+  if (!column_exists('guest_profiles', 'password_hash')) {
+    try { pdo()->exec("ALTER TABLE guest_profiles ADD password_hash VARCHAR(255) NULL AFTER avatar_token"); } catch (Throwable $e) {}
+  }
+  if (!column_exists('guest_profiles', 'password_set_at')) {
+    try { pdo()->exec("ALTER TABLE guest_profiles ADD password_set_at DATETIME NULL AFTER password_hash"); } catch (Throwable $e) {}
+  }
+  if (!column_exists('guest_profiles', 'password_token')) {
+    try { pdo()->exec("ALTER TABLE guest_profiles ADD password_token VARCHAR(64) NULL AFTER password_set_at"); } catch (Throwable $e) {}
+  }
+  if (!column_exists('guest_profiles', 'password_token_expires_at')) {
+    try { pdo()->exec("ALTER TABLE guest_profiles ADD password_token_expires_at DATETIME NULL AFTER password_token"); } catch (Throwable $e) {}
+  }
+  if (!column_exists('guest_profiles', 'last_login_at')) {
+    try { pdo()->exec("ALTER TABLE guest_profiles ADD last_login_at DATETIME NULL AFTER password_token_expires_at"); } catch (Throwable $e) {}
+  }
+  try {
+    pdo()->exec("ALTER TABLE guest_profiles ADD INDEX idx_guest_password_token (password_token)");
+  } catch (Throwable $e) {}
 
   if (!column_exists('uploads', 'profile_id')) {
     try { pdo()->exec("ALTER TABLE uploads ADD profile_id INT NULL AFTER guest_name"); } catch (Throwable $e) {}

--- a/includes/dealer_auth.php
+++ b/includes/dealer_auth.php
@@ -60,6 +60,6 @@ function dealer_refresh_session(int $dealer_id): void {
 }
 
 function dealer_can_manage_events(array $dealer): bool {
-  if ($dealer['status'] !== DEALER_STATUS_ACTIVE) return false;
-  return dealer_has_valid_license($dealer);
+  $status = dealer_event_creation_status($dealer);
+  return $status['allowed'];
 }

--- a/includes/dealer_auth.php
+++ b/includes/dealer_auth.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * includes/dealer_auth.php — Bayi paneli oturum yardımcıları
+ */
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/db.php';
+require_once __DIR__.'/functions.php';
+require_once __DIR__.'/dealers.php';
+
+function dealer_login(string $email, string $password): bool {
+  $email = trim($email);
+  if ($email === '' || $password === '') return false;
+
+  $st = pdo()->prepare("SELECT * FROM dealers WHERE email=? LIMIT 1");
+  $st->execute([$email]);
+  $dealer = $st->fetch();
+  if (!$dealer) return false;
+  if ($dealer['status'] !== DEALER_STATUS_ACTIVE) return false;
+  if (empty($dealer['password_hash']) || !password_verify($password, $dealer['password_hash'])) {
+    return false;
+  }
+
+  $_SESSION['dealer'] = [
+    'id'    => (int)$dealer['id'],
+    'email' => $dealer['email'],
+    'name'  => $dealer['name'],
+    'since' => time(),
+  ];
+  dealer_update_last_login((int)$dealer['id']);
+  return true;
+}
+
+function dealer_logout(): void {
+  unset($_SESSION['dealer']);
+}
+
+function dealer_user(): ?array {
+  return !empty($_SESSION['dealer']) ? $_SESSION['dealer'] : null;
+}
+
+function dealer_require_login(string $login_url = '/dealer/login.php'): void {
+  if (!dealer_user()) {
+    $back = urlencode($_SERVER['REQUEST_URI'] ?? '/dealer/dashboard.php');
+    redirect($login_url.'?next='.$back);
+  }
+}
+
+function dealer_refresh_session(int $dealer_id): void {
+  $dealer = dealer_get($dealer_id);
+  if (!$dealer) {
+    dealer_logout();
+    return;
+  }
+  $_SESSION['dealer'] = [
+    'id'    => (int)$dealer['id'],
+    'email' => $dealer['email'],
+    'name'  => $dealer['name'],
+    'since' => time(),
+  ];
+}
+
+function dealer_can_manage_events(array $dealer): bool {
+  if ($dealer['status'] !== DEALER_STATUS_ACTIVE) return false;
+  return dealer_has_valid_license($dealer);
+}

--- a/includes/dealers.php
+++ b/includes/dealers.php
@@ -388,9 +388,9 @@ function dealer_get_balance(int $dealer_id): int {
 
 function dealer_wallet_flow_totals(int $dealer_id): array {
   $st = pdo()->prepare(
-    "SELECT \
-        COALESCE(SUM(CASE WHEN amount_cents > 0 THEN amount_cents ELSE 0 END),0) AS total_in, \
-        COALESCE(SUM(CASE WHEN amount_cents < 0 THEN amount_cents ELSE 0 END),0) AS total_out \
+    "SELECT
+        COALESCE(SUM(CASE WHEN amount_cents > 0 THEN amount_cents ELSE 0 END), 0) AS total_in,
+        COALESCE(SUM(CASE WHEN amount_cents < 0 THEN amount_cents ELSE 0 END), 0) AS total_out
      FROM dealer_wallet_transactions WHERE dealer_id=?"
   );
   $st->execute([$dealer_id]);

--- a/includes/dealers.php
+++ b/includes/dealers.php
@@ -13,6 +13,28 @@ const DEALER_STATUS_INACTIVE= 'inactive';
 const DEALER_CODE_STATIC = 'static';
 const DEALER_CODE_TRIAL  = 'trial';
 
+const DEALER_PURCHASE_STATUS_ACTIVE   = 'active';
+const DEALER_PURCHASE_STATUS_USED     = 'used';
+const DEALER_PURCHASE_STATUS_EXPIRED  = 'expired';
+const DEALER_PURCHASE_STATUS_PENDING  = 'pending';
+const DEALER_PURCHASE_STATUS_CANCELLED= 'cancelled';
+
+const DEALER_CASHBACK_NONE      = 'none';
+const DEALER_CASHBACK_AWAITING  = 'awaiting_event';
+const DEALER_CASHBACK_PENDING   = 'pending';
+const DEALER_CASHBACK_PAID      = 'paid';
+
+const DEALER_TOPUP_STATUS_PENDING   = 'pending';
+const DEALER_TOPUP_STATUS_COMPLETED = 'completed';
+const DEALER_TOPUP_STATUS_CANCELLED = 'cancelled';
+
+const DEALER_WALLET_TYPE_TOPUP      = 'topup';
+const DEALER_WALLET_TYPE_PURCHASE   = 'purchase';
+const DEALER_WALLET_TYPE_CASHBACK   = 'cashback';
+const DEALER_WALLET_TYPE_ADJUSTMENT = 'adjustment';
+const DEALER_WALLET_TYPE_REFUND     = 'refund';
+const DEALER_WALLET_TYPE_TOPUP_REQ  = 'topup_request';
+
 function dealer_generate_identifier_candidate(): string {
   return 'B'.str_pad((string)random_int(0, 999999), 6, '0', STR_PAD_LEFT);
 }
@@ -354,4 +376,572 @@ function dealer_fetch_assigned_event_ids(int $dealer_id): array {
   $st = pdo()->prepare("SELECT e.id FROM events e INNER JOIN dealer_venues dv ON dv.venue_id=e.venue_id WHERE dv.dealer_id=?");
   $st->execute([$dealer_id]);
   return array_map('intval', array_column($st->fetchAll(), 'id'));
+}
+
+function dealer_get_balance(int $dealer_id): int {
+  $st = pdo()->prepare("SELECT balance_cents FROM dealers WHERE id=? LIMIT 1");
+  $st->execute([$dealer_id]);
+  $value = $st->fetchColumn();
+  return $value !== false ? (int)$value : 0;
+}
+
+function dealer_wallet_adjust(int $dealer_id, int $amount_cents, string $type, string $description = '', array $meta = []): int {
+  $pdo = pdo();
+  $ownTxn = !$pdo->inTransaction();
+  if ($ownTxn) {
+    $pdo->beginTransaction();
+  }
+  try {
+    $lock = $pdo->prepare("SELECT balance_cents FROM dealers WHERE id=? FOR UPDATE");
+    $lock->execute([$dealer_id]);
+    $row = $lock->fetch();
+    if (!$row) {
+      throw new RuntimeException('Bayi bulunamadı.');
+    }
+    $current = (int)$row['balance_cents'];
+    $newBalance = $current + $amount_cents;
+    if ($newBalance < 0) {
+      throw new RuntimeException('Bayi bakiyesi yetersiz.');
+    }
+    $pdo->prepare("UPDATE dealers SET balance_cents=?, updated_at=? WHERE id=?")
+        ->execute([$newBalance, now(), $dealer_id]);
+    $metaJson = $meta ? safe_json_encode($meta) : null;
+    $pdo->prepare("INSERT INTO dealer_wallet_transactions (dealer_id,type,amount_cents,balance_after,description,meta_json,created_at) VALUES (?,?,?,?,?,?,?)")
+        ->execute([
+          $dealer_id,
+          $type,
+          $amount_cents,
+          $newBalance,
+          $description !== '' ? $description : null,
+          $metaJson,
+          now(),
+        ]);
+    if ($ownTxn) {
+      $pdo->commit();
+    }
+    return $newBalance;
+  } catch (Throwable $e) {
+    if ($ownTxn && $pdo->inTransaction()) {
+      $pdo->rollBack();
+    }
+    throw $e;
+  }
+}
+
+function dealer_wallet_transactions(int $dealer_id, int $limit = 20): array {
+  $limit = max(1, (int)$limit);
+  $sql = "SELECT * FROM dealer_wallet_transactions WHERE dealer_id=? ORDER BY id DESC LIMIT $limit";
+  $st = pdo()->prepare($sql);
+  $st->execute([$dealer_id]);
+  $rows = $st->fetchAll();
+  foreach ($rows as &$row) {
+    $row['amount_cents'] = (int)$row['amount_cents'];
+    $row['balance_after'] = (int)$row['balance_after'];
+    $row['meta'] = !empty($row['meta_json']) ? safe_json_decode($row['meta_json']) : null;
+  }
+  return $rows;
+}
+
+function dealer_wallet_type_label(string $type): string {
+  return match ($type) {
+    DEALER_WALLET_TYPE_TOPUP      => 'Bakiye Yükleme',
+    DEALER_WALLET_TYPE_PURCHASE   => 'Paket Satın Alımı',
+    DEALER_WALLET_TYPE_CASHBACK   => 'Cashback',
+    DEALER_WALLET_TYPE_ADJUSTMENT => 'Düzenleme',
+    DEALER_WALLET_TYPE_REFUND     => 'İade',
+    DEALER_WALLET_TYPE_TOPUP_REQ  => 'Yükleme Talebi',
+    default                       => ucfirst($type),
+  };
+}
+
+function dealer_packages_all(bool $onlyActive = false): array {
+  $sql = "SELECT * FROM dealer_packages";
+  if ($onlyActive) {
+    $sql .= " WHERE is_active=1";
+  }
+  $sql .= " ORDER BY price_cents ASC, id ASC";
+  $rows = pdo()->query($sql)->fetchAll();
+  foreach ($rows as &$row) {
+    $row['price_cents'] = (int)$row['price_cents'];
+    $row['event_quota'] = $row['event_quota'] !== null ? (int)$row['event_quota'] : null;
+    $row['duration_days'] = $row['duration_days'] !== null ? (int)$row['duration_days'] : null;
+    $row['cashback_rate'] = (float)$row['cashback_rate'];
+    $row['is_active'] = (int)$row['is_active'];
+  }
+  return $rows;
+}
+
+function dealer_packages_available(): array {
+  return dealer_packages_all(true);
+}
+
+function dealer_package_get(int $package_id): ?array {
+  $st = pdo()->prepare("SELECT * FROM dealer_packages WHERE id=? LIMIT 1");
+  $st->execute([$package_id]);
+  $row = $st->fetch();
+  if (!$row) return null;
+  $row['price_cents'] = (int)$row['price_cents'];
+  $row['event_quota'] = $row['event_quota'] !== null ? (int)$row['event_quota'] : null;
+  $row['duration_days'] = $row['duration_days'] !== null ? (int)$row['duration_days'] : null;
+  $row['cashback_rate'] = (float)$row['cashback_rate'];
+  $row['is_active'] = (int)$row['is_active'];
+  return $row;
+}
+
+function dealer_purchase_get(int $purchase_id): ?array {
+  $sql = "SELECT pp.*, pkg.name AS package_name, pkg.description AS package_description"
+       . " FROM dealer_package_purchases pp"
+       . " INNER JOIN dealer_packages pkg ON pkg.id=pp.package_id"
+       . " WHERE pp.id=? LIMIT 1";
+  $st = pdo()->prepare($sql);
+  $st->execute([$purchase_id]);
+  $row = $st->fetch();
+  if (!$row) return null;
+  $row['price_cents'] = (int)$row['price_cents'];
+  $row['event_quota'] = $row['event_quota'] !== null ? (int)$row['event_quota'] : null;
+  $row['events_used'] = (int)$row['events_used'];
+  $row['duration_days'] = $row['duration_days'] !== null ? (int)$row['duration_days'] : null;
+  $row['cashback_rate'] = (float)$row['cashback_rate'];
+  $row['cashback_amount'] = (int)$row['cashback_amount'];
+  $row['dealer_id'] = (int)$row['dealer_id'];
+  $row['package_id'] = (int)$row['package_id'];
+  $row['lead_event_id'] = $row['lead_event_id'] !== null ? (int)$row['lead_event_id'] : null;
+  return $row;
+}
+
+function dealer_fetch_purchases(int $dealer_id, ?string $status = null): array {
+  $sql = "SELECT pp.*, pkg.name AS package_name, pkg.description AS package_description"
+       . " FROM dealer_package_purchases pp"
+       . " INNER JOIN dealer_packages pkg ON pkg.id=pp.package_id"
+       . " WHERE pp.dealer_id=?";
+  $params = [$dealer_id];
+  if ($status !== null) {
+    $sql .= " AND pp.status=?";
+    $params[] = $status;
+  }
+  $sql .= " ORDER BY pp.created_at DESC";
+  $st = pdo()->prepare($sql);
+  $st->execute($params);
+  $rows = $st->fetchAll();
+  foreach ($rows as &$row) {
+    $row['price_cents'] = (int)$row['price_cents'];
+    $row['event_quota'] = $row['event_quota'] !== null ? (int)$row['event_quota'] : null;
+    $row['events_used'] = (int)$row['events_used'];
+    $row['duration_days'] = $row['duration_days'] !== null ? (int)$row['duration_days'] : null;
+    $row['cashback_rate'] = (float)$row['cashback_rate'];
+    $row['cashback_amount'] = (int)$row['cashback_amount'];
+    $row['dealer_id'] = (int)$row['dealer_id'];
+    $row['package_id'] = (int)$row['package_id'];
+    $row['lead_event_id'] = $row['lead_event_id'] !== null ? (int)$row['lead_event_id'] : null;
+  }
+  return $rows;
+}
+
+function dealer_purchase_status_label(string $status): string {
+  return match ($status) {
+    DEALER_PURCHASE_STATUS_ACTIVE    => 'Aktif',
+    DEALER_PURCHASE_STATUS_USED      => 'Tüketildi',
+    DEALER_PURCHASE_STATUS_EXPIRED   => 'Süresi Doldu',
+    DEALER_PURCHASE_STATUS_PENDING   => 'Beklemede',
+    DEALER_PURCHASE_STATUS_CANCELLED => 'İptal',
+    default                          => ucfirst($status),
+  };
+}
+
+function dealer_cashback_status_label(string $status): string {
+  return match ($status) {
+    DEALER_CASHBACK_PENDING   => 'Ödeme Bekliyor',
+    DEALER_CASHBACK_PAID      => 'Ödendi',
+    DEALER_CASHBACK_AWAITING  => 'Etkinlik Bekleniyor',
+    DEALER_CASHBACK_NONE      => 'N/A',
+    default                   => ucfirst($status),
+  };
+}
+
+function dealer_refresh_purchase_states(int $dealer_id): void {
+  $pdo = pdo();
+  $now = now();
+  $pdo->prepare("UPDATE dealer_package_purchases SET status=?, updated_at=? WHERE dealer_id=? AND status=? AND expires_at IS NOT NULL AND expires_at < ?")
+      ->execute([DEALER_PURCHASE_STATUS_EXPIRED, $now, $dealer_id, DEALER_PURCHASE_STATUS_ACTIVE, $now]);
+  $pdo->prepare("UPDATE dealer_package_purchases SET status=?, updated_at=? WHERE dealer_id=? AND status=? AND event_quota IS NOT NULL AND events_used >= event_quota")
+      ->execute([DEALER_PURCHASE_STATUS_USED, $now, $dealer_id, DEALER_PURCHASE_STATUS_ACTIVE]);
+}
+
+function dealer_event_quota_summary(int $dealer_id): array {
+  dealer_refresh_purchase_states($dealer_id);
+  $active = dealer_fetch_purchases($dealer_id, DEALER_PURCHASE_STATUS_ACTIVE);
+  $summary = [
+    'has_credit' => false,
+    'remaining_events' => 0,
+    'has_unlimited' => false,
+    'unlimited_until' => null,
+    'next_expiry' => null,
+    'active' => $active,
+    'cashback_waiting' => 0,
+    'cashback_pending_amount' => 0,
+    'cashback_awaiting_event' => 0,
+  ];
+  foreach ($active as &$purchase) {
+    $quota = $purchase['event_quota'];
+    $used  = $purchase['events_used'];
+    if (!empty($purchase['expires_at'])) {
+      $expTs = strtotime($purchase['expires_at']);
+      if ($expTs !== false) {
+        if ($summary['next_expiry'] === null || $expTs < strtotime($summary['next_expiry'])) {
+          $summary['next_expiry'] = $purchase['expires_at'];
+        }
+      }
+    }
+    if ($quota === null) {
+      $summary['has_credit'] = true;
+      $summary['has_unlimited'] = true;
+      if (!empty($purchase['expires_at'])) {
+        $expTs = strtotime($purchase['expires_at']);
+        if ($expTs !== false) {
+          if ($summary['unlimited_until'] === null || $expTs < strtotime($summary['unlimited_until'])) {
+            $summary['unlimited_until'] = $purchase['expires_at'];
+          }
+        }
+      }
+    } else {
+      $remaining = max(0, $quota - $used);
+      if ($remaining > 0) {
+        $summary['has_credit'] = true;
+        $summary['remaining_events'] += $remaining;
+      }
+    }
+    if ($purchase['cashback_status'] === DEALER_CASHBACK_PENDING) {
+      $summary['cashback_waiting']++;
+      $summary['cashback_pending_amount'] += max(0, $purchase['cashback_amount']);
+    }
+    if ($purchase['cashback_status'] === DEALER_CASHBACK_AWAITING) {
+      $summary['cashback_awaiting_event']++;
+    }
+  }
+  return $summary;
+}
+
+function dealer_has_event_credit(int $dealer_id): bool {
+  $summary = dealer_event_quota_summary($dealer_id);
+  return $summary['has_credit'];
+}
+
+function dealer_event_creation_status(array $dealer): array {
+  $summary = dealer_event_quota_summary((int)$dealer['id']);
+  if ($dealer['status'] !== DEALER_STATUS_ACTIVE) {
+    return ['allowed' => false, 'reason' => 'Bayiniz aktif durumda değil.', 'summary' => $summary];
+  }
+  if (!dealer_has_valid_license($dealer)) {
+    return ['allowed' => false, 'reason' => 'Lisans süresi geçerli olmadığı için yeni etkinlik oluşturamazsınız.', 'summary' => $summary];
+  }
+  if (!$summary['has_credit']) {
+    return ['allowed' => false, 'reason' => 'Yeni etkinlik oluşturmak için paket satın alın veya bakiyenizi artırın.', 'summary' => $summary];
+  }
+  return ['allowed' => true, 'reason' => null, 'summary' => $summary];
+}
+
+function dealer_purchase_package(int $dealer_id, int $package_id): array {
+  $package = dealer_package_get($package_id);
+  if (!$package) {
+    throw new RuntimeException('Paket bulunamadı.');
+  }
+  if (empty($package['is_active'])) {
+    throw new RuntimeException('Bu paket şu anda satışta değil.');
+  }
+  $price = (int)$package['price_cents'];
+  if ($price <= 0) {
+    throw new RuntimeException('Paket fiyatı geçersiz.');
+  }
+  $pdo = pdo();
+  $ownTxn = !$pdo->inTransaction();
+  if ($ownTxn) {
+    $pdo->beginTransaction();
+  }
+  try {
+    dealer_refresh_purchase_states($dealer_id);
+    dealer_wallet_adjust($dealer_id, -$price, DEALER_WALLET_TYPE_PURCHASE, 'Paket: '.$package['name'], [
+      'package_id' => $package_id,
+    ]);
+    $now = now();
+    $expiresAt = null;
+    $duration = $package['duration_days'];
+    if ($duration !== null && $duration > 0) {
+      $dt = new DateTime($now);
+      $dt->modify('+'.$duration.' days');
+      $expiresAt = $dt->format('Y-m-d H:i:s');
+    }
+    $eventQuota = $package['event_quota'];
+    if ($eventQuota !== null && $eventQuota <= 0) {
+      $eventQuota = null;
+    }
+    $cashbackRate = (float)$package['cashback_rate'];
+    $cashbackStatus = ($cashbackRate > 0 && $eventQuota === 1) ? DEALER_CASHBACK_AWAITING : DEALER_CASHBACK_NONE;
+    $pdo->prepare("INSERT INTO dealer_package_purchases (dealer_id,package_id,status,price_cents,event_quota,events_used,duration_days,starts_at,expires_at,cashback_rate,cashback_status,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)")
+        ->execute([
+          $dealer_id,
+          $package_id,
+          DEALER_PURCHASE_STATUS_ACTIVE,
+          $price,
+          $eventQuota,
+          0,
+          $duration,
+          $now,
+          $expiresAt,
+          $cashbackRate,
+          $cashbackStatus,
+          $now,
+          $now,
+        ]);
+    $purchaseId = (int)$pdo->lastInsertId();
+    dealer_refresh_purchase_states($dealer_id);
+    if ($ownTxn) {
+      $pdo->commit();
+    }
+    $purchase = dealer_purchase_get($purchaseId);
+    return $purchase ?? [];
+  } catch (Throwable $e) {
+    if ($ownTxn && $pdo->inTransaction()) {
+      $pdo->rollBack();
+    }
+    throw $e;
+  }
+}
+
+function dealer_consume_event_credit(int $dealer_id, int $event_id): void {
+  $pdo = pdo();
+  $ownTxn = !$pdo->inTransaction();
+  if ($ownTxn) {
+    $pdo->beginTransaction();
+  }
+  try {
+    dealer_refresh_purchase_states($dealer_id);
+    $now = now();
+    $sql = "SELECT pp.*, pkg.name AS package_name FROM dealer_package_purchases pp"
+         . " INNER JOIN dealer_packages pkg ON pkg.id=pp.package_id"
+         . " WHERE pp.dealer_id=? AND pp.status=? AND (pp.expires_at IS NULL OR pp.expires_at >= ?)"
+         . " ORDER BY (pp.event_quota IS NULL) ASC, pp.expires_at IS NULL, pp.expires_at ASC, pp.id ASC FOR UPDATE";
+    $st = $pdo->prepare($sql);
+    $st->execute([$dealer_id, DEALER_PURCHASE_STATUS_ACTIVE, $now]);
+    $rows = $st->fetchAll();
+    $target = null;
+    foreach ($rows as $row) {
+      $quota = $row['event_quota'] !== null ? (int)$row['event_quota'] : null;
+      $used = (int)$row['events_used'];
+      if ($quota === null || $used < $quota) {
+        $target = $row;
+        break;
+      }
+    }
+    if (!$target) {
+      throw new RuntimeException('Kullanılabilir paket bulunamadı.');
+    }
+    $quota = $target['event_quota'] !== null ? (int)$target['event_quota'] : null;
+    $used = (int)$target['events_used'];
+    $used++;
+    $fields = ['events_used=?', 'updated_at=?'];
+    $params = [$used, $now];
+    $newStatus = $target['status'];
+    if ($quota !== null && $used >= $quota) {
+      $newStatus = DEALER_PURCHASE_STATUS_USED;
+      $fields[] = 'status=?';
+      $params[] = $newStatus;
+    }
+    $setLead = empty($target['lead_event_id']);
+    $cashbackRate = (float)$target['cashback_rate'];
+    if ($cashbackRate > 0 && $quota === 1 && $target['cashback_status'] !== DEALER_CASHBACK_PENDING && $target['cashback_status'] !== DEALER_CASHBACK_PAID) {
+      $amount = (int)round(((int)$target['price_cents']) * $cashbackRate);
+      $fields[] = 'cashback_status=?';
+      $params[] = DEALER_CASHBACK_PENDING;
+      $fields[] = 'cashback_amount=?';
+      $params[] = $amount;
+      $fields[] = 'lead_event_id=?';
+      $params[] = $event_id;
+      $setLead = false;
+    }
+    if ($setLead) {
+      $fields[] = 'lead_event_id=?';
+      $params[] = $event_id;
+    }
+    $params[] = (int)$target['id'];
+    $pdo->prepare('UPDATE dealer_package_purchases SET '.implode(', ', $fields).' WHERE id=?')
+        ->execute($params);
+    dealer_refresh_purchase_states($dealer_id);
+    if ($ownTxn) {
+      $pdo->commit();
+    }
+  } catch (Throwable $e) {
+    if ($ownTxn && $pdo->inTransaction()) {
+      $pdo->rollBack();
+    }
+    throw $e;
+  }
+}
+
+function dealer_cashback_candidates(int $dealer_id, ?string $status = DEALER_CASHBACK_PENDING): array {
+  $sql = "SELECT pp.*, pkg.name AS package_name, e.title AS event_title, e.event_date"
+       . " FROM dealer_package_purchases pp"
+       . " INNER JOIN dealer_packages pkg ON pkg.id=pp.package_id"
+       . " LEFT JOIN events e ON e.id=pp.lead_event_id"
+       . " WHERE pp.dealer_id=?";
+  $params = [$dealer_id];
+  if ($status !== null) {
+    $sql .= " AND pp.cashback_status=?";
+    $params[] = $status;
+  }
+  $sql .= " ORDER BY pp.created_at DESC";
+  $st = pdo()->prepare($sql);
+  $st->execute($params);
+  $rows = $st->fetchAll();
+  foreach ($rows as &$row) {
+    $row['cashback_amount'] = (int)$row['cashback_amount'];
+    $row['price_cents'] = (int)$row['price_cents'];
+  }
+  return $rows;
+}
+
+function dealer_pay_cashback(int $purchase_id, string $note = '', array $meta = []): void {
+  $pdo = pdo();
+  $ownTxn = !$pdo->inTransaction();
+  if ($ownTxn) {
+    $pdo->beginTransaction();
+  }
+  try {
+    $st = $pdo->prepare("SELECT * FROM dealer_package_purchases WHERE id=? FOR UPDATE");
+    $st->execute([$purchase_id]);
+    $purchase = $st->fetch();
+    if (!$purchase) {
+      throw new RuntimeException('Satın alma kaydı bulunamadı.');
+    }
+    if ($purchase['cashback_status'] !== DEALER_CASHBACK_PENDING) {
+      throw new RuntimeException('Bu satın alma için bekleyen cashback yok.');
+    }
+    $amount = (int)$purchase['cashback_amount'];
+    if ($amount <= 0) {
+      throw new RuntimeException('Cashback tutarı tanımlı değil.');
+    }
+    $meta['purchase_id'] = $purchase_id;
+    if (!empty($purchase['lead_event_id'])) {
+      $meta['event_id'] = (int)$purchase['lead_event_id'];
+    }
+    dealer_wallet_adjust((int)$purchase['dealer_id'], $amount, DEALER_WALLET_TYPE_CASHBACK, 'Cashback ödemesi', $meta);
+    $pdo->prepare("UPDATE dealer_package_purchases SET cashback_status=?, cashback_paid_at=?, cashback_note=?, updated_at=? WHERE id=?")
+        ->execute([
+          DEALER_CASHBACK_PAID,
+          now(),
+          $note !== '' ? $note : null,
+          now(),
+          $purchase_id,
+        ]);
+    if ($ownTxn) {
+      $pdo->commit();
+    }
+  } catch (Throwable $e) {
+    if ($ownTxn && $pdo->inTransaction()) {
+      $pdo->rollBack();
+    }
+    throw $e;
+  }
+}
+
+function dealer_create_topup_request(int $dealer_id, int $amount_cents): int {
+  if ($amount_cents <= 0) {
+    throw new RuntimeException('Geçerli bir tutar girin.');
+  }
+  $now = now();
+  $st = pdo()->prepare("INSERT INTO dealer_topups (dealer_id, amount_cents, status, created_at, updated_at) VALUES (?,?,?,?,?)");
+  $st->execute([$dealer_id, $amount_cents, DEALER_TOPUP_STATUS_PENDING, $now, $now]);
+  return (int)pdo()->lastInsertId();
+}
+
+function dealer_topups_for_dealer(int $dealer_id, ?string $status = null): array {
+  $sql = "SELECT * FROM dealer_topups WHERE dealer_id=?";
+  $params = [$dealer_id];
+  if ($status !== null) {
+    $sql .= " AND status=?";
+    $params[] = $status;
+  }
+  $sql .= " ORDER BY id DESC";
+  $st = pdo()->prepare($sql);
+  $st->execute($params);
+  $rows = $st->fetchAll();
+  foreach ($rows as &$row) {
+    $row['amount_cents'] = (int)$row['amount_cents'];
+    $row['dealer_id'] = (int)$row['dealer_id'];
+    $row['payload'] = !empty($row['payload_json']) ? safe_json_decode($row['payload_json']) : null;
+  }
+  return $rows;
+}
+
+function dealer_topup_status_label(string $status): string {
+  return match ($status) {
+    DEALER_TOPUP_STATUS_PENDING   => 'Bekliyor',
+    DEALER_TOPUP_STATUS_COMPLETED => 'Tamamlandı',
+    DEALER_TOPUP_STATUS_CANCELLED => 'İptal',
+    default                       => ucfirst($status),
+  };
+}
+
+function dealer_mark_topup_completed(int $topup_id, ?string $reference = null, array $payload = []): void {
+  $pdo = pdo();
+  $ownTxn = !$pdo->inTransaction();
+  if ($ownTxn) {
+    $pdo->beginTransaction();
+  }
+  try {
+    $st = $pdo->prepare("SELECT * FROM dealer_topups WHERE id=? FOR UPDATE");
+    $st->execute([$topup_id]);
+    $row = $st->fetch();
+    if (!$row) {
+      throw new RuntimeException('Yükleme isteği bulunamadı.');
+    }
+    if ($row['status'] === DEALER_TOPUP_STATUS_COMPLETED) {
+      if ($ownTxn) {
+        $pdo->commit();
+      }
+      return;
+    }
+    if ($row['status'] !== DEALER_TOPUP_STATUS_PENDING) {
+      throw new RuntimeException('Bu kayıt işleme kapalı.');
+    }
+    $amount = (int)$row['amount_cents'];
+    if ($amount <= 0) {
+      throw new RuntimeException('Tutar tanımlı değil.');
+    }
+    $meta = ['topup_id' => $topup_id];
+    if ($reference) {
+      $meta['reference'] = $reference;
+    }
+    dealer_wallet_adjust((int)$row['dealer_id'], $amount, DEALER_WALLET_TYPE_TOPUP, 'Bakiye yükleme', $meta);
+    $payloadJson = $payload ? safe_json_encode($payload) : null;
+    $pdo->prepare("UPDATE dealer_topups SET status=?, paytr_reference=?, payload_json=?, completed_at=?, updated_at=? WHERE id=?")
+        ->execute([
+          DEALER_TOPUP_STATUS_COMPLETED,
+          $reference ?: null,
+          $payloadJson,
+          now(),
+          now(),
+          $topup_id,
+        ]);
+    if ($ownTxn) {
+      $pdo->commit();
+    }
+  } catch (Throwable $e) {
+    if ($ownTxn && $pdo->inTransaction()) {
+      $pdo->rollBack();
+    }
+    throw $e;
+  }
+}
+
+function dealer_cancel_topup(int $topup_id, ?int $dealer_id = null): void {
+  if ($dealer_id !== null) {
+    $st = pdo()->prepare("UPDATE dealer_topups SET status=?, updated_at=? WHERE id=? AND dealer_id=? AND status=?");
+    $st->execute([DEALER_TOPUP_STATUS_CANCELLED, now(), $topup_id, $dealer_id, DEALER_TOPUP_STATUS_PENDING]);
+  } else {
+    $st = pdo()->prepare("UPDATE dealer_topups SET status=?, updated_at=? WHERE id=? AND status=?");
+    $st->execute([DEALER_TOPUP_STATUS_CANCELLED, now(), $topup_id, DEALER_TOPUP_STATUS_PENDING]);
+  }
+  if ($st->rowCount() === 0) {
+    throw new RuntimeException('İptal edilecek bekleyen yükleme bulunamadı.');
+  }
 }

--- a/includes/dealers.php
+++ b/includes/dealers.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * includes/dealers.php — Bayi (franchise) yardımcı fonksiyonları
+ */
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/db.php';
+require_once __DIR__.'/functions.php';
+
+const DEALER_STATUS_PENDING = 'pending';
+const DEALER_STATUS_ACTIVE  = 'active';
+const DEALER_STATUS_INACTIVE= 'inactive';
+
+const DEALER_CODE_STATIC = 'static';
+const DEALER_CODE_TRIAL  = 'trial';
+
+/** Benzersiz kod üret (harf + rakam, karışık). */
+function dealer_generate_code_string(int $length = 8): string {
+  $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  $out = '';
+  $max = strlen($alphabet) - 1;
+  for ($i = 0; $i < $length; $i++) {
+    $out .= $alphabet[random_int(0, $max)];
+  }
+  return $out;
+}
+
+function dealer_generate_unique_code(): string {
+  while (true) {
+    $code = dealer_generate_code_string(8);
+    $st = pdo()->prepare("SELECT 1 FROM dealer_codes WHERE code=? LIMIT 1");
+    $st->execute([$code]);
+    if ($st->fetch()) continue;
+    // qr_codes ile çakışmasın
+    $st2 = pdo()->prepare("SELECT 1 FROM qr_codes WHERE code=? LIMIT 1");
+    $st2->execute([$code]);
+    if ($st2->fetch()) continue;
+    return $code;
+  }
+}
+
+function dealer_ensure_codes(int $dealer_id): array {
+  $types = [DEALER_CODE_STATIC, DEALER_CODE_TRIAL];
+  foreach ($types as $type) {
+    $st = pdo()->prepare("SELECT id FROM dealer_codes WHERE dealer_id=? AND type=? LIMIT 1");
+    $st->execute([$dealer_id, $type]);
+    if (!$st->fetch()) {
+      $code = dealer_generate_unique_code();
+      pdo()->prepare("INSERT INTO dealer_codes (dealer_id,type,code,created_at) VALUES (?,?,?,?)")
+          ->execute([$dealer_id, $type, $code, now()]);
+    }
+  }
+  return dealer_get_codes($dealer_id);
+}
+
+function dealer_get_codes(int $dealer_id): array {
+  $st = pdo()->prepare("SELECT * FROM dealer_codes WHERE dealer_id=? ORDER BY type");
+  $st->execute([$dealer_id]);
+  $rows = [];
+  foreach ($st->fetchAll() as $row) {
+    $rows[$row['type']] = $row;
+  }
+  return $rows;
+}
+
+function dealer_regenerate_code(int $dealer_id, string $type): string {
+  $type = $type === DEALER_CODE_TRIAL ? DEALER_CODE_TRIAL : DEALER_CODE_STATIC;
+  $code = dealer_generate_unique_code();
+  pdo()->prepare("UPDATE dealer_codes SET code=?, updated_at=?, target_event_id=NULL WHERE dealer_id=? AND type=?")
+      ->execute([$code, now(), $dealer_id, $type]);
+  return $code;
+}
+
+function dealer_set_code_target(int $dealer_id, string $type, ?int $event_id): void {
+  $type = $type === DEALER_CODE_TRIAL ? DEALER_CODE_TRIAL : DEALER_CODE_STATIC;
+  pdo()->prepare("UPDATE dealer_codes SET target_event_id=?, updated_at=? WHERE dealer_id=? AND type=?")
+      ->execute([$event_id ?: null, now(), $dealer_id, $type]);
+}
+
+function dealer_get(int $dealer_id): ?array {
+  $st = pdo()->prepare("SELECT * FROM dealers WHERE id=? LIMIT 1");
+  $st->execute([$dealer_id]);
+  $row = $st->fetch();
+  return $row ?: null;
+}
+
+function dealer_find_by_email(string $email): ?array {
+  $st = pdo()->prepare("SELECT * FROM dealers WHERE email=? LIMIT 1");
+  $st->execute([$email]);
+  $row = $st->fetch();
+  return $row ?: null;
+}
+
+function dealer_status_badge(string $status): string {
+  return match ($status) {
+    DEALER_STATUS_ACTIVE   => 'Aktif',
+    DEALER_STATUS_INACTIVE => 'Pasif',
+    default                => 'Onay Bekliyor',
+  };
+}
+
+function dealer_has_valid_license(array $dealer): bool {
+  if (empty($dealer['license_expires_at'])) return false;
+  $exp = new DateTime($dealer['license_expires_at']);
+  $now = new DateTime('now');
+  return $exp >= $now;
+}
+
+function dealer_license_label(array $dealer): string {
+  if (empty($dealer['license_expires_at'])) {
+    return 'Tanımlı değil';
+  }
+  $exp = new DateTime($dealer['license_expires_at']);
+  return $exp->format('d.m.Y H:i');
+}
+
+function dealer_assign_venues(int $dealer_id, array $venue_ids): void {
+  $venue_ids = array_map('intval', $venue_ids);
+  $venue_ids = array_values(array_unique(array_filter($venue_ids)));
+  $pdo = pdo();
+  $pdo->beginTransaction();
+  try {
+    if ($venue_ids) {
+      $ph = implode(',', array_fill(0, count($venue_ids), '?'));
+      $params = array_merge([$dealer_id], $venue_ids);
+      $pdo->prepare("DELETE FROM dealer_venues WHERE dealer_id=? AND venue_id NOT IN ($ph)")
+          ->execute($params);
+    } else {
+      $pdo->prepare("DELETE FROM dealer_venues WHERE dealer_id=?")->execute([$dealer_id]);
+    }
+
+    $existing = $pdo->prepare("SELECT venue_id FROM dealer_venues WHERE dealer_id=?");
+    $existing->execute([$dealer_id]);
+    $current = array_map('intval', array_column($existing->fetchAll(), 'venue_id'));
+    foreach ($venue_ids as $vid) {
+      if (!in_array($vid, $current, true)) {
+        $pdo->prepare("INSERT INTO dealer_venues (dealer_id, venue_id, created_at) VALUES (?,?,?)")
+            ->execute([$dealer_id, $vid, now()]);
+      }
+    }
+    $pdo->commit();
+  } catch (Throwable $e) {
+    $pdo->rollBack();
+    throw $e;
+  }
+}
+
+function dealer_fetch_venues(int $dealer_id, bool $onlyActive = false): array {
+  $sql = "SELECT v.* FROM venues v INNER JOIN dealer_venues dv ON dv.venue_id=v.id WHERE dv.dealer_id=?";
+  if ($onlyActive) {
+    $sql .= " AND v.is_active=1";
+  }
+  $sql .= " ORDER BY v.name";
+  $st = pdo()->prepare($sql);
+  $st->execute([$dealer_id]);
+  return $st->fetchAll();
+}
+
+function dealer_event_belongs_to_dealer(int $dealer_id, int $event_id): bool {
+  $st = pdo()->prepare("SELECT 1 FROM events e INNER JOIN dealer_venues dv ON dv.venue_id=e.venue_id WHERE e.id=? AND dv.dealer_id=? LIMIT 1");
+  $st->execute([$event_id, $dealer_id]);
+  return (bool)$st->fetchColumn();
+}
+
+function dealer_allowed_events(int $dealer_id): array {
+  $st = pdo()->prepare("SELECT e.* FROM events e INNER JOIN dealer_venues dv ON dv.venue_id=e.venue_id WHERE dv.dealer_id=? ORDER BY e.event_date DESC, e.id DESC");
+  $st->execute([$dealer_id]);
+  return $st->fetchAll();
+}
+
+function dealer_sync_codes(int $dealer_id): array {
+  dealer_ensure_codes($dealer_id);
+  return dealer_get_codes($dealer_id);
+}
+
+function dealer_notify_new_application(array $dealer): void {
+  $to = defined('MAIL_FROM') && MAIL_FROM ? MAIL_FROM : 'info@localhost';
+  $subject = 'Yeni bayi başvurusu';
+  $html = '<h3>'.h(APP_NAME).' — Yeni Bayi Başvurusu</h3>'
+        . '<p><strong>Ad:</strong> '.h($dealer['name']).'</p>'
+        . '<p><strong>E-posta:</strong> '.h($dealer['email']).'</p>';
+  if (!empty($dealer['phone'])) {
+    $html .= '<p><strong>Telefon:</strong> '.h($dealer['phone']).'</p>';
+  }
+  if (!empty($dealer['company'])) {
+    $html .= '<p><strong>Firma:</strong> '.h($dealer['company']).'</p>';
+  }
+  if (!empty($dealer['notes'])) {
+    $html .= '<p><strong>Not:</strong><br>'.nl2br(h($dealer['notes'])).'</p>';
+  }
+  send_mail_simple($to, $subject, $html);
+}
+
+function dealer_send_application_receipt(array $dealer): void {
+  $html = '<h3>'.h(APP_NAME).' Bayi Başvurusu</h3>'
+        . '<p>Başvurunuz alınmıştır. İnceleme sonrasında size dönüş yapılacaktır.</p>';
+  send_mail_simple($dealer['email'], 'Başvurunuz alındı', $html);
+}
+
+function dealer_random_password(int $length = 10): string {
+  $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789';
+  $out = '';
+  $max = strlen($alphabet) - 1;
+  for ($i=0; $i<$length; $i++) {
+    $out .= $alphabet[random_int(0, $max)];
+  }
+  return $out;
+}
+
+function dealer_send_welcome_mail(array $dealer, string $plain_password): void {
+  $loginUrl = BASE_URL.'/dealer/login.php';
+  $html = '<h3>'.h(APP_NAME).' Bayi Paneli</h3>'
+        . '<p>Bayilik başvurunuz onaylandı.</p>'
+        . '<p><strong>Giriş E-postası:</strong> '.h($dealer['email']).'<br>'
+        . '<strong>Geçici Şifre:</strong> '.h($plain_password).'</p>'
+        . '<p><a href="'.h($loginUrl).'">Panele giriş yapın</a> ve ilk girişte şifrenizi değiştirin.</p>';
+  send_mail_simple($dealer['email'], 'Bayilik paneliniz hazır', $html);
+}
+
+function dealer_update_last_login(int $dealer_id): void {
+  pdo()->prepare("UPDATE dealers SET last_login_at=?, updated_at=? WHERE id=?")
+      ->execute([now(), now(), $dealer_id]);
+}
+
+function dealer_license_warning(array $dealer): ?string {
+  if (empty($dealer['license_expires_at'])) {
+    return 'Lisans süresi tanımlı değil.';
+  }
+  $exp = new DateTime($dealer['license_expires_at']);
+  $now = new DateTime('now');
+  if ($exp < $now) {
+    return 'Lisans süresi dolmuştur.';
+  }
+  $diff = $now->diff($exp);
+  if ($diff->days !== false && $diff->days <= 14) {
+    return 'Lisans süresi yakında ('.max(0, $diff->days).' gün) dolacak.';
+  }
+  return null;
+}
+
+function dealer_fetch_assigned_event_ids(int $dealer_id): array {
+  $st = pdo()->prepare("SELECT e.id FROM events e INNER JOIN dealer_venues dv ON dv.venue_id=e.venue_id WHERE dv.dealer_id=?");
+  $st->execute([$dealer_id]);
+  return array_map('intval', array_column($st->fetchAll(), 'id'));
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -105,7 +105,9 @@ function send_mail_simple(string $to, string $subject, string $html){
   $headers  = "MIME-Version: 1.0\r\n";
   $headers .= "Content-type:text/html;charset=UTF-8\r\n";
   $fromHost = parse_url(BASE_URL, PHP_URL_HOST) ?: 'localhost';
-  $headers .= "From: ".APP_NAME." <no-reply@".$fromHost.">\r\n";
+  $fromName = defined('MAIL_FROM_NAME') && MAIL_FROM_NAME ? MAIL_FROM_NAME : APP_NAME;
+  $fromAddr = defined('MAIL_FROM') && MAIL_FROM ? MAIL_FROM : 'no-reply@'.$fromHost;
+  $headers .= "From: ".$fromName." <".$fromAddr.">\r\n";
   return @mail($to, $subject, $html, $headers);
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -11,6 +11,38 @@ function h($v){ return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
 function redirect($url, $code=302){ header("Location: $url", true, $code); exit; }
 function now(){ return date('Y-m-d H:i:s'); }
 
+function format_currency(int $cents, string $suffix = ' TL'): string {
+  $value = $cents / 100;
+  return number_format($value, 2, ',', '.').$suffix;
+}
+
+function money_to_cents(string $input): int {
+  $clean = trim($input);
+  if ($clean === '') return 0;
+  $clean = str_replace(['₺', 'TL', 'tl'], '', $clean);
+  $clean = trim($clean);
+  if ($clean === '') return 0;
+  $clean = str_replace(' ', '', $clean);
+  $comma = strrpos($clean, ',');
+  $dot   = strrpos($clean, '.');
+  if ($comma !== false && $dot !== false) {
+    if ($comma > $dot) {
+      $clean = str_replace('.', '', $clean);
+      $clean = str_replace(',', '.', $clean);
+    } else {
+      $clean = str_replace(',', '', $clean);
+    }
+  } elseif ($comma !== false) {
+    $clean = str_replace('.', '', $clean);
+    $clean = str_replace(',', '.', $clean);
+  }
+  if (!is_numeric($clean)) {
+    return 0;
+  }
+  $value = (float)$clean;
+  return (int)round($value * 100);
+}
+
 function slugify($s){
   $s = (string)$s;
   $s = trim($s);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -16,6 +16,10 @@ function format_currency(int $cents, string $suffix = ' TL'): string {
   return number_format($value, 2, ',', '.').$suffix;
 }
 
+function paytr_is_test_mode(): bool {
+  return defined('PAYTR_TEST_MODE') && (int)PAYTR_TEST_MODE === 1;
+}
+
 function money_to_cents(string $input): int {
   $clean = trim($input);
   if ($clean === '') return 0;

--- a/includes/guests.php
+++ b/includes/guests.php
@@ -1,0 +1,253 @@
+<?php
+require_once __DIR__.'/db.php';
+require_once __DIR__.'/functions.php';
+
+function guest_profile_normalize_email(string $email): string {
+  $email = trim($email);
+  return $email === '' ? '' : mb_strtolower($email, 'UTF-8');
+}
+
+function guest_profile_current(int $eventId): ?array {
+  $store = $_SESSION['guest_profiles'][$eventId] ?? null;
+  if (!$store) return null;
+  $profileId = (int)$store;
+  $st = pdo()->prepare("SELECT * FROM guest_profiles WHERE id=? AND event_id=? LIMIT 1");
+  $st->execute([$profileId, $eventId]);
+  $profile = $st->fetch();
+  if (!$profile) {
+    unset($_SESSION['guest_profiles'][$eventId]);
+    return null;
+  }
+  return $profile;
+}
+
+function guest_profile_set_session(int $eventId, int $profileId): void {
+  if (!isset($_SESSION['guest_profiles']) || !is_array($_SESSION['guest_profiles'])) {
+    $_SESSION['guest_profiles'] = [];
+  }
+  $_SESSION['guest_profiles'][$eventId] = $profileId;
+}
+
+function guest_profile_clear_session(int $eventId): void {
+  if (isset($_SESSION['guest_profiles'][$eventId])) {
+    unset($_SESSION['guest_profiles'][$eventId]);
+  }
+}
+
+function guest_profile_touch(int $profileId): void {
+  $st = pdo()->prepare("UPDATE guest_profiles SET last_seen_at=?, updated_at=? WHERE id=?");
+  $now = now();
+  $st->execute([$now, $now, $profileId]);
+}
+
+function guest_profile_find_by_email(int $eventId, string $email): ?array {
+  if ($email === '') return null;
+  $st = pdo()->prepare("SELECT * FROM guest_profiles WHERE event_id=? AND email=? LIMIT 1");
+  $st->execute([$eventId, $email]);
+  return $st->fetch() ?: null;
+}
+
+function guest_profile_upsert(int $eventId, string $name, string $email, bool $marketingOptIn): ?array {
+  $email = guest_profile_normalize_email($email);
+  if ($email === '') return null;
+  $pdo = pdo();
+  $pdo->beginTransaction();
+  try {
+    $profile = guest_profile_find_by_email($eventId, $email);
+    $now = now();
+    if ($profile) {
+      $updates = [];
+      $params = [];
+      if ($name !== '' && $profile['name'] !== $name) {
+        $updates[] = 'name=?';
+        $params[] = $name;
+        if ($profile['display_name'] === $profile['name']) {
+          $updates[] = 'display_name=?';
+          $params[] = $name;
+        }
+      }
+      if ($profile['display_name'] === '' && $name !== '') {
+        $updates[] = 'display_name=?';
+        $params[] = $name;
+      }
+      if ($marketingOptIn && (int)$profile['marketing_opt_in'] !== 1) {
+        $updates[] = 'marketing_opt_in=1';
+        $updates[] = 'marketing_opted_at=?';
+        $params[] = $now;
+      }
+      if ($updates) {
+        $updates[] = 'updated_at=?';
+        $params[] = $now;
+        $params[] = (int)$profile['id'];
+        $pdo->prepare('UPDATE guest_profiles SET '.implode(',', $updates).' WHERE id=?')->execute($params);
+      }
+      $pdo->prepare('UPDATE guest_profiles SET last_seen_at=? WHERE id=?')->execute([$now, (int)$profile['id']]);
+    } else {
+      $token = bin2hex(random_bytes(20));
+      $pdo->prepare("INSERT INTO guest_profiles (event_id,email,name,display_name,is_verified,verify_token,marketing_opt_in,marketing_opted_at,last_seen_at,created_at,updated_at)
+                     VALUES (?,?,?,?,0,?,?,?,?,?,?)")
+          ->execute([
+            $eventId,
+            $email,
+            $name ?: 'Misafir',
+            $name ?: 'Misafir',
+            $token,
+            $marketingOptIn ? 1 : 0,
+            $marketingOptIn ? $now : null,
+            $now,
+            $now,
+            $now
+          ]);
+      $profileId = (int)$pdo->lastInsertId();
+      $profile = guest_profile_find_by_email($eventId, $email);
+      if ($profile) {
+        $profile['id'] = $profileId;
+      }
+    }
+    $pdo->commit();
+  } catch (Throwable $e) {
+    if ($pdo->inTransaction()) $pdo->rollBack();
+    throw $e;
+  }
+  return guest_profile_find_by_email($eventId, $email);
+}
+
+function guest_profile_send_verification(array $profile, array $event): bool {
+  if ((int)$profile['is_verified'] === 1) return true;
+  if (empty($profile['verify_token'])) {
+    $token = bin2hex(random_bytes(20));
+    pdo()->prepare('UPDATE guest_profiles SET verify_token=?, updated_at=? WHERE id=?')->execute([$token, now(), (int)$profile['id']]);
+    $profile['verify_token'] = $token;
+  }
+  $verifyUrl = BASE_URL.'/public/guest_verify.php?token='.rawurlencode($profile['verify_token']);
+  $eventUrl = public_upload_url((int)$event['id']);
+  $html = '<div style="font-family:Inter,Arial,sans-serif;background:#f8fafc;padding:24px">'
+        .'<div style="max-width:520px;margin:0 auto;background:#fff;border-radius:18px;padding:32px;box-shadow:0 18px 45px rgba(15,23,42,0.08);">'
+        .'<h2 style="margin-top:0;color:#0ea5b5;font-size:24px;">BİKARE Misafir Profilinizi Doğrulayın</h2>'
+        .'<p style="color:#475569;font-size:15px;line-height:1.6;">Merhaba '.h($profile['display_name'] ?: $profile['name']).',</p>'
+        .'<p style="color:#475569;font-size:15px;line-height:1.6;">'.h($event['title']).' etkinliğinin dijital albümüne katıldığınız için teşekkür ederiz. Profilinizi doğruladığınızda fotoğrafları beğenebilir, yorum yazabilir ve misafir sohbetine katılabilirsiniz.</p>'
+        .'<p style="text-align:center;margin:32px 0">'
+        .'<a href="'.h($verifyUrl).'" style="background:#0ea5b5;color:#fff;text-decoration:none;padding:14px 26px;border-radius:999px;font-weight:600;display:inline-block;">Profilimi Doğrula</a>'
+        .'</p>'
+        .'<p style="color:#475569;font-size:14px;line-height:1.6;">Bağlantı çalışmazsa kopyalayıp tarayıcınıza yapıştırabilirsiniz:<br><a href="'.h($verifyUrl).'" style="color:#0ea5b5;text-decoration:none;">'.h($verifyUrl).'</a></p>'
+        .'<p style="color:#94a3b8;font-size:13px;margin-top:32px;">Etkinlik sayfasına dönmek için <a href="'.h($eventUrl).'" style="color:#0ea5b5;text-decoration:none;">buraya tıklayın</a>.</p>'
+        .'</div></div>';
+  require_once __DIR__.'/mailer.php';
+  $sent = send_smtp_mail($profile['email'], 'BİKARE profil doğrulaması', $html);
+  if ($sent) {
+    pdo()->prepare('UPDATE guest_profiles SET last_verification_sent_at=?, updated_at=? WHERE id=?')
+        ->execute([now(), now(), (int)$profile['id']]);
+  }
+  return $sent;
+}
+
+function guest_profile_verify_token(string $token): ?array {
+  $token = trim($token);
+  if ($token === '') return null;
+  $st = pdo()->prepare('SELECT * FROM guest_profiles WHERE verify_token=? LIMIT 1');
+  $st->execute([$token]);
+  $profile = $st->fetch();
+  if (!$profile) return null;
+  $now = now();
+  pdo()->prepare('UPDATE guest_profiles SET is_verified=1, verified_at=?, verify_token=NULL, updated_at=? WHERE id=?')
+      ->execute([$now, $now, (int)$profile['id']]);
+  $fresh = guest_profile_current_after_verify((int)$profile['id']);
+  if ($fresh) {
+    guest_profile_touch((int)$fresh['id']);
+  }
+  return $fresh;
+}
+
+function guest_profile_current_after_verify(int $profileId): ?array {
+  $st = pdo()->prepare('SELECT * FROM guest_profiles WHERE id=? LIMIT 1');
+  $st->execute([$profileId]);
+  return $st->fetch() ?: null;
+}
+
+function guest_upload_like(int $uploadId, int $profileId): void {
+  $now = now();
+  $st = pdo()->prepare('INSERT IGNORE INTO guest_upload_likes (upload_id, profile_id, created_at) VALUES (?,?,?)');
+  $st->execute([$uploadId, $profileId, $now]);
+}
+
+function guest_upload_unlike(int $uploadId, int $profileId): void {
+  $st = pdo()->prepare('DELETE FROM guest_upload_likes WHERE upload_id=? AND profile_id=?');
+  $st->execute([$uploadId, $profileId]);
+}
+
+function guest_upload_comment_add(int $uploadId, ?array $profile, string $body): void {
+  $body = trim($body);
+  if ($body === '') return;
+  $body = mb_substr($body, 0, 1000, 'UTF-8');
+  $now = now();
+  $pdo = pdo();
+  $pdo->prepare('INSERT INTO guest_upload_comments (upload_id, profile_id, guest_name, guest_email, body, created_at)
+                 VALUES (?,?,?,?,?,?)')
+      ->execute([
+        $uploadId,
+        $profile ? (int)$profile['id'] : null,
+        $profile['display_name'] ?? ($profile['name'] ?? 'Misafir'),
+        $profile['email'] ?? null,
+        $body,
+        $now
+      ]);
+}
+
+function guest_chat_add_message(int $eventId, array $profile, string $message, ?int $attachmentUploadId = null): void {
+  $message = trim($message);
+  if ($message === '') return;
+  $message = mb_substr($message, 0, 2000, 'UTF-8');
+  $now = now();
+  pdo()->prepare('INSERT INTO guest_chat_messages (event_id, profile_id, message, attachment_upload_id, created_at)
+                  VALUES (?,?,?,?,?)')
+      ->execute([$eventId, (int)$profile['id'], $message, $attachmentUploadId, $now]);
+  guest_profile_touch((int)$profile['id']);
+}
+
+function guest_profile_update(int $profileId, string $displayName, string $bio, string $avatarToken, bool $marketingOptIn): void {
+  $displayName = trim($displayName);
+  if ($displayName === '') $displayName = 'Misafir';
+  $bio = trim($bio);
+  $bio = mb_substr($bio, 0, 600, 'UTF-8');
+  $avatarToken = trim($avatarToken);
+  $now = now();
+  $fields = ['display_name=?', 'bio=?', 'avatar_token=?', 'marketing_opt_in=?', 'updated_at=?'];
+  $params = [
+    $displayName,
+    $bio === '' ? null : $bio,
+    $avatarToken === '' ? null : $avatarToken,
+    $marketingOptIn ? 1 : 0,
+    $now,
+    $profileId
+  ];
+  if ($marketingOptIn) {
+    pdo()->prepare('UPDATE guest_profiles SET '.implode(',', $fields).', marketing_opted_at=? WHERE id=?')
+        ->execute([
+          $displayName,
+          $bio === '' ? null : $bio,
+          $avatarToken === '' ? null : $avatarToken,
+          1,
+          $now,
+          $now,
+          $profileId
+        ]);
+  } else {
+    pdo()->prepare('UPDATE guest_profiles SET '.implode(',', $fields).', marketing_opted_at=NULL WHERE id=?')
+        ->execute([
+          $displayName,
+          $bio === '' ? null : $bio,
+          $avatarToken === '' ? null : $avatarToken,
+          0,
+          $now,
+          $profileId
+        ]);
+  }
+}
+
+function guest_profile_avatar_seed(array $profile): string {
+  $token = $profile['avatar_token'] ?? '';
+  if ($token === '' || $token === null) {
+    $token = substr(hash('sha256', $profile['email'].$profile['id']), 0, 6);
+  }
+  return $token;
+}

--- a/includes/mailer.php
+++ b/includes/mailer.php
@@ -4,7 +4,7 @@ require_once __DIR__.'/../config.php';
 /*
 config.php içine şunlar tanımlı olmalı:
 const MAIL_FROM = 'no-reply@SIZINDOMAIN.com';
-const MAIL_FROM_NAME = 'Wedding Share';
+const MAIL_FROM_NAME = 'BİKARE';
 const SMTP_HOST = 'smtp.sizindomain.com';
 const SMTP_PORT = 587;          // 587 (TLS) ya da 465 (SSL)
 const SMTP_USER = 'smtp-kullanici@SIZINDOMAIN.com';

--- a/includes/site.php
+++ b/includes/site.php
@@ -175,7 +175,7 @@ function site_create_event(int $venue_id, ?int $dealer_id, array $package, array
   } catch (Throwable $e) {
     // Eski şema desteği için dealer ve user alanlarını çıkarıp tekrar dene
     $columnsFallback = "venue_id,title,slug,is_active,couple_panel_key,theme_primary,theme_accent,event_date,created_at,couple_username,couple_password_hash,couple_force_reset";
-    $placeholdersFallback = "?,?,?,?,?,?,?,?,?,?,?,?,?";
+    $placeholdersFallback = "?,?,?,?,?,?,?,?,?,?,?,?";
     $valuesFallback = [
       $venue_id,
       $title,

--- a/includes/site.php
+++ b/includes/site.php
@@ -7,6 +7,14 @@ require_once __DIR__.'/db.php';
 require_once __DIR__.'/functions.php';
 require_once __DIR__.'/dealers.php';
 
+if (!defined('SITE_ORDER_STATUS_PENDING')) {
+  define('SITE_ORDER_STATUS_PENDING', 'pending_payment');
+  define('SITE_ORDER_STATUS_AWAITING', 'awaiting_payment');
+  define('SITE_ORDER_STATUS_PAID', 'paid');
+  define('SITE_ORDER_STATUS_COMPLETED', 'completed');
+  define('SITE_ORDER_STATUS_FAILED', 'failed');
+}
+
 function site_seed_default_packages(): void {
   try {
     $count = (int)pdo()->query("SELECT COUNT(*) FROM dealer_packages")->fetchColumn();
@@ -228,7 +236,52 @@ function site_create_event(int $venue_id, ?int $dealer_id, array $package, array
   ];
 }
 
-function site_process_customer_order(array $input): array {
+function site_order_normalize_row(?array $row): ?array {
+  if (!$row) {
+    return null;
+  }
+  $row['id'] = (int)$row['id'];
+  $row['package_id'] = (int)$row['package_id'];
+  $row['dealer_id'] = $row['dealer_id'] !== null ? (int)$row['dealer_id'] : null;
+  $row['event_id'] = $row['event_id'] !== null ? (int)$row['event_id'] : null;
+  $row['price_cents'] = (int)$row['price_cents'];
+  $row['cashback_cents'] = (int)$row['cashback_cents'];
+  $row['meta'] = !empty($row['meta_json']) ? (safe_json_decode($row['meta_json']) ?: []) : [];
+  $row['payload'] = !empty($row['payload_json']) ? (safe_json_decode($row['payload_json']) ?: []) : [];
+  $row['created_at'] = $row['created_at'] ?? now();
+  $row['paid_at'] = $row['paid_at'] ?? null;
+  return $row;
+}
+
+function site_get_order(int $order_id): ?array {
+  $st = pdo()->prepare("SELECT * FROM site_orders WHERE id=? LIMIT 1");
+  $st->execute([$order_id]);
+  return site_order_normalize_row($st->fetch());
+}
+
+function site_get_order_by_oid(string $oid): ?array {
+  $oid = trim($oid);
+  if ($oid === '') {
+    return null;
+  }
+  $st = pdo()->prepare("SELECT * FROM site_orders WHERE merchant_oid=? LIMIT 1");
+  $st->execute([$oid]);
+  return site_order_normalize_row($st->fetch());
+}
+
+function site_generate_order_oid(int $order_id): string {
+  do {
+    $rand = strtoupper(bin2hex(random_bytes(6)));
+    $oid = 'SO'.$order_id.'O'.$rand;
+    $oid = substr(preg_replace('/[^A-Za-z0-9]/', '', $oid), 0, 64);
+    $st = pdo()->prepare("SELECT 1 FROM site_orders WHERE merchant_oid=? LIMIT 1");
+    $st->execute([$oid]);
+    $exists = (bool)$st->fetchColumn();
+  } while ($exists);
+  return $oid;
+}
+
+function site_create_customer_order(array $input): array {
   $packageId = (int)($input['package_id'] ?? 0);
   $customerName = trim($input['customer_name'] ?? '');
   $customerEmail = trim($input['customer_email'] ?? '');
@@ -264,97 +317,481 @@ function site_process_customer_order(array $input): array {
       throw new RuntimeException('Bayi kodu şu anda pasif durumda.');
     }
   }
+
+  $pdo = pdo();
+  $now = now();
+  $price = (int)$package['price_cents'];
+  $cashbackRate = $dealer ? max(0, (float)$package['cashback_rate']) : 0.0;
+  $cashbackCents = $dealer ? (int)round($price * $cashbackRate) : 0;
+  $meta = array_filter([
+    'notes' => $notes !== '' ? $notes : null,
+  ]);
+  $pdo->prepare(
+    "INSERT INTO site_orders (package_id, dealer_id, customer_name, customer_email, customer_phone, event_title, event_date, referral_code, status, price_cents, cashback_cents, meta_json, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+  )->execute([
+    $packageId,
+    $dealer ? (int)$dealer['id'] : null,
+    $customerName,
+    $customerEmail,
+    $customerPhone !== '' ? $customerPhone : null,
+    $eventTitle,
+    site_normalize_event_date($eventDate),
+    $referral !== '' ? $referral : null,
+    SITE_ORDER_STATUS_PENDING,
+    $price,
+    $cashbackCents,
+    $meta ? safe_json_encode($meta) : null,
+    $now,
+    $now,
+  ]);
+
+  $orderId = (int)$pdo->lastInsertId();
+  $order = site_get_order($orderId);
+
+  return [
+    'order' => $order,
+    'package' => $package,
+    'dealer' => $dealer,
+    'customer' => [
+      'name' => $customerName,
+      'email' => $customerEmail,
+      'phone' => $customerPhone,
+    ],
+  ];
+}
+
+function site_ensure_order_paytr_token(int $order_id): array {
+  $order = site_get_order($order_id);
+  if (!$order) {
+    throw new RuntimeException('Sipariş bulunamadı.');
+  }
+  $package = dealer_package_get($order['package_id']);
+  if (!$package) {
+    throw new RuntimeException('Paket bulunamadı.');
+  }
+  $dealer = $order['dealer_id'] ? dealer_get((int)$order['dealer_id']) : null;
+
+  if ($order['status'] === SITE_ORDER_STATUS_COMPLETED && $order['event_id']) {
+    return [
+      'order' => $order,
+      'package' => $package,
+      'dealer' => $dealer,
+      'token' => $order['paytr_token'] ?? null,
+      'merchant_oid' => $order['merchant_oid'] ?? null,
+    ];
+  }
+
+  $email = $order['customer_email'];
+  $user_name = mb_substr($order['customer_name'], 0, 64, 'UTF-8');
+  $user_address = 'Online Sipariş';
+  $user_phone = $order['customer_phone'] ?: '—';
+
+  $ip = $_SERVER['HTTP_CF_CONNECTING_IP']
+     ?? $_SERVER['HTTP_X_FORWARDED_FOR']
+     ?? $_SERVER['REMOTE_ADDR']
+     ?? '1.2.3.4';
+  if (strpos($ip, ',') !== false) {
+    $ip = trim(explode(',', $ip)[0]);
+  }
+  if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+    $ip = '1.2.3.4';
+  }
+
+  $amount_cents = max(0, (int)$order['price_cents']);
+  if ($amount_cents <= 0) {
+    throw new RuntimeException('Ödeme tutarı geçersiz.');
+  }
+
+  $basket = [[
+    $package['name'],
+    number_format($amount_cents / 100, 2, '.', ''),
+    1,
+  ]];
+  $user_basket = base64_encode(json_encode($basket, JSON_UNESCAPED_UNICODE));
+
+  $merchantOid = $order['merchant_oid'] ?: site_generate_order_oid($order['id']);
+  $no_installment = 0;
+  $max_installment = 0;
+  $currency = 'TL';
+  $test = (int)PAYTR_TEST_MODE;
+  $hash_str = PAYTR_MERCHANT_ID . $ip . $merchantOid . $email . $amount_cents . $user_basket . $no_installment . $max_installment . $currency . $test;
+  $paytr_token = base64_encode(hash_hmac('sha256', $hash_str . PAYTR_MERCHANT_SALT, PAYTR_MERCHANT_KEY, true));
+
+  $post = [
+    'merchant_id'          => PAYTR_MERCHANT_ID,
+    'user_ip'              => $ip,
+    'merchant_oid'         => $merchantOid,
+    'email'                => $email,
+    'payment_amount'       => $amount_cents,
+    'paytr_token'          => $paytr_token,
+    'user_basket'          => $user_basket,
+    'no_installment'       => $no_installment,
+    'max_installment'      => $max_installment,
+    'user_name'            => $user_name,
+    'user_address'         => $user_address,
+    'user_phone'           => $user_phone,
+    'merchant_ok_url'      => PAYTR_SITE_OK_URL,
+    'merchant_fail_url'    => PAYTR_SITE_FAIL_URL,
+    'merchant_callback_url'=> PAYTR_CALLBACK_URL,
+    'timeout_limit'        => 30,
+    'currency'             => $currency,
+    'test_mode'            => $test,
+  ];
+
+  $ch = curl_init();
+  curl_setopt_array($ch, [
+    CURLOPT_URL            => 'https://www.paytr.com/odeme/api/get-token',
+    CURLOPT_RETURNTRANSFER => 1,
+    CURLOPT_POST           => 1,
+    CURLOPT_POSTFIELDS     => $post,
+    CURLOPT_TIMEOUT        => 30,
+    CURLOPT_SSL_VERIFYPEER => 1,
+  ]);
+  $res = curl_exec($ch);
+  $curlErr = curl_errno($ch) ? curl_error($ch) : null;
+  curl_close($ch);
+
+  if ($curlErr) {
+    throw new RuntimeException('PAYTR bağlantı hatası: '.$curlErr);
+  }
+  $data = json_decode((string)$res, true);
+  if (!$data || ($data['status'] ?? '') !== 'success') {
+    $reason = $data['reason'] ?? 'bilinmiyor';
+    throw new RuntimeException('PAYTR token alınamadı: '.$reason);
+  }
+
+  $token = $data['token'];
+  $payload = [
+    'request' => [
+      'amount_cents' => $amount_cents,
+      'basket'       => $basket,
+      'ip'           => $ip,
+    ],
+    'merchant_oid' => $merchantOid,
+  ];
+
+  pdo()->prepare("UPDATE site_orders SET merchant_oid=?, paytr_token=?, status=?, payload_json=?, updated_at=? WHERE id=?")
+      ->execute([
+        $merchantOid,
+        $token,
+        SITE_ORDER_STATUS_AWAITING,
+        safe_json_encode($payload),
+        now(),
+        $order['id'],
+      ]);
+
+  $order = site_get_order($order['id']);
+
+  return [
+    'order' => $order,
+    'package' => $package,
+    'dealer' => $dealer,
+    'token' => $token,
+    'merchant_oid' => $merchantOid,
+  ];
+}
+
+function site_handle_paytr_callback(string $merchant_oid, string $status, array $payload = []): void {
+  $merchant_oid = trim($merchant_oid);
+  if ($merchant_oid === '') {
+    return;
+  }
   $pdo = pdo();
   $pdo->beginTransaction();
-  try {
-    $now = now();
-    $price = (int)$package['price_cents'];
-    $cashbackRate = $dealer ? max(0, (float)$package['cashback_rate']) : 0.0;
-    $cashbackCents = $dealer ? (int)round($price * $cashbackRate) : 0;
-    $meta = array_filter([
-      'notes' => $notes !== '' ? $notes : null,
-    ]);
-    $metaJson = $meta ? safe_json_encode($meta) : null;
-    $pdo->prepare("INSERT INTO site_orders (package_id, dealer_id, customer_name, customer_email, customer_phone, event_title, event_date, referral_code, status, price_cents, cashback_cents, meta_json, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
+  $st = $pdo->prepare("SELECT * FROM site_orders WHERE merchant_oid=? FOR UPDATE");
+  $st->execute([$merchant_oid]);
+  $row = $st->fetch();
+  if (!$row) {
+    $pdo->commit();
+    return;
+  }
+  $order = site_order_normalize_row($row);
+  $now = now();
+  $payloadData = $order['payload'];
+  if (!is_array($payloadData)) {
+    $payloadData = [];
+  }
+  if (!isset($payloadData['callbacks']) || !is_array($payloadData['callbacks'])) {
+    $payloadData['callbacks'] = [];
+  }
+  $payloadData['callbacks'][] = [
+    'status' => $status,
+    'received_at' => $now,
+    'body' => $payload,
+  ];
+  $reference = $payload['payment_id'] ?? ($payload['merchant_oid'] ?? null);
+
+  $newStatus = $order['status'];
+  $paidAt = $order['paid_at'];
+  if ($status === 'success') {
+    $newStatus = SITE_ORDER_STATUS_PAID;
+    if (!$paidAt) {
+      $paidAt = $now;
+    }
+  } elseif ($status === 'failed') {
+    $newStatus = SITE_ORDER_STATUS_FAILED;
+  }
+
+  $pdo->prepare("UPDATE site_orders SET status=?, paytr_reference=?, paid_at=?, payload_json=?, updated_at=? WHERE id=?")
+      ->execute([
+        $newStatus,
+        $reference ?: ($order['paytr_reference'] ?? null),
+        $paidAt,
+        safe_json_encode($payloadData),
+        $now,
+        $order['id'],
+      ]);
+  $pdo->commit();
+
+  if ($status === 'success') {
+    site_finalize_order($order['id'], ['payload' => $payload]);
+  }
+}
+
+function site_fetch_event_summary(int $event_id): array {
+  $st = pdo()->prepare("SELECT id, venue_id, title, couple_username, couple_panel_key, contact_email FROM events WHERE id=? LIMIT 1");
+  $st->execute([$event_id]);
+  $row = $st->fetch();
+  if (!$row) {
+    throw new RuntimeException('Etkinlik bulunamadı.');
+  }
+  $row['id'] = (int)$row['id'];
+  $row['venue_id'] = (int)$row['venue_id'];
+  return $row;
+}
+
+function site_event_dynamic_code(int $event_id): ?string {
+  $st = pdo()->prepare("SELECT code FROM qr_codes WHERE target_event_id=? ORDER BY id DESC LIMIT 1");
+  $st->execute([$event_id]);
+  $code = $st->fetchColumn();
+  return $code ? (string)$code : null;
+}
+
+function site_finalize_order(int $order_id, array $options = []): array {
+  $pdo = pdo();
+  $pdo->beginTransaction();
+  $st = $pdo->prepare("SELECT * FROM site_orders WHERE id=? FOR UPDATE");
+  $st->execute([$order_id]);
+  $row = $st->fetch();
+  if (!$row) {
+    $pdo->rollBack();
+    throw new RuntimeException('Sipariş bulunamadı.');
+  }
+  $order = site_order_normalize_row($row);
+  $package = dealer_package_get($order['package_id']);
+  if (!$package) {
+    $pdo->rollBack();
+    throw new RuntimeException('Paket bulunamadı.');
+  }
+  $dealer = $order['dealer_id'] ? dealer_get((int)$order['dealer_id']) : null;
+  $meta = is_array($order['meta']) ? $order['meta'] : [];
+  $payloadData = is_array($order['payload']) ? $order['payload'] : [];
+  $now = now();
+
+  if (!empty($options['payload'])) {
+    if (!isset($payloadData['callbacks']) || !is_array($payloadData['callbacks'])) {
+      $payloadData['callbacks'] = [];
+    }
+    $payloadData['callbacks'][] = [
+      'status' => 'finalize',
+      'received_at' => $now,
+      'body' => $options['payload'],
+    ];
+  }
+
+  $alreadyCompleted = $order['status'] === SITE_ORDER_STATUS_COMPLETED && $order['event_id'];
+  $justCreated = false;
+  $eventSummary = null;
+  $eventData = null;
+
+  if ($order['event_id']) {
+    $eventSummary = site_fetch_event_summary($order['event_id']);
+  }
+
+  if (!$alreadyCompleted) {
+    if (!$order['event_id']) {
+      $venueId = $dealer ? (dealer_primary_venue_id((int)$dealer['id']) ?? site_default_sales_venue_id()) : site_default_sales_venue_id();
+      $eventData = site_create_event($venueId, $dealer ? (int)$dealer['id'] : null, $package, [
+        'event_title' => $order['event_title'],
+        'event_date' => $order['event_date'],
+        'customer_email' => $order['customer_email'],
+      ]);
+      $order['event_id'] = $eventData['id'];
+      $eventSummary = site_fetch_event_summary($order['event_id']);
+      $meta['plain_password'] = $eventData['plain_password'];
+      $meta['qr_code'] = $eventData['qr_code'];
+      $meta['upload_url'] = $eventData['upload_url'];
+      $justCreated = true;
+    } elseif (!$eventSummary) {
+      $eventSummary = site_fetch_event_summary($order['event_id']);
+    }
+
+    $paidAt = $order['paid_at'] ?: $now;
+
+    $pdo->prepare("UPDATE site_orders SET status=?, event_id=?, paid_at=?, meta_json=?, payload_json=?, updated_at=? WHERE id=?")
         ->execute([
-          $packageId,
-          $dealer ? (int)$dealer['id'] : null,
-          $customerName,
-          $customerEmail,
-          $customerPhone !== '' ? $customerPhone : null,
-          $eventTitle,
-          site_normalize_event_date($eventDate),
-          $referral !== '' ? $referral : null,
-          'processing',
-          $price,
-          $cashbackCents,
-          $metaJson,
+          SITE_ORDER_STATUS_COMPLETED,
+          $order['event_id'],
+          $paidAt,
+          $meta ? safe_json_encode($meta) : null,
+          $payloadData ? safe_json_encode($payloadData) : null,
+          $now,
+          $order['id'],
+        ]);
+
+    $order['status'] = SITE_ORDER_STATUS_COMPLETED;
+    $order['paid_at'] = $paidAt;
+    $order['meta'] = $meta;
+    $order['payload'] = $payloadData;
+
+    if ($dealer && $order['cashback_cents'] > 0) {
+      $existsSt = $pdo->prepare("SELECT id FROM dealer_package_purchases WHERE dealer_id=? AND lead_event_id=? AND source=? LIMIT 1");
+      $existsSt->execute([(int)$dealer['id'], $order['event_id'], DEALER_PURCHASE_SOURCE_LEAD]);
+      $exists = $existsSt->fetchColumn();
+      if (!$exists) {
+        dealer_wallet_adjust((int)$dealer['id'], (int)$order['cashback_cents'], DEALER_WALLET_TYPE_CASHBACK, 'Web satış cashback', [
+          'order_id' => $order['id'],
+          'package_id' => $order['package_id'],
+        ]);
+        $duration = $package['duration_days'];
+        $startsAt = $now;
+        $expiresAt = null;
+        if ($duration) {
+          $dt = new DateTime($now);
+          $dt->modify('+'.(int)$duration.' days');
+          $expiresAt = $dt->format('Y-m-d H:i:s');
+        }
+        $pdo->prepare(
+          "INSERT INTO dealer_package_purchases (dealer_id, package_id, status, price_cents, event_quota, events_used, duration_days, starts_at, expires_at, cashback_rate, cashback_status, cashback_amount, cashback_paid_at, lead_event_id, source, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+        )->execute([
+          (int)$dealer['id'],
+          $order['package_id'],
+          DEALER_PURCHASE_STATUS_USED,
+          $order['price_cents'],
+          1,
+          1,
+          $package['duration_days'],
+          $startsAt,
+          $expiresAt,
+          $package['cashback_rate'],
+          DEALER_CASHBACK_PAID,
+          $order['cashback_cents'],
+          $now,
+          $order['event_id'],
+          DEALER_PURCHASE_SOURCE_LEAD,
           $now,
           $now,
         ]);
-    $orderId = (int)$pdo->lastInsertId();
-    $venueId = $dealer ? (dealer_primary_venue_id((int)$dealer['id']) ?? site_default_sales_venue_id()) : site_default_sales_venue_id();
-    $event = site_create_event($venueId, $dealer ? (int)$dealer['id'] : null, $package, [
-      'event_title' => $eventTitle,
-      'event_date' => $eventDate,
-      'customer_email' => $customerEmail,
-    ]);
-    if ($orderId && $event['id']) {
-      $pdo->prepare("UPDATE site_orders SET status=?, event_id=?, updated_at=? WHERE id=?")
-          ->execute(['completed', $event['id'], now(), $orderId]);
-    }
-    if ($dealer && $cashbackCents > 0) {
-      dealer_wallet_adjust((int)$dealer['id'], $cashbackCents, DEALER_WALLET_TYPE_CASHBACK, 'Web satış cashback', [
-        'order_id' => $orderId,
-        'package_id' => $packageId,
-      ]);
-      $duration = $package['duration_days'];
-      $startsAt = $now;
-      $expiresAt = null;
-      if ($duration) {
-        $dt = new DateTime($now);
-        $dt->modify('+'.(int)$duration.' days');
-        $expiresAt = $dt->format('Y-m-d H:i:s');
       }
-      $pdo->prepare("INSERT INTO dealer_package_purchases (dealer_id, package_id, status, price_cents, event_quota, events_used, duration_days, starts_at, expires_at, cashback_rate, cashback_status, cashback_amount, cashback_paid_at, lead_event_id, source, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
-          ->execute([
-            (int)$dealer['id'],
-            $packageId,
-            DEALER_PURCHASE_STATUS_USED,
-            $price,
-            1,
-            1,
-            $duration,
-            $startsAt,
-            $expiresAt,
-            $cashbackRate,
-            DEALER_CASHBACK_PAID,
-            $cashbackCents,
-            $now,
-            $event['id'],
-            DEALER_PURCHASE_SOURCE_LEAD,
-            $now,
-            $now,
-          ]);
     }
-    $pdo->commit();
-    return [
-      'order_id' => $orderId,
-      'package' => $package,
-      'dealer' => $dealer,
-      'event' => $event,
-      'customer' => [
-        'name' => $customerName,
-        'email' => $customerEmail,
-        'phone' => $customerPhone,
-      ],
-      'cashback_cents' => $dealer ? $cashbackCents : 0,
-      'referral_code' => $referral,
-    ];
-  } catch (Throwable $e) {
-    if ($pdo->inTransaction()) {
-      $pdo->rollBack();
-    }
-    throw $e;
   }
+
+  if (!$eventSummary) {
+    $pdo->rollBack();
+    throw new RuntimeException('Etkinlik bilgisi alınamadı.');
+  }
+
+  $pdo->commit();
+
+  $eventMeta = [
+    'id' => $eventSummary['id'],
+    'title' => $order['event_title'],
+    'upload_url' => $meta['upload_url'] ?? public_upload_url($eventSummary['id']),
+    'qr_code' => $meta['qr_code'] ?? site_event_dynamic_code($eventSummary['id']),
+    'plain_password' => $meta['plain_password'] ?? null,
+    'login_url' => BASE_URL.'/couple/login.php?event='.$eventSummary['id'],
+  ];
+  $eventMeta['qr_dynamic_url'] = $eventMeta['qr_code'] ? BASE_URL.'/qr.php?code='.$eventMeta['qr_code'] : null;
+  $qrTarget = $eventMeta['qr_dynamic_url'] ?: $eventMeta['upload_url'];
+  $eventMeta['qr_image_url'] = $qrTarget ? 'https://api.qrserver.com/v1/create-qr-code/?size=500x500&data='.rawurlencode($qrTarget) : null;
+
+  $result = [
+    'order' => $order,
+    'package' => $package,
+    'dealer' => $dealer,
+    'event' => $eventMeta,
+    'customer' => [
+      'name' => $order['customer_name'],
+      'email' => $order['customer_email'],
+      'phone' => $order['customer_phone'] ?? '',
+    ],
+    'cashback_cents' => (int)$order['cashback_cents'],
+    'just_created' => $justCreated,
+  ];
+
+  if ($justCreated) {
+    site_send_customer_order_mail($result);
+    if ($dealer) {
+      site_send_dealer_order_mail($result);
+    }
+  }
+
+  return $result;
+}
+
+function site_send_customer_order_mail(array $result): void {
+  $event = $result['event'];
+  $customer = $result['customer'];
+  $package = $result['package'];
+  $plainPassword = $event['plain_password'] ?? null;
+  $uploadUrl = $event['upload_url'];
+  $dynamicUrl = $event['qr_dynamic_url'];
+  $qrImage = $event['qr_image_url'];
+  $loginUrl = $event['login_url'];
+
+  $html = '<h2>'.h(APP_NAME).' — Etkinliğiniz Hazır</h2>'
+    .'<p>Merhaba '.h($customer['name']).',</p>'
+    .'<p>Ödemeniz onaylandı ve etkinlik paneliniz oluşturuldu.</p>'
+    .'<ul>'
+    .'<li><strong>Giriş adresi:</strong> <a href="'.h($loginUrl).'">'.h($loginUrl).'</a></li>'
+    .'<li><strong>Kullanıcı adı:</strong> '.h($customer['email']).'</li>';
+  if ($plainPassword) {
+    $html .= '<li><strong>Geçici şifre:</strong> '.h($plainPassword).'</li>';
+  }
+  $html .= '</ul>'
+    .'<p>Misafir yükleme bağlantınız: <a href="'.h($uploadUrl).'">'.h($uploadUrl).'</a></p>';
+  if ($dynamicUrl) {
+    $html .= '<p>Kalıcı QR yönlendirme adresiniz: <a href="'.h($dynamicUrl).'">'.h($dynamicUrl).'</a></p>';
+  }
+  if ($qrImage) {
+    $html .= '<p>QR kodu yazdırmak için aşağıdaki görseli kullanabilirsiniz:</p>'
+          . '<p><img src="'.h($qrImage).'" alt="QR Kod" width="220" height="220"></p>';
+  }
+  $html .= '<p>Paketiniz: '.h($package['name']).' — '.h(format_currency((int)$package['price_cents'])) .'</p>'
+         . '<p>Keyifli bir etkinlik dileriz!<br>'.h(APP_NAME).' Ekibi</p>';
+
+  send_mail_simple($customer['email'], 'Wedding Share etkinliğiniz hazır', $html);
+}
+
+function site_send_dealer_order_mail(array $result): void {
+  $dealer = $result['dealer'];
+  if (!$dealer) {
+    return;
+  }
+  $customer = $result['customer'];
+  $package = $result['package'];
+  $event = $result['event'];
+  $dynamicUrl = $event['qr_dynamic_url'];
+  $uploadUrl = $event['upload_url'];
+  $loginUrl = $event['login_url'];
+  $cashback = (int)$result['cashback_cents'];
+
+  $html = '<h2>Yeni Web Satışı</h2>'
+    .'<p><strong>Müşteri:</strong> '.h($customer['name']).'<br>'
+    .'<strong>E-posta:</strong> '.h($customer['email']).'<br>';
+  if (!empty($customer['phone'])) {
+    $html .= '<strong>Telefon:</strong> '.h($customer['phone']).'<br>';
+  }
+  $html .= '<strong>Paket:</strong> '.h($package['name']).' — '.h(format_currency((int)$package['price_cents'])).'</p>'
+    .'<p><strong>Etkinlik paneli:</strong> <a href="'.h($loginUrl).'">'.h($loginUrl).'</a><br>'
+    .'<strong>Misafir yükleme:</strong> <a href="'.h($uploadUrl).'">'.h($uploadUrl).'</a></p>';
+  if ($dynamicUrl) {
+    $html .= '<p><strong>QR 301 adresi:</strong> <a href="'.h($dynamicUrl).'">'.h($dynamicUrl).'</a></p>';
+  }
+  if ($cashback > 0) {
+    $html .= '<p><strong>Cashback:</strong> '.h(format_currency($cashback)).' hesabınıza tanımlandı.</p>';
+  }
+  $html .= '<p>Referans satışınız için teşekkür ederiz.</p>';
+
+  send_mail_simple($dealer['email'], 'Referans satışınız tamamlandı', $html);
 }

--- a/includes/site.php
+++ b/includes/site.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * includes/site.php — Genel web sitesi satış & sipariş yardımcıları
+ */
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/db.php';
+require_once __DIR__.'/functions.php';
+require_once __DIR__.'/dealers.php';
+
+function site_seed_default_packages(): void {
+  try {
+    $count = (int)pdo()->query("SELECT COUNT(*) FROM dealer_packages")->fetchColumn();
+  } catch (Throwable $e) {
+    return;
+  }
+  if ($count > 0) {
+    return;
+  }
+  $now = now();
+  $defaults = [
+    [
+      'name' => 'Tek Etkinlik Paketi',
+      'description' => '1 etkinlik için panel, limitsiz yükleme, standart tema desteği.',
+      'price_cents' => 300000,
+      'event_quota' => 1,
+      'duration_days' => 365,
+      'cashback_rate' => 0.20,
+    ],
+    [
+      'name' => 'İki Etkinlik Paketi',
+      'description' => 'Aynı sezon iki etkinlik için QR yönetimi ve misafir galerisi.',
+      'price_cents' => 520000,
+      'event_quota' => 2,
+      'duration_days' => 365,
+      'cashback_rate' => 0.20,
+    ],
+    [
+      'name' => 'Sınırsız Aylık Paketi',
+      'description' => '30 gün boyunca sınırsız etkinlik, premium destek ve kampanya modülleri.',
+      'price_cents' => 890000,
+      'event_quota' => null,
+      'duration_days' => 30,
+      'cashback_rate' => 0.20,
+    ],
+  ];
+  $st = pdo()->prepare("INSERT INTO dealer_packages (name, description, price_cents, event_quota, duration_days, cashback_rate, is_active, is_public, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?)");
+  foreach ($defaults as $pkg) {
+    $st->execute([
+      $pkg['name'],
+      $pkg['description'],
+      $pkg['price_cents'],
+      $pkg['event_quota'],
+      $pkg['duration_days'],
+      $pkg['cashback_rate'],
+      1,
+      1,
+      $now,
+      $now,
+    ]);
+  }
+}
+
+function site_public_packages(): array {
+  site_seed_default_packages();
+  return dealer_packages_public();
+}
+
+function site_default_sales_venue_id(): int {
+  $slug = 'genel-satis';
+  $st = pdo()->prepare("SELECT id FROM venues WHERE slug=? LIMIT 1");
+  $st->execute([$slug]);
+  $id = $st->fetchColumn();
+  if ($id) {
+    return (int)$id;
+  }
+  $name = 'Genel Satışlar';
+  $now = now();
+  pdo()->prepare("INSERT INTO venues (name, slug, created_at, is_active) VALUES (?,?,?,1)")
+      ->execute([$name, $slug, $now]);
+  return (int)pdo()->lastInsertId();
+}
+
+function site_normalize_event_date(?string $date): ?string {
+  if (!$date) {
+    return null;
+  }
+  $date = trim($date);
+  if ($date === '') {
+    return null;
+  }
+  $formats = ['Y-m-d', 'd.m.Y'];
+  foreach ($formats as $fmt) {
+    $dt = DateTime::createFromFormat($fmt, $date);
+    if ($dt && $dt->format($fmt) === $date) {
+      return $dt->format('Y-m-d');
+    }
+  }
+  $ts = strtotime($date);
+  if ($ts !== false) {
+    return date('Y-m-d', $ts);
+  }
+  return null;
+}
+
+function site_create_event(int $venue_id, ?int $dealer_id, array $package, array $data): array {
+  $pdo = pdo();
+  $title = $data['event_title'];
+  $slug = slugify($title);
+  if ($slug === '') {
+    $slug = 'etkinlik-'.bin2hex(random_bytes(3));
+  }
+  $base = $slug;
+  $i = 1;
+  while (true) {
+    $chk = $pdo->prepare("SELECT id FROM events WHERE venue_id=? AND slug=? LIMIT 1");
+    $chk->execute([$venue_id, $slug]);
+    if (!$chk->fetch()) {
+      break;
+    }
+    $slug = $base.'-'.$i++;
+  }
+  $key = bin2hex(random_bytes(16));
+  $plainPassword = substr(bin2hex(random_bytes(8)), 0, 12);
+  $hash = password_hash($plainPassword, PASSWORD_DEFAULT);
+  $now = now();
+  $eventDate = site_normalize_event_date($data['event_date'] ?? null);
+  $primary = defined('THEME_PRIMARY_DEFAULT') ? THEME_PRIMARY_DEFAULT : '#0ea5b5';
+  $accent  = defined('THEME_ACCENT_DEFAULT') ? THEME_ACCENT_DEFAULT : '#e0f7fb';
+  $licenseUntil = null;
+  if (!empty($package['duration_days'])) {
+    $dt = new DateTime($now);
+    $dt->modify('+'.(int)$package['duration_days'].' days');
+    $licenseUntil = $dt->format('Y-m-d H:i:s');
+  }
+  $dealerCreditAt = $dealer_id ? $now : null;
+  $columns = "venue_id,dealer_id,dealer_credit_consumed_at,user_id,contact_email,title,slug,is_active,couple_panel_key,theme_primary,theme_accent,event_date,created_at,updated_at,couple_username,couple_password_hash,couple_force_reset";
+  $placeholders = "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?";
+  $values = [
+    $venue_id,
+    $dealer_id,
+    $dealerCreditAt,
+    null,
+    $data['customer_email'],
+    $title,
+    $slug,
+    1,
+    $key,
+    $primary,
+    $accent,
+    $eventDate,
+    $now,
+    $now,
+    $data['customer_email'],
+    $hash,
+    1,
+  ];
+  if (column_exists('events', 'license_expires_at')) {
+    $columns .= ',license_expires_at';
+    $placeholders .= ',?';
+    $values[] = $licenseUntil;
+  }
+  $eventId = null;
+  try {
+    $sql = 'INSERT INTO events ('.$columns.') VALUES ('.$placeholders.')';
+    $pdo->prepare($sql)->execute($values);
+    $eventId = (int)$pdo->lastInsertId();
+  } catch (Throwable $e) {
+    // Eski şema desteği için dealer ve user alanlarını çıkarıp tekrar dene
+    $columnsFallback = "venue_id,title,slug,is_active,couple_panel_key,theme_primary,theme_accent,event_date,created_at,couple_username,couple_password_hash,couple_force_reset";
+    $placeholdersFallback = "?,?,?,?,?,?,?,?,?,?,?,?,?";
+    $valuesFallback = [
+      $venue_id,
+      $title,
+      $slug,
+      1,
+      $key,
+      $primary,
+      $accent,
+      $eventDate,
+      $now,
+      $data['customer_email'],
+      $hash,
+      1,
+    ];
+    $pdo->prepare('INSERT INTO events ('.$columnsFallback.') VALUES ('.$placeholdersFallback.')')
+        ->execute($valuesFallback);
+    $eventId = (int)$pdo->lastInsertId();
+    $updateSql = 'UPDATE events SET contact_email=?, dealer_id=?, dealer_credit_consumed_at=?, updated_at=?';
+    $params = [
+      $data['customer_email'],
+      $dealer_id,
+      $dealerCreditAt,
+      $now,
+    ];
+    if (column_exists('events', 'license_expires_at')) {
+      $updateSql .= ', license_expires_at=?';
+      $params[] = $licenseUntil;
+    }
+    $updateSql .= ' WHERE id=?';
+    $params[] = $eventId;
+    $pdo->prepare($updateSql)->execute($params);
+  }
+  if (!$eventId) {
+    $eventId = (int)$pdo->lastInsertId();
+  }
+  $qrCode = null;
+  if ($eventId > 0) {
+    for ($attempt = 0; $attempt < 5; $attempt++) {
+      $candidate = dealer_generate_unique_code();
+      try {
+        $pdo->prepare("INSERT INTO qr_codes (venue_id, code, target_event_id, created_at, updated_at) VALUES (?,?,?,?,?)")
+            ->execute([$venue_id, $candidate, $eventId, $now, $now]);
+        $qrCode = $candidate;
+        break;
+      } catch (Throwable $e) {
+        continue;
+      }
+    }
+  }
+  return [
+    'id' => $eventId,
+    'slug' => $slug,
+    'plain_password' => $plainPassword,
+    'qr_code' => $qrCode,
+    'upload_url' => $eventId ? public_upload_url($eventId) : null,
+    'license_expires_at' => $licenseUntil,
+    'event_date' => $eventDate,
+  ];
+}
+
+function site_process_customer_order(array $input): array {
+  $packageId = (int)($input['package_id'] ?? 0);
+  $customerName = trim($input['customer_name'] ?? '');
+  $customerEmail = trim($input['customer_email'] ?? '');
+  $customerPhone = trim($input['customer_phone'] ?? '');
+  $eventTitle = trim($input['event_title'] ?? '');
+  $eventDate = trim($input['event_date'] ?? '');
+  $notes = trim($input['notes'] ?? '');
+  $referral = trim($input['referral_code'] ?? '');
+
+  if ($packageId <= 0) {
+    throw new RuntimeException('Lütfen bir paket seçin.');
+  }
+  if ($customerName === '') {
+    throw new RuntimeException('Adınızı ve soyadınızı girin.');
+  }
+  if (!filter_var($customerEmail, FILTER_VALIDATE_EMAIL)) {
+    throw new RuntimeException('Geçerli bir e-posta adresi girin.');
+  }
+  if ($eventTitle === '') {
+    $eventTitle = $customerName.' Etkinliği';
+  }
+  $package = dealer_package_get($packageId);
+  if (!$package || !$package['is_active'] || !$package['is_public']) {
+    throw new RuntimeException('Seçtiğiniz paket şu anda satışta değil.');
+  }
+  $dealer = null;
+  if ($referral !== '') {
+    $dealer = dealer_find_by_code($referral);
+    if (!$dealer) {
+      throw new RuntimeException('Girilen referans kodu bulunamadı.');
+    }
+    if (!in_array($dealer['status'], [DEALER_STATUS_ACTIVE, DEALER_STATUS_PENDING], true)) {
+      throw new RuntimeException('Bayi kodu şu anda pasif durumda.');
+    }
+  }
+  $pdo = pdo();
+  $pdo->beginTransaction();
+  try {
+    $now = now();
+    $price = (int)$package['price_cents'];
+    $cashbackRate = $dealer ? max(0, (float)$package['cashback_rate']) : 0.0;
+    $cashbackCents = $dealer ? (int)round($price * $cashbackRate) : 0;
+    $meta = array_filter([
+      'notes' => $notes !== '' ? $notes : null,
+    ]);
+    $metaJson = $meta ? safe_json_encode($meta) : null;
+    $pdo->prepare("INSERT INTO site_orders (package_id, dealer_id, customer_name, customer_email, customer_phone, event_title, event_date, referral_code, status, price_cents, cashback_cents, meta_json, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
+        ->execute([
+          $packageId,
+          $dealer ? (int)$dealer['id'] : null,
+          $customerName,
+          $customerEmail,
+          $customerPhone !== '' ? $customerPhone : null,
+          $eventTitle,
+          site_normalize_event_date($eventDate),
+          $referral !== '' ? $referral : null,
+          'processing',
+          $price,
+          $cashbackCents,
+          $metaJson,
+          $now,
+          $now,
+        ]);
+    $orderId = (int)$pdo->lastInsertId();
+    $venueId = $dealer ? (dealer_primary_venue_id((int)$dealer['id']) ?? site_default_sales_venue_id()) : site_default_sales_venue_id();
+    $event = site_create_event($venueId, $dealer ? (int)$dealer['id'] : null, $package, [
+      'event_title' => $eventTitle,
+      'event_date' => $eventDate,
+      'customer_email' => $customerEmail,
+    ]);
+    if ($orderId && $event['id']) {
+      $pdo->prepare("UPDATE site_orders SET status=?, event_id=?, updated_at=? WHERE id=?")
+          ->execute(['completed', $event['id'], now(), $orderId]);
+    }
+    if ($dealer && $cashbackCents > 0) {
+      dealer_wallet_adjust((int)$dealer['id'], $cashbackCents, DEALER_WALLET_TYPE_CASHBACK, 'Web satış cashback', [
+        'order_id' => $orderId,
+        'package_id' => $packageId,
+      ]);
+      $duration = $package['duration_days'];
+      $startsAt = $now;
+      $expiresAt = null;
+      if ($duration) {
+        $dt = new DateTime($now);
+        $dt->modify('+'.(int)$duration.' days');
+        $expiresAt = $dt->format('Y-m-d H:i:s');
+      }
+      $pdo->prepare("INSERT INTO dealer_package_purchases (dealer_id, package_id, status, price_cents, event_quota, events_used, duration_days, starts_at, expires_at, cashback_rate, cashback_status, cashback_amount, cashback_paid_at, lead_event_id, source, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
+          ->execute([
+            (int)$dealer['id'],
+            $packageId,
+            DEALER_PURCHASE_STATUS_USED,
+            $price,
+            1,
+            1,
+            $duration,
+            $startsAt,
+            $expiresAt,
+            $cashbackRate,
+            DEALER_CASHBACK_PAID,
+            $cashbackCents,
+            $now,
+            $event['id'],
+            DEALER_PURCHASE_SOURCE_LEAD,
+            $now,
+            $now,
+          ]);
+    }
+    $pdo->commit();
+    return [
+      'order_id' => $orderId,
+      'package' => $package,
+      'dealer' => $dealer,
+      'event' => $event,
+      'customer' => [
+        'name' => $customerName,
+        'email' => $customerEmail,
+        'phone' => $customerPhone,
+      ],
+      'cashback_cents' => $dealer ? $cashbackCents : 0,
+      'referral_code' => $referral,
+    ];
+  } catch (Throwable $e) {
+    if ($pdo->inTransaction()) {
+      $pdo->rollBack();
+    }
+    throw $e;
+  }
+}

--- a/includes/site.php
+++ b/includes/site.php
@@ -686,10 +686,6 @@ function site_finalize_order(int $order_id, array $options = []): array {
       $existsSt->execute([(int)$dealer['id'], $order['event_id'], DEALER_PURCHASE_SOURCE_LEAD]);
       $exists = $existsSt->fetchColumn();
       if (!$exists) {
-        dealer_wallet_adjust((int)$dealer['id'], (int)$order['cashback_cents'], DEALER_WALLET_TYPE_CASHBACK, 'Web satış cashback', [
-          'order_id' => $order['id'],
-          'package_id' => $order['package_id'],
-        ]);
         $duration = $package['duration_days'];
         $startsAt = $now;
         $expiresAt = null;
@@ -711,9 +707,9 @@ function site_finalize_order(int $order_id, array $options = []): array {
           $startsAt,
           $expiresAt,
           $package['cashback_rate'],
-          DEALER_CASHBACK_PAID,
+          DEALER_CASHBACK_PENDING,
           $order['cashback_cents'],
-          $now,
+          null,
           $order['event_id'],
           DEALER_PURCHASE_SOURCE_LEAD,
           $now,
@@ -845,6 +841,9 @@ function site_send_dealer_order_mail(array $result): void {
     .'<table style="width:100%;margin:20px 0;border-collapse:collapse;font-size:14px;">'.$rows.'</table>'
     .'<p>Ekibimiz desteğe her zaman hazır. İş ortaklığınız için teşekkür ederiz.</p>'
     .'<p><strong>BİKARE Bayi Destek</strong></p>';
+  if ($cashback > 0) {
+    $body .= '<p style="margin-top:18px;color:#475569;">Cashback tutarınız finans ekibimizin onayına iletildi. Onaylandığında bakiyenize eklenecek ve ayrıca e-posta ile bilgilendirileceksiniz.</p>';
+  }
 
   $html = site_email_template('Yeni web siparişiniz var', $body);
   send_mail_simple($dealer['email'], 'BİKARE referans siparişiniz tamamlandı', $html);

--- a/index.php
+++ b/index.php
@@ -1,54 +1,221 @@
 <?php
 require_once __DIR__.'/config.php';
 require_once __DIR__.'/includes/db.php';
-$set = pdo()->query("SELECT * FROM settings WHERE id=1")->fetch();
+require_once __DIR__.'/includes/functions.php';
+require_once __DIR__.'/includes/site.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+  session_start();
+}
+
+install_schema();
+
+$packages = site_public_packages();
+$formData = $_SESSION['lead_form'] ?? [
+  'customer_name' => '',
+  'customer_email' => '',
+  'customer_phone' => '',
+  'event_title' => '',
+  'event_date' => '',
+  'referral_code' => '',
+  'notes' => '',
+  'package_id' => $packages[0]['id'] ?? null,
+];
+unset($_SESSION['lead_form']);
+
+$success = $_SESSION['lead_success'] ?? null;
+unset($_SESSION['lead_success']);
 ?>
 <!doctype html><html lang="tr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title><?=h(APP_NAME)?> — Düğün Foto/Video Paylaşım</title>
+<title><?=h(APP_NAME)?> — Dijital Etkinlik Deneyiminiz</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <style>
-  :root{--gold:#c7a06b;--ink:#333}
-  .hero{background:linear-gradient(180deg,#ffdbe6,#fff);border-radius:18px;padding:48px 16px}
-  .btn-gold{background:var(--gold);color:#fff;border:none}
+  :root {
+    --ink:#111827;
+    --muted:#6b7280;
+    --brand:#0ea5b5;
+    --brand-soft:#e0f7fb;
+    --card:#ffffff;
+  }
+  body { background:linear-gradient(180deg,#f5fbfd,#fff); font-family:'Inter',sans-serif; color:var(--ink); }
+  .hero { border-radius:28px; background:linear-gradient(135deg,#0ea5b5,#60a5fa); color:#fff; padding:72px 32px; position:relative; overflow:hidden; }
+  .hero::after { content:""; position:absolute; inset:auto -80px -80px 50%; width:280px; height:280px; background:rgba(255,255,255,0.15); border-radius:50%; }
+  .hero h1 { font-weight:800; font-size:2.8rem; }
+  .stat-card { border-radius:20px; background:#fff; box-shadow:0 20px 60px rgba(14,165,181,0.15); padding:28px; }
+  .package-card { border-radius:20px; border:1px solid rgba(14,165,181,0.12); background:#fff; transition:transform .2s, box-shadow .2s; }
+  .package-card:hover { transform:translateY(-4px); box-shadow:0 16px 40px rgba(15,118,110,0.12); }
+  .package-price { font-size:1.6rem; font-weight:700; color:var(--brand); }
+  .bg-brand { background:var(--brand); }
+  .text-brand { color:var(--brand); }
+  .feature-badge { display:inline-flex; align-items:center; gap:8px; padding:6px 14px; border-radius:999px; background:rgba(255,255,255,0.2); color:#fff; font-weight:600; }
+  .form-section { border-radius:24px; background:#fff; box-shadow:0 24px 70px rgba(15,118,110,0.18); padding:40px; }
+  .btn-brand { background:var(--brand); color:#fff; border:none; border-radius:16px; padding:14px 28px; font-weight:700; }
+  .btn-brand:hover { background:#0c8d9a; color:#fff; }
+  .input-rounded { border-radius:14px; border:1px solid #dbe9ee; padding:12px 16px; }
+  .muted { color:var(--muted); }
+  @media (max-width: 768px) {
+    .hero { padding:48px 24px; }
+    .hero h1 { font-size:2.2rem; }
+    .form-section { padding:28px; }
+  }
 </style>
-</head><body class="bg-light">
-<nav class="navbar bg-white border-bottom"><div class="container">
-  <a class="navbar-brand fw-bold" href="#"><?=h(APP_NAME)?></a>
-</div></nav>
-
-<div class="container py-5">
-  <div class="hero text-center mb-5">
-    <h1 class="fw-bold mb-2">Düğününüzden Anılar — Kolayca Toplayın</h1>
-    <p class="lead text-muted mb-3">Misafirleriniz QR’ı okutsun, anında foto/video yüklensin. Siz de tek panelden yönetin.</p>
-    <a class="btn btn-gold" href="https://wa.me/905555555555?text=Wedding%20Share%20satın%20alma%20talebi">Hemen Fiyat Al</a>
+</head><body>
+<nav class="navbar navbar-expand-lg bg-white border-bottom shadow-sm">
+  <div class="container">
+    <a class="navbar-brand fw-bold" href="#"><?=h(APP_NAME)?></a>
+    <span class="badge bg-info-subtle text-info-emphasis rounded-pill">Etkinlik Teknolojisi</span>
   </div>
+</nav>
 
-  <div class="row g-4">
-    <div class="col-md-4"><div class="card shadow-sm h-100"><div class="card-body">
-      <h5>Nasıl Çalışır?</h5>
-      <ol class="small">
-        <li>Biz kalıcı bir QR oluştururuz (broşüre basılır).</li>
-        <li>Her düğünde QR’ı yeni etkinliğe bağlarız.</li>
-        <li>Misafirler ad yazarak foto/video yükler.</li>
-      </ol>
-    </div></div></div>
-    <div class="col-md-4"><div class="card shadow-sm h-100"><div class="card-body">
-      <h5>Çift Paneli</h5>
-      <p class="small">Tema & metin özelleştirme, toplu ZIP indirme, seçerek silme, montaj talebi.</p>
-    </div></div></div>
-    <div class="col-md-4"><div class="card shadow-sm h-100"><div class="card-body">
-      <h5>Fiyatlar</h5>
-      <ul class="small">
-        <li>Tek düğün kurulumu: <strong>1000 TL</strong></li>
-        <li>Montaj 10 sn: <strong><?= (int)$set['price_10s']?> TL</strong></li>
-        <li>Montaj 100 sn: <strong><?= (int)$set['price_100s']?> TL</strong></li>
-      </ul>
-    </div></div></div>
-  </div>
+<main class="container py-5">
+  <section class="hero mb-5 text-center text-lg-start">
+    <div class="row align-items-center g-4">
+      <div class="col-lg-7 position-relative">
+        <span class="feature-badge">Misafirleriniz QR ile paylaşsın</span>
+        <h1 class="mt-4 mb-3">Anılarınızı aynı gün dijitalleştirin</h1>
+        <p class="lead mb-4">Wedding Share; davetlilerinizden fotoğraf ve videoları tek QR ile toplar, çift paneli ve bayi ekosistemiyle profesyonel bir deneyim sunar.</p>
+        <div class="d-flex flex-wrap gap-3">
+          <a class="btn btn-light text-brand fw-semibold" href="#paketler">Paketleri Gör</a>
+          <a class="btn btn-outline-light fw-semibold" href="#lead-form">Demo Talep Et</a>
+        </div>
+      </div>
+      <div class="col-lg-5">
+        <div class="stat-card text-start">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <div>
+              <div class="muted text-uppercase small">2024 Yazı</div>
+              <h3 class="fw-bold mb-0">Davetli deneyimini yükseltin</h3>
+            </div>
+            <span class="badge bg-success-subtle text-success-emphasis rounded-pill">Yeni</span>
+          </div>
+          <ul class="list-unstyled mb-0 small">
+            <li class="mb-2">• Kalıcı & anlık QR kod üretimi</li>
+            <li class="mb-2">• Sosyal medya tarzı galeri ve beğeni sistemi</li>
+            <li class="mb-2">• Otomatik çift paneli, e-posta bildirimleri</li>
+            <li>• Bayi referansıyla %20 cashback fırsatı</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
 
-  <div class="text-center mt-5">
-    <a class="btn btn-outline-secondary" href="mailto:sales@demozerosoft.com.tr?subject=Wedding%20Share%20Talep">E-posta ile İletişim</a>
+  <?php if ($success): ?>
+    <div class="alert alert-success shadow-sm"><?=h($success)?></div>
+  <?php endif; ?>
+  <?php flash_box(); ?>
+
+  <section id="paketler" class="mb-5">
+    <div class="text-center mb-4">
+      <h2 class="fw-bold">Sizin için tasarlanan paketler</h2>
+      <p class="muted">Etkinlik sayınıza göre seçim yapın, QR kodlar ve paneliniz dakikalar içinde hazır olsun.</p>
+    </div>
+    <div class="row g-4">
+      <?php foreach ($packages as $pkg): ?>
+        <div class="col-md-4">
+          <div class="package-card h-100 p-4">
+            <div class="d-flex justify-content-between align-items-start mb-3">
+              <h4 class="fw-semibold mb-0"><?=h($pkg['name'])?></h4>
+              <?php if ($pkg['event_quota'] === null): ?>
+                <span class="badge bg-brand text-white">Sınırsız</span>
+              <?php else: ?>
+                <span class="badge bg-info-subtle text-info-emphasis"><?=$pkg['event_quota']?> etkinlik</span>
+              <?php endif; ?>
+            </div>
+            <div class="package-price mb-3"><?=h(format_currency((int)$pkg['price_cents']))?></div>
+            <?php if (!empty($pkg['description'])): ?>
+              <p class="muted small mb-4"><?=nl2br(h($pkg['description']))?></p>
+            <?php endif; ?>
+            <ul class="small text-muted mb-0">
+              <li>Kalıcı ve etkinliğe özel QR kodlar</li>
+              <li>Çift paneli otomatik kurulum</li>
+              <li>Misafir galerisi ve sosyal etkileşim</li>
+              <?php if ($pkg['cashback_rate'] > 0): ?>
+                <li>Bayi referansında %<?=number_format($pkg['cashback_rate'] * 100, 0)?> cashback</li>
+              <?php endif; ?>
+            </ul>
+          </div>
+        </div>
+      <?php endforeach; ?>
+      <?php if (!$packages): ?>
+        <div class="col-12">
+          <div class="alert alert-warning">Aktif müşteri paketleri henüz tanımlanmadı. Lütfen yönetim panelinden paket ekleyin.</div>
+        </div>
+      <?php endif; ?>
+    </div>
+  </section>
+
+  <section id="lead-form" class="form-section">
+    <div class="row g-4 align-items-start">
+      <div class="col-lg-5">
+        <h3 class="fw-bold">Müşteri formu</h3>
+        <p class="muted">Paketinizi seçin, referans kodunuzu paylaşın. Wedding Share ekibi etkinliğinizi otomatik olarak oluşturup QR kodları size ve bayinize e-posta ile iletsin.</p>
+        <div class="d-flex flex-column gap-3 mt-4 small text-muted">
+          <div><strong>•</strong> Paket ücreti online olarak alınır, referans bayi %20 cashback kazanır.</div>
+          <div><strong>•</strong> QR bağlantınız ve çift paneli giriş bilgileriniz otomatik gönderilir.</div>
+          <div><strong>•</strong> Referans kodunuz yoksa alanı boş bırakabilirsiniz.</div>
+        </div>
+      </div>
+      <div class="col-lg-7">
+        <form method="post" action="order.php" class="row g-3">
+          <input type="hidden" name="_csrf" value="<?=h(csrf_token())?>">
+          <div class="col-12">
+            <label class="form-label fw-semibold">Paket Seçimi</label>
+            <div class="row g-3">
+              <?php foreach ($packages as $pkg): ?>
+                <div class="col-md-6">
+                  <label class="border rounded-4 p-3 w-100 <?=(int)$formData['package_id'] === (int)$pkg['id'] ? 'border-2 border-info' : 'border-light'?>">
+                    <input class="form-check-input me-2" type="radio" name="package_id" value="<?= (int)$pkg['id']?>" <?=(int)$formData['package_id'] === (int)$pkg['id'] ? 'checked' : ''?> required>
+                    <span class="fw-semibold d-block"><?=h($pkg['name'])?></span>
+                    <span class="small text-muted d-block"><?=h(format_currency((int)$pkg['price_cents']))?></span>
+                  </label>
+                </div>
+              <?php endforeach; ?>
+            </div>
+          </div>
+
+          <div class="col-md-6">
+            <label class="form-label fw-semibold">Ad Soyad</label>
+            <input type="text" name="customer_name" class="form-control input-rounded" value="<?=h($formData['customer_name'])?>" required>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label fw-semibold">E-posta</label>
+            <input type="email" name="customer_email" class="form-control input-rounded" value="<?=h($formData['customer_email'])?>" required>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label fw-semibold">Telefon</label>
+            <input type="text" name="customer_phone" class="form-control input-rounded" value="<?=h($formData['customer_phone'])?>" placeholder="0 (5xx) xxx xx xx">
+          </div>
+          <div class="col-md-6">
+            <label class="form-label fw-semibold">Etkinlik Başlığı</label>
+            <input type="text" name="event_title" class="form-control input-rounded" value="<?=h($formData['event_title'])?>" placeholder="Örn. Deniz & Efe Düğünü">
+          </div>
+          <div class="col-md-6">
+            <label class="form-label fw-semibold">Etkinlik Tarihi</label>
+            <input type="date" name="event_date" class="form-control input-rounded" value="<?=h($formData['event_date'])?>">
+          </div>
+          <div class="col-md-6">
+            <label class="form-label fw-semibold">Referans Kodu</label>
+            <input type="text" name="referral_code" class="form-control input-rounded" value="<?=h($formData['referral_code'])?>" placeholder="Bayi kodu">
+          </div>
+          <div class="col-12">
+            <label class="form-label fw-semibold">Notunuz</label>
+            <textarea name="notes" class="form-control input-rounded" rows="3" placeholder="Etkinliğe dair eklemek istediğiniz bilgiler"><?=h($formData['notes'])?></textarea>
+          </div>
+          <div class="col-12 d-flex justify-content-between align-items-center pt-3">
+            <span class="muted small">Formu gönderdiğinizde ekibimiz sizinle iletişime geçer.</span>
+            <button class="btn btn-brand" type="submit">QR Kodlarımı Oluştur</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer class="py-4 border-top bg-white">
+  <div class="container d-flex flex-wrap gap-2 justify-content-between small text-muted">
+    <span>© <?=date('Y')?> <?=h(APP_NAME)?> — Wedding Share Teknoloji</span>
+    <span>Destek: <a href="mailto:support@demozerosoft.com.tr" class="text-decoration-none">support@demozerosoft.com.tr</a></span>
   </div>
-</div>
+</footer>
 </body></html>

--- a/index.php
+++ b/index.php
@@ -32,69 +32,86 @@ unset($_SESSION['lead_success']);
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <style>
   :root {
-    --ink:#111827;
+    --ink:#0f172a;
     --muted:#6b7280;
     --brand:#0ea5b5;
-    --brand-soft:#e0f7fb;
+    --brand-dark:#0c8d9a;
     --card:#ffffff;
+    --bg:#f4f7fb;
   }
-  body { background:linear-gradient(180deg,#f5fbfd,#fff); font-family:'Inter',sans-serif; color:var(--ink); }
-  .hero { border-radius:28px; background:linear-gradient(135deg,#0ea5b5,#60a5fa); color:#fff; padding:72px 32px; position:relative; overflow:hidden; }
-  .hero::after { content:""; position:absolute; inset:auto -80px -80px 50%; width:280px; height:280px; background:rgba(255,255,255,0.15); border-radius:50%; }
-  .hero h1 { font-weight:800; font-size:2.8rem; }
-  .stat-card { border-radius:20px; background:#fff; box-shadow:0 20px 60px rgba(14,165,181,0.15); padding:28px; }
-  .package-card { border-radius:20px; border:1px solid rgba(14,165,181,0.12); background:#fff; transition:transform .2s, box-shadow .2s; }
-  .package-card:hover { transform:translateY(-4px); box-shadow:0 16px 40px rgba(15,118,110,0.12); }
-  .package-price { font-size:1.6rem; font-weight:700; color:var(--brand); }
-  .bg-brand { background:var(--brand); }
-  .text-brand { color:var(--brand); }
-  .feature-badge { display:inline-flex; align-items:center; gap:8px; padding:6px 14px; border-radius:999px; background:rgba(255,255,255,0.2); color:#fff; font-weight:600; }
-  .form-section { border-radius:24px; background:#fff; box-shadow:0 24px 70px rgba(15,118,110,0.18); padding:40px; }
-  .btn-brand { background:var(--brand); color:#fff; border:none; border-radius:16px; padding:14px 28px; font-weight:700; }
-  .btn-brand:hover { background:#0c8d9a; color:#fff; }
-  .input-rounded { border-radius:14px; border:1px solid #dbe9ee; padding:12px 16px; }
-  .muted { color:var(--muted); }
-  @media (max-width: 768px) {
-    .hero { padding:48px 24px; }
-    .hero h1 { font-size:2.2rem; }
-    .form-section { padding:28px; }
-  }
+  body{background:linear-gradient(180deg,var(--bg),#fff);font-family:'Inter',sans-serif;color:var(--ink);}
+  .hero{position:relative;overflow:hidden;border-radius:36px;padding:96px 48px;background:linear-gradient(140deg,rgba(14,165,181,0.92),rgba(59,130,246,0.88));color:#fff;}
+  .hero::after{content:"";position:absolute;inset:-120px -60px auto 40%;width:420px;height:420px;background:rgba(255,255,255,0.12);filter:blur(0);border-radius:50%;}
+  .hero-visual{position:relative;z-index:1;}
+  .hero-visual img{border-radius:24px;box-shadow:0 30px 90px rgba(15,118,110,0.35);}
+  .hero-visual img:nth-child(2){position:absolute;top:40%;left:50%;width:220px;border:6px solid rgba(255,255,255,0.8);transform:translate(-30%, -10%);}
+  .metrics-card{border-radius:24px;background:rgba(255,255,255,0.16);padding:28px;backdrop-filter:blur(8px);}
+  .feature-card{border-radius:24px;background:#fff;box-shadow:0 24px 60px rgba(148,163,184,0.18);padding:32px;transition:transform .25s ease,box-shadow .25s ease;}
+  .feature-card:hover{transform:translateY(-6px);box-shadow:0 36px 80px rgba(148,163,184,0.25);}
+  .feature-icon{width:56px;height:56px;border-radius:18px;background:rgba(14,165,181,0.12);display:flex;align-items:center;justify-content:center;font-size:1.6rem;color:var(--brand);}
+  .timeline-step{display:flex;gap:16px;padding:16px;border-radius:18px;background:#fff;box-shadow:0 16px 40px rgba(15,118,110,0.12);}
+  .timeline-step span{width:44px;height:44px;border-radius:14px;background:rgba(14,165,181,0.12);color:var(--brand);display:flex;align-items:center;justify-content:center;font-weight:700;}
+  .package-card{border-radius:24px;border:1px solid rgba(14,165,181,0.12);background:#fff;height:100%;padding:32px;transition:transform .2s ease,box-shadow .2s ease;}
+  .package-card:hover{transform:translateY(-6px);box-shadow:0 28px 70px rgba(15,118,110,0.18);}
+  .package-price{font-size:1.9rem;font-weight:800;color:var(--brand);}
+  .gallery-grid{display:grid;gap:18px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));}
+  .gallery-grid img{width:100%;height:220px;object-fit:cover;border-radius:24px;box-shadow:0 18px 50px rgba(15,118,110,0.18);}
+  .testimonial{border-radius:24px;background:#fff;padding:32px;box-shadow:0 22px 60px rgba(15,118,110,0.16);position:relative;}
+  .testimonial::before{content:'“';position:absolute;top:-16px;left:24px;font-size:5rem;color:rgba(14,165,181,0.2);}
+  .cta-section{border-radius:32px;background:linear-gradient(135deg,#0ea5b5,#6366f1);color:#fff;padding:48px;}
+  .form-section{border-radius:28px;background:#fff;box-shadow:0 32px 90px rgba(15,118,110,0.2);padding:48px;}
+  .input-rounded{border-radius:16px;border:1px solid #d7e4eb;padding:12px 16px;}
+  .btn-brand{background:var(--brand);color:#fff;border:none;border-radius:18px;padding:14px 32px;font-weight:700;}
+  .btn-brand:hover{background:var(--brand-dark);color:#fff;}
+  .muted{color:var(--muted);}
+  footer{background:#0f172a;color:#e2e8f0;padding:36px 0;}
+  footer a{color:#94a3b8;text-decoration:none;}
+  footer a:hover{text-decoration:underline;}
+  @media(max-width:992px){.hero{padding:72px 28px;}.hero-visual img:nth-child(2){display:none;}}
+  @media(max-width:768px){.form-section{padding:32px;}}
 </style>
 </head><body>
-<nav class="navbar navbar-expand-lg bg-white border-bottom shadow-sm">
+<nav class="navbar navbar-expand-lg bg-white border-bottom shadow-sm py-3">
   <div class="container">
     <a class="navbar-brand fw-bold" href="#"><?=h(APP_NAME)?></a>
-    <span class="badge bg-info-subtle text-info-emphasis rounded-pill">Etkinlik Teknolojisi</span>
+    <span class="badge text-bg-info-subtle text-info-emphasis rounded-pill">Dijital Etkinlik Deneyimi</span>
   </div>
 </nav>
 
 <main class="container py-5">
-  <section class="hero mb-5 text-center text-lg-start">
-    <div class="row align-items-center g-4">
-      <div class="col-lg-7 position-relative">
-        <span class="feature-badge">Misafirleriniz QR ile paylaşsın</span>
-        <h1 class="mt-4 mb-3">Anılarınızı aynı gün dijitalleştirin</h1>
-        <p class="lead mb-4">Wedding Share; davetlilerinizden fotoğraf ve videoları tek QR ile toplar, çift paneli ve bayi ekosistemiyle profesyonel bir deneyim sunar.</p>
+  <section class="hero mb-5">
+    <div class="row align-items-center g-5 position-relative" style="z-index:2;">
+      <div class="col-lg-6">
+        <span class="badge bg-light text-dark rounded-pill px-3 py-2 fw-semibold">Yeni nesil misafir paylaşımı</span>
+        <h1 class="fw-bold display-5 mt-4 mb-3">Tek QR kodla tüm fotoğraf ve videoları toplayın</h1>
+        <p class="lead mb-4">Wedding Share, davetlilerinizin çektikleri anıları saniyeler içinde toplayarak çift panelinizi, misafir galerilerini ve paylaşılabilir QR kodlarını otomatik olarak hazırlar.</p>
         <div class="d-flex flex-wrap gap-3">
-          <a class="btn btn-light text-brand fw-semibold" href="#paketler">Paketleri Gör</a>
-          <a class="btn btn-outline-light fw-semibold" href="#lead-form">Demo Talep Et</a>
+          <a class="btn btn-light text-dark fw-semibold" href="#paketler">Paketleri İncele</a>
+          <a class="btn btn-outline-light fw-semibold" href="#lead-form">Hemen Başlayın</a>
         </div>
       </div>
-      <div class="col-lg-5">
-        <div class="stat-card text-start">
-          <div class="d-flex justify-content-between align-items-center mb-3">
-            <div>
-              <div class="muted text-uppercase small">2024 Yazı</div>
-              <h3 class="fw-bold mb-0">Davetli deneyimini yükseltin</h3>
-            </div>
-            <span class="badge bg-success-subtle text-success-emphasis rounded-pill">Yeni</span>
-          </div>
-          <ul class="list-unstyled mb-0 small">
-            <li class="mb-2">• Kalıcı & anlık QR kod üretimi</li>
-            <li class="mb-2">• Sosyal medya tarzı galeri ve beğeni sistemi</li>
-            <li class="mb-2">• Otomatik çift paneli, e-posta bildirimleri</li>
-            <li>• Bayi referansıyla %20 cashback fırsatı</li>
-          </ul>
+      <div class="col-lg-6 hero-visual">
+        <img src="https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=820&q=80" alt="Düğün kutlaması" class="img-fluid">
+        <img src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=520&q=80" alt="Etkinlikten kare" class="img-fluid">
+      </div>
+    </div>
+    <div class="row mt-5 g-4 position-relative" style="z-index:2;">
+      <div class="col-md-4">
+        <div class="metrics-card h-100">
+          <div class="h2 fw-bold mb-1">12.500+</div>
+          <div class="small">Toplanan fotoğraf ve videolar</div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="metrics-card h-100">
+          <div class="h2 fw-bold mb-1">%98</div>
+          <div class="small">Misafir memnuniyeti</div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="metrics-card h-100">
+          <div class="h2 fw-bold mb-1">5 dk</div>
+          <div class="small">Ödeme sonrası panel hazır olma süresi</div>
         </div>
       </div>
     </div>
@@ -105,21 +122,61 @@ unset($_SESSION['lead_success']);
   <?php endif; ?>
   <?php flash_box(); ?>
 
+  <section class="mb-5">
+    <div class="row g-4">
+      <div class="col-md-4">
+        <div class="feature-card h-100">
+          <div class="feature-icon mb-3">📸</div>
+          <h4 class="fw-semibold mb-2">Anında QR Toplama</h4>
+          <p class="muted mb-0">Misafirleriniz QR kodu okutup doğrudan galerinize fotoğraf ve videoları yükler. Her yükleme çift panelinizde otomatik görünür.</p>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="feature-card h-100">
+          <div class="feature-icon mb-3">✨</div>
+          <h4 class="fw-semibold mb-2">Sosyal Galeri Deneyimi</h4>
+          <p class="muted mb-0">Beğeniler, yıldızlar ve yorumlarla misafir galerisi sosyal medya tadında. Albümünüzü dilediğiniz gibi düzenleyin.</p>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="feature-card h-100">
+          <div class="feature-icon mb-3">🔒</div>
+          <h4 class="fw-semibold mb-2">Güvenli Online Ödeme</h4>
+          <p class="muted mb-0">PayTR altyapısıyla kart bilgileriniz güvende. Ödeme tamamlandığında paneliniz ve QR kodlarınız otomatik hazırlanır.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <div class="row g-4 align-items-center">
+      <div class="col-lg-6">
+        <h2 class="fw-bold mb-3">Wedding Share nasıl çalışır?</h2>
+        <p class="muted">Basit 3 adımda etkinliğinizi dijitalleştiriyoruz. Kurulum ve teknik detaylarla vakit kaybetmenize gerek yok.</p>
+      </div>
+      <div class="col-lg-6 d-flex flex-column gap-3">
+        <div class="timeline-step"><span>1</span><div><strong>Paketi seçin & ödeme yapın</strong><br><small class="text-muted">Formu doldurup güvenli ödeme adımında işlemi tamamlayın.</small></div></div>
+        <div class="timeline-step"><span>2</span><div><strong>Panel otomatik kurulsun</strong><br><small class="text-muted">Çift paneliniz, QR kodlarınız ve misafir galeriniz dakikalar içinde hazırlanır.</small></div></div>
+        <div class="timeline-step"><span>3</span><div><strong>Misafirlerinizi davet edin</strong><br><small class="text-muted">QR kodu paylaşın, fotoğraflar ve videolar gerçek zamanlı olarak panelinize düşsün.</small></div></div>
+      </div>
+    </div>
+  </section>
+
   <section id="paketler" class="mb-5">
     <div class="text-center mb-4">
-      <h2 class="fw-bold">Sizin için tasarlanan paketler</h2>
-      <p class="muted">Etkinlik sayınıza göre seçim yapın, QR kodlar ve paneliniz dakikalar içinde hazır olsun.</p>
+      <h2 class="fw-bold">İhtiyacınıza uygun paketleri seçin</h2>
+      <p class="muted">Her paket güvenli online ödeme, otomatik panel kurulumu ve sınırsız misafir yüklemesi içerir.</p>
     </div>
     <div class="row g-4">
       <?php foreach ($packages as $pkg): ?>
         <div class="col-md-4">
-          <div class="package-card h-100 p-4">
+          <div class="package-card">
             <div class="d-flex justify-content-between align-items-start mb-3">
               <h4 class="fw-semibold mb-0"><?=h($pkg['name'])?></h4>
               <?php if ($pkg['event_quota'] === null): ?>
-                <span class="badge bg-brand text-white">Sınırsız</span>
+                <span class="badge bg-info text-white">Sınırsız</span>
               <?php else: ?>
-                <span class="badge bg-info-subtle text-info-emphasis"><?=$pkg['event_quota']?> etkinlik</span>
+                <span class="badge bg-light text-dark"><?=$pkg['event_quota']?> etkinlik</span>
               <?php endif; ?>
             </div>
             <div class="package-price mb-3"><?=h(format_currency((int)$pkg['price_cents']))?></div>
@@ -128,10 +185,11 @@ unset($_SESSION['lead_success']);
             <?php endif; ?>
             <ul class="small text-muted mb-0">
               <li>Kalıcı ve etkinliğe özel QR kodlar</li>
-              <li>Çift paneli otomatik kurulum</li>
-              <li>Misafir galerisi ve sosyal etkileşim</li>
+              <li>Çift paneli otomatik kurulum ve e-posta bildirimi</li>
+              <li>Sosyal medya tarzı misafir galerisi</li>
+              <li>HD fotoğraf & video yükleme desteği</li>
               <?php if ($pkg['cashback_rate'] > 0): ?>
-                <li>Bayi referansında %<?=number_format($pkg['cashback_rate'] * 100, 0)?> cashback</li>
+                <li>Referans koduyla %<?=number_format($pkg['cashback_rate'] * 100, 0)?> cashback</li>
               <?php endif; ?>
             </ul>
           </div>
@@ -145,16 +203,61 @@ unset($_SESSION['lead_success']);
     </div>
   </section>
 
+  <section class="mb-5">
+    <div class="row g-4 align-items-center">
+      <div class="col-lg-5">
+        <h2 class="fw-bold mb-3">Gerçek hikayelerden ilham alın</h2>
+        <p class="muted">Misafirleriniz sadece düğünlerde değil; nişan, kına, doğum günü ve kurumsal etkinliklerde de QR kodunuzla içerik paylaşabilir.</p>
+      </div>
+      <div class="col-lg-7 gallery-grid">
+        <img src="https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=600&q=80" alt="Düğün davetlileri">
+        <img src="https://images.unsplash.com/photo-1530023367847-a683933f4177?auto=format&fit=crop&w=600&q=80" alt="Nişan etkinliği">
+        <img src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=600&q=80" alt="Kurumsal etkinlik">
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <div class="row g-4">
+      <div class="col-md-6">
+        <div class="testimonial h-100">
+          <p class="mb-3">"Misafirlerimiz tüm fotoğrafları bir araya getirirken inanılmaz eğlendi. Panellerin otomatik kurulması bizim için büyük kolaylık sağladı."</p>
+          <div class="fw-semibold">İpek &amp; Cem</div>
+          <div class="small text-muted">İstanbul Boğazı Düğünü</div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="testimonial h-100">
+          <p class="mb-3">"Kurumsal lansmanımızda katılımcıların videolarını toplamak bu kadar kolay olmamıştı. Wedding Share ekibi her detayla ilgilendi."</p>
+          <div class="fw-semibold">Berna U.</div>
+          <div class="small text-muted">Etkinlik Ajansı Sahibi</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="cta-section mb-5 text-center text-lg-start">
+    <div class="row g-4 align-items-center">
+      <div class="col-lg-8">
+        <h2 class="fw-bold mb-2">Etkinliğiniz için hazırız</h2>
+        <p class="mb-0">Formu doldurup güvenli ödeme adımını tamamlayın, paneliniz birkaç dakika içinde aktif olsun. Anılarınızı kaybetmeyin, değerini artırın.</p>
+      </div>
+      <div class="col-lg-4 text-lg-end">
+        <a class="btn btn-light text-dark fw-semibold px-4 py-3" href="#lead-form">Paket Seç &amp; Ödeme Yap</a>
+      </div>
+    </div>
+  </section>
+
   <section id="lead-form" class="form-section">
     <div class="row g-4 align-items-start">
       <div class="col-lg-5">
-        <h3 class="fw-bold">Müşteri formu</h3>
-        <p class="muted">Paketinizi seçin, referans kodunuzu paylaşın. Wedding Share ekibi etkinliğinizi otomatik olarak oluşturup QR kodları size ve bayinize e-posta ile iletsin.</p>
-        <div class="d-flex flex-column gap-3 mt-4 small text-muted">
-          <div><strong>•</strong> Paket ücreti online olarak alınır, referans bayi %20 cashback kazanır.</div>
-          <div><strong>•</strong> QR bağlantınız ve çift paneli giriş bilgileriniz otomatik gönderilir.</div>
-          <div><strong>•</strong> Referans kodunuz yoksa alanı boş bırakabilirsiniz.</div>
-        </div>
+        <h3 class="fw-bold mb-3">Sipariş Formu</h3>
+        <p class="muted">Paketinizi seçin, bilgilerinizi girin ve PayTR ile güvenli ödeme adımına yönlendirilin. Ödeme onaylandığında giriş bilgilerinizi otomatik olarak e-posta ile alacaksınız.</p>
+        <ul class="small text-muted ps-3">
+          <li>Misafir galerisi, QR kodlar ve çift paneli otomatik hazırlanır.</li>
+          <li>Referans kodu alanı isteğe bağlıdır. Kod kullanırsanız ilgili bayi cashback kazanır.</li>
+          <li>Dilediğiniz zaman destek ekibimizle iletişime geçebilirsiniz.</li>
+        </ul>
       </div>
       <div class="col-lg-7">
         <form method="post" action="order.php" class="row g-3">
@@ -188,23 +291,23 @@ unset($_SESSION['lead_success']);
           </div>
           <div class="col-md-6">
             <label class="form-label fw-semibold">Etkinlik Başlığı</label>
-            <input type="text" name="event_title" class="form-control input-rounded" value="<?=h($formData['event_title'])?>" placeholder="Örn. Deniz & Efe Düğünü">
+            <input type="text" name="event_title" class="form-control input-rounded" value="<?=h($formData['event_title'])?>" placeholder="Örn. Deniz &amp; Efe Düğünü">
           </div>
           <div class="col-md-6">
             <label class="form-label fw-semibold">Etkinlik Tarihi</label>
             <input type="date" name="event_date" class="form-control input-rounded" value="<?=h($formData['event_date'])?>">
           </div>
           <div class="col-md-6">
-            <label class="form-label fw-semibold">Referans Kodu</label>
+            <label class="form-label fw-semibold">Referans Kodu (opsiyonel)</label>
             <input type="text" name="referral_code" class="form-control input-rounded" value="<?=h($formData['referral_code'])?>" placeholder="Bayi kodu">
           </div>
           <div class="col-12">
             <label class="form-label fw-semibold">Notunuz</label>
-            <textarea name="notes" class="form-control input-rounded" rows="3" placeholder="Etkinliğe dair eklemek istediğiniz bilgiler"><?=h($formData['notes'])?></textarea>
+            <textarea name="notes" class="form-control input-rounded" rows="3" placeholder="Etkinlikle ilgili paylaşmak istediğiniz ek bilgiler"><?=h($formData['notes'])?></textarea>
           </div>
-          <div class="col-12 d-flex justify-content-between align-items-center pt-3">
-            <span class="muted small">Formu gönderdiğinizde ekibimiz sizinle iletişime geçer.</span>
-            <button class="btn btn-brand" type="submit">QR Kodlarımı Oluştur</button>
+          <div class="col-12 d-flex flex-column flex-md-row gap-3 justify-content-between align-items-md-center pt-3">
+            <span class="muted small">Formu gönderdiğinizde PayTR güvenli ödeme sayfasına yönlendirileceksiniz.</span>
+            <button class="btn btn-brand" type="submit">Ödeme Adımına Geç</button>
           </div>
         </form>
       </div>
@@ -212,10 +315,13 @@ unset($_SESSION['lead_success']);
   </section>
 </main>
 
-<footer class="py-4 border-top bg-white">
-  <div class="container d-flex flex-wrap gap-2 justify-content-between small text-muted">
-    <span>© <?=date('Y')?> <?=h(APP_NAME)?> — Wedding Share Teknoloji</span>
-    <span>Destek: <a href="mailto:support@demozerosoft.com.tr" class="text-decoration-none">support@demozerosoft.com.tr</a></span>
+<footer>
+  <div class="container d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+    <div>
+      <div class="fw-semibold mb-1">© <?=date('Y')?> <?=h(APP_NAME)?></div>
+      <div class="small text-muted">Anılarınızı güvenli bir şekilde dijitalleştirmenize yardımcı oluyoruz.</div>
+    </div>
+    <div class="small">Destek: <a href="mailto:support@demozerosoft.com.tr">support@demozerosoft.com.tr</a></div>
   </div>
 </footer>
 </body></html>

--- a/index.php
+++ b/index.php
@@ -84,15 +84,15 @@ unset($_SESSION['lead_success']);
       <div class="col-lg-6">
         <span class="badge bg-light text-dark rounded-pill px-3 py-2 fw-semibold">Yeni nesil misafir paylaşımı</span>
         <h1 class="fw-bold display-5 mt-4 mb-3">Tek QR kodla tüm fotoğraf ve videoları toplayın</h1>
-        <p class="lead mb-4">Wedding Share, davetlilerinizin çektikleri anıları saniyeler içinde toplayarak çift panelinizi, misafir galerilerini ve paylaşılabilir QR kodlarını otomatik olarak hazırlar.</p>
+        <p class="lead mb-4">BİKARE, davetlilerinizin çektikleri anıları saniyeler içinde toplayarak çift panelinizi, misafir galerilerini ve paylaşılabilir QR kodlarını otomatik olarak hazırlar.</p>
         <div class="d-flex flex-wrap gap-3">
           <a class="btn btn-light text-dark fw-semibold" href="#paketler">Paketleri İncele</a>
           <a class="btn btn-outline-light fw-semibold" href="#lead-form">Hemen Başlayın</a>
         </div>
       </div>
       <div class="col-lg-6 hero-visual">
-        <img src="https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=820&q=80" alt="Düğün kutlaması" class="img-fluid">
-        <img src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=520&q=80" alt="Etkinlikten kare" class="img-fluid">
+        <img src="https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=compress&cs=tinysrgb&fit=crop&w=820&q=80" alt="Düğün kutlaması" class="img-fluid">
+        <img src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=compress&cs=tinysrgb&fit=crop&w=520&q=80" alt="Etkinlikten kare" class="img-fluid">
       </div>
     </div>
     <div class="row mt-5 g-4 position-relative" style="z-index:2;">
@@ -151,7 +151,7 @@ unset($_SESSION['lead_success']);
   <section class="mb-5">
     <div class="row g-4 align-items-center">
       <div class="col-lg-6">
-        <h2 class="fw-bold mb-3">Wedding Share nasıl çalışır?</h2>
+        <h2 class="fw-bold mb-3">BİKARE nasıl çalışır?</h2>
         <p class="muted">Basit 3 adımda etkinliğinizi dijitalleştiriyoruz. Kurulum ve teknik detaylarla vakit kaybetmenize gerek yok.</p>
       </div>
       <div class="col-lg-6 d-flex flex-column gap-3">
@@ -210,9 +210,9 @@ unset($_SESSION['lead_success']);
         <p class="muted">Misafirleriniz sadece düğünlerde değil; nişan, kına, doğum günü ve kurumsal etkinliklerde de QR kodunuzla içerik paylaşabilir.</p>
       </div>
       <div class="col-lg-7 gallery-grid">
-        <img src="https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=600&q=80" alt="Düğün davetlileri">
-        <img src="https://images.unsplash.com/photo-1530023367847-a683933f4177?auto=format&fit=crop&w=600&q=80" alt="Nişan etkinliği">
-        <img src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=600&q=80" alt="Kurumsal etkinlik">
+        <img src="https://images.unsplash.com/photo-1603015444030-0e4d0a568d2e?auto=compress&cs=tinysrgb&fit=crop&w=600&q=80" alt="Düğün davetlileri">
+        <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=compress&cs=tinysrgb&fit=crop&w=600&q=80" alt="Kurumsal etkinlik">
+        <img src="https://images.unsplash.com/photo-1525253013412-55c1a69a5738?auto=compress&cs=tinysrgb&fit=crop&w=600&q=80" alt="Yemek organizasyonu">
       </div>
     </div>
   </section>
@@ -228,7 +228,7 @@ unset($_SESSION['lead_success']);
       </div>
       <div class="col-md-6">
         <div class="testimonial h-100">
-          <p class="mb-3">"Kurumsal lansmanımızda katılımcıların videolarını toplamak bu kadar kolay olmamıştı. Wedding Share ekibi her detayla ilgilendi."</p>
+          <p class="mb-3">"Kurumsal lansmanımızda katılımcıların videolarını toplamak bu kadar kolay olmamıştı. BİKARE ekibi her detayla ilgilendi."</p>
           <div class="fw-semibold">Berna U.</div>
           <div class="small text-muted">Etkinlik Ajansı Sahibi</div>
         </div>

--- a/index.php
+++ b/index.php
@@ -11,6 +11,15 @@ if (session_status() === PHP_SESSION_NONE) {
 install_schema();
 
 $packages = site_public_packages();
+$content = site_public_content();
+$faqItems = $content['faq_items'];
+$footerNav = $content['footer_nav_links'];
+$contactWebsiteUrl = site_normalize_url($content['contact_website'] ?? '') ?? '';
+$contactWebsiteLabel = $content['contact_website_label'] ?? '';
+$contactPhoneHref = site_phone_href($content['contact_phone'] ?? '') ?? '';
+$contactPrimaryUrl = site_resolve_button_url($content['contact_primary_url'] ?? '') ?? '';
+$contactSecondaryUrl = site_resolve_button_url($content['contact_secondary_url'] ?? '') ?? '';
+$contactCtaButtonUrl = site_resolve_button_url($content['contact_cta_button_url'] ?? '') ?? '';
 $formData = $_SESSION['lead_form'] ?? [
   'customer_name' => '',
   'customer_email' => '',
@@ -68,11 +77,23 @@ unset($_SESSION['lead_success']);
   .muted{color:var(--muted);}
   .nav-link{font-weight:600;color:var(--muted)!important;}
   .nav-link:hover,.nav-link:focus{color:var(--brand)!important;}
+  .contact-card{border-radius:24px;background:#fff;box-shadow:0 24px 60px rgba(15,118,110,0.18);padding:32px;}
+  .contact-card ul{margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:12px;}
+  .contact-card ul li strong{color:var(--ink);min-width:84px;display:inline-block;}
+  .contact-card ul li a{color:var(--brand);font-weight:600;text-decoration:none;}
+  .contact-card ul li a:hover{color:var(--brand-dark);text-decoration:underline;}
+  .contact-card .btn-outline-secondary{border-color:rgba(14,165,181,0.35);color:var(--brand);background:rgba(14,165,181,0.08);}
+  .contact-card .btn-outline-secondary:hover{background:var(--brand);color:#fff;border-color:var(--brand);}
   .cta-bar{display:flex;gap:12px;align-items:center;flex-wrap:wrap;}
   .navbar-toggler{border:none;box-shadow:none;}
-  footer{background:#0f172a;color:#e2e8f0;padding:36px 0;}
-  footer a{color:#94a3b8;text-decoration:none;}
-  footer a:hover{text-decoration:underline;}
+  footer{background:var(--brand);color:#f0fdfa;padding:48px 0 40px;margin-top:48px;}
+  footer h5, footer h6{color:#fff;}
+  footer a{color:rgba(255,255,255,0.9);font-weight:600;text-decoration:none;}
+  footer a:hover{color:#0f172a;text-decoration:underline;}
+  .footer-payment-logo{height:28px;filter:brightness(0) invert(1);opacity:0.85;transition:opacity .2s ease;}
+  .footer-payment-logo:hover{opacity:1;}
+  .footer-nav a{color:#fdfdfd;display:inline-block;margin-bottom:8px;}
+  .footer-nav a:hover{color:#0f172a;}
   @media(max-width:992px){.hero{padding:72px 28px;}.hero-visual img:nth-child(2){display:none;}}
   @media(max-width:768px){.form-section{padding:32px;}}
 </style>
@@ -311,40 +332,26 @@ unset($_SESSION['lead_success']);
         <p class="muted">BİKARE ile ilgili merak ettiğiniz konuları sizin için derledik. Daha fazlası için bizimle iletişime geçebilirsiniz.</p>
       </div>
       <div class="col-lg-7">
-        <div class="accordion" id="faqAccordion">
-          <div class="accordion-item">
-            <h2 class="accordion-header" id="faqOne">
-              <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#faqOneCollapse" aria-expanded="true" aria-controls="faqOneCollapse">Ödeme sonrasında panel ne kadar sürede hazır olur?</button>
-            </h2>
-            <div id="faqOneCollapse" class="accordion-collapse collapse show" aria-labelledby="faqOne" data-bs-parent="#faqAccordion">
-              <div class="accordion-body">PayTR üzerinden ödemeniz tamamlandığında sistemimiz etkinliğinizi birkaç dakika içinde kurar. QR kodlar ve giriş bilgileri otomatik olarak e-posta ile gönderilir.</div>
-            </div>
+        <?php if ($faqItems): ?>
+          <div class="accordion" id="faqAccordion">
+            <?php foreach ($faqItems as $i => $faq):
+              $headingId = 'faqHeading'.$i;
+              $collapseId = 'faqCollapse'.$i;
+              $isFirst = ($i === 0);
+            ?>
+              <div class="accordion-item">
+                <h2 class="accordion-header" id="<?=h($headingId)?>">
+                  <button class="accordion-button<?=$isFirst ? '' : ' collapsed'?>" type="button" data-bs-toggle="collapse" data-bs-target="#<?=h($collapseId)?>" aria-expanded="<?=$isFirst ? 'true' : 'false'?>" aria-controls="<?=h($collapseId)?>"><?=h($faq['question'])?></button>
+                </h2>
+                <div id="<?=h($collapseId)?>" class="accordion-collapse collapse<?=$isFirst ? ' show' : ''?>" aria-labelledby="<?=h($headingId)?>" data-bs-parent="#faqAccordion">
+                  <div class="accordion-body"><?=nl2br(h($faq['answer']))?></div>
+                </div>
+              </div>
+            <?php endforeach; ?>
           </div>
-          <div class="accordion-item">
-            <h2 class="accordion-header" id="faqTwo">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqTwoCollapse" aria-expanded="false" aria-controls="faqTwoCollapse">Misafirler hangi formatlarda dosya yükleyebilir?</button>
-            </h2>
-            <div id="faqTwoCollapse" class="accordion-collapse collapse" aria-labelledby="faqTwo" data-bs-parent="#faqAccordion">
-              <div class="accordion-body">BİKARE yüksek çözünürlüklü fotoğraf ve videoları destekler. Büyük dosyalar için otomatik sıkıştırma ve format uyumluluğu sunar.</div>
-            </div>
-          </div>
-          <div class="accordion-item">
-            <h2 class="accordion-header" id="faqThree">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqThreeCollapse" aria-expanded="false" aria-controls="faqThreeCollapse">Etkinlik sonrası misafir galerisini kullanmaya devam edebilir miyiz?</button>
-            </h2>
-            <div id="faqThreeCollapse" class="accordion-collapse collapse" aria-labelledby="faqThree" data-bs-parent="#faqAccordion">
-              <div class="accordion-body">Evet. Galeriniz etkinlikten sonra da açık kalır. Yorumları, beğenileri ve sohbet geçmişini dilediğiniz zaman görüntüleyebilirsiniz.</div>
-            </div>
-          </div>
-          <div class="accordion-item">
-            <h2 class="accordion-header" id="faqFour">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqFourCollapse" aria-expanded="false" aria-controls="faqFourCollapse">Bayi olmadan da BİKARE'yi kullanabilir miyiz?</button>
-            </h2>
-            <div id="faqFourCollapse" class="accordion-collapse collapse" aria-labelledby="faqFour" data-bs-parent="#faqAccordion">
-              <div class="accordion-body">Elbette. Web sitemiz üzerinden dilediğiniz paketi seçip saniyeler içinde satın alabilir, kendi etkinliğiniz için BİKARE panelini kurabilirsiniz.</div>
-            </div>
-          </div>
-        </div>
+        <?php else: ?>
+          <div class="alert alert-info">Henüz sıkça sorulan soru eklenmedi.</div>
+        <?php endif; ?>
       </div>
     </div>
   </section>
@@ -352,28 +359,50 @@ unset($_SESSION['lead_success']);
   <section id="iletisim" class="mb-5">
     <div class="row g-4 align-items-stretch">
       <div class="col-lg-6">
-        <div class="feature-card h-100">
-          <h3 class="fw-bold mb-3">Bizimle iletişime geçin</h3>
-          <p class="muted">Projenizle ilgili sorularınızı, özel taleplerinizi veya demo isteğinizi paylaşın. Ekibimiz en kısa sürede dönüş yapacaktır.</p>
-          <ul class="list-unstyled d-flex flex-column gap-3">
-            <li><strong>Telefon:</strong> <a href="tel:+908502225566">+90 850 222 55 66</a></li>
-            <li><strong>E-posta:</strong> <a href="mailto:info@zerosoft.com.tr">info@zerosoft.com.tr</a></li>
-            <li><strong>Adres:</strong> Zerosoft Teknoloji, İzmir Teknopark</li>
-            <li><strong>Web:</strong> <a href="https://zerosoft.com.tr" target="_blank" rel="noopener">zerosoft.com.tr</a></li>
+        <div class="contact-card h-100">
+          <h3 class="fw-bold mb-3"><?=h($content['contact_title'])?></h3>
+          <?php if (!empty($content['contact_text'])): ?>
+            <p class="muted mb-4"><?=h($content['contact_text'])?></p>
+          <?php endif; ?>
+          <ul>
+            <?php if (!empty($content['contact_phone'])): ?>
+              <li><strong>Telefon:</strong> <?php if ($contactPhoneHref): ?><a href="<?=h($contactPhoneHref)?>"><?=h($content['contact_phone'])?></a><?php else: ?><?=h($content['contact_phone'])?><?php endif; ?></li>
+            <?php endif; ?>
+            <?php if (!empty($content['contact_email'])): ?>
+              <li><strong>E-posta:</strong> <a href="mailto:<?=h($content['contact_email'])?>"><?=h($content['contact_email'])?></a></li>
+            <?php endif; ?>
+            <?php if (!empty($content['contact_address'])): ?>
+              <li><strong>Adres:</strong> <?=h($content['contact_address'])?></li>
+            <?php endif; ?>
+            <?php if ($contactWebsiteUrl): ?>
+              <li><strong>Web:</strong> <a href="<?=h($contactWebsiteUrl)?>" target="_blank" rel="noopener"><?=h($contactWebsiteLabel ?: $contactWebsiteUrl)?></a></li>
+            <?php endif; ?>
           </ul>
-          <div class="d-flex flex-wrap gap-3">
-            <a class="btn btn-outline-secondary rounded-pill" href="mailto:info@zerosoft.com.tr">E-posta Gönder</a>
-            <a class="btn btn-brand" href="tel:+908502225566">Hemen Ara</a>
+          <div class="d-flex flex-wrap gap-3 pt-3">
+            <?php if ($contactPrimaryUrl && !empty($content['contact_primary_label'])): ?>
+              <a class="btn btn-outline-secondary rounded-pill" href="<?=h($contactPrimaryUrl)?>"><?=h($content['contact_primary_label'])?></a>
+            <?php endif; ?>
+            <?php if ($contactSecondaryUrl && !empty($content['contact_secondary_label'])): ?>
+              <a class="btn btn-brand" href="<?=h($contactSecondaryUrl)?>"><?=h($content['contact_secondary_label'])?></a>
+            <?php endif; ?>
           </div>
         </div>
       </div>
       <div class="col-lg-6">
         <div class="hero position-relative text-white h-100" style="min-height:320px;">
           <div class="position-relative" style="z-index:2;">
-            <span class="badge bg-light text-dark rounded-pill px-3 py-2 fw-semibold">Zerosoft ile tanışın</span>
-            <h3 class="fw-bold mt-3">Birlikte unutulmaz deneyimler tasarlayalım</h3>
-            <p>Etkinlik konseptiniz, katılımcı sayınız veya ihtiyaç duyduğunuz entegrasyonları konuşmak için randevu planlayalım. BİKARE ekibi tüm süreci sizin için yönetir.</p>
-            <a class="btn btn-light text-dark fw-semibold" href="#lead-form">Demo Talep Et</a>
+            <?php if (!empty($content['contact_cta_badge'])): ?>
+              <span class="badge bg-light text-dark rounded-pill px-3 py-2 fw-semibold"><?=h($content['contact_cta_badge'])?></span>
+            <?php endif; ?>
+            <?php if (!empty($content['contact_cta_title'])): ?>
+              <h3 class="fw-bold mt-3"><?=h($content['contact_cta_title'])?></h3>
+            <?php endif; ?>
+            <?php if (!empty($content['contact_cta_text'])): ?>
+              <p><?=nl2br(h($content['contact_cta_text']))?></p>
+            <?php endif; ?>
+            <?php if ($contactCtaButtonUrl && !empty($content['contact_cta_button_label'])): ?>
+              <a class="btn btn-light text-dark fw-semibold" href="<?=h($contactCtaButtonUrl)?>"><?=h($content['contact_cta_button_label'])?></a>
+            <?php endif; ?>
           </div>
         </div>
       </div>
@@ -461,34 +490,44 @@ unset($_SESSION['lead_success']);
 
 <footer>
   <div class="container">
-    <div class="row gy-4">
-      <div class="col-md-4">
+    <div class="row gy-4 align-items-start">
+      <div class="col-lg-4">
         <h5 class="fw-bold">BİKARE</h5>
-        <p class="small">Misafir deneyimini dijitalleştirir, etkinliğinizin her anını tek karede toplarız. Zerosoft güvencesiyle geliştirilen BİKARE, modern etkinliklerin vazgeçilmezi.</p>
+        <p class="small mb-3"><?=nl2br(h($content['footer_about']))?></p>
+        <div class="d-flex align-items-center gap-3 flex-wrap">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/2/2a/Mastercard-logo.svg" alt="Mastercard" class="footer-payment-logo" loading="lazy">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/5/5e/Visa_Inc._logo.svg" alt="Visa" class="footer-payment-logo" loading="lazy">
+          <img src="https://www.paytr.com/img/paytr-logo.svg" alt="PayTR" class="footer-payment-logo" loading="lazy">
+        </div>
       </div>
-      <div class="col-md-4">
-        <h6 class="fw-semibold">Zerosoft</h6>
-        <ul class="list-unstyled small">
-          <li>Telefon: <a href="tel:+908502225566">+90 850 222 55 66</a></li>
-          <li>E-posta: <a href="mailto:info@zerosoft.com.tr">info@zerosoft.com.tr</a></li>
-          <li>Web: <a href="https://zerosoft.com.tr" target="_blank" rel="noopener">zerosoft.com.tr</a></li>
+      <div class="col-lg-4">
+        <h6 class="fw-semibold mb-2"><?=h($content['footer_company'])?></h6>
+        <ul class="list-unstyled small mb-0">
+          <?php if (!empty($content['contact_phone'])): ?>
+            <li>Telefon: <?php if ($contactPhoneHref): ?><a href="<?=h($contactPhoneHref)?>"><?=h($content['contact_phone'])?></a><?php else: ?><?=h($content['contact_phone'])?><?php endif; ?></li>
+          <?php endif; ?>
+          <?php if (!empty($content['contact_email'])): ?>
+            <li>E-posta: <a href="mailto:<?=h($content['contact_email'])?>"><?=h($content['contact_email'])?></a></li>
+          <?php endif; ?>
+          <?php if ($contactWebsiteUrl): ?>
+            <li>Web: <a href="<?=h($contactWebsiteUrl)?>" target="_blank" rel="noopener"><?=h($contactWebsiteLabel ?: $contactWebsiteUrl)?></a></li>
+          <?php endif; ?>
         </ul>
       </div>
-      <div class="col-md-4">
-        <h6 class="fw-semibold">Navigasyon</h6>
-        <ul class="list-unstyled small">
-          <li><a href="#hakkimizda">Hakkımızda</a></li>
-          <li><a href="#nasil">Nasıl Çalışıyoruz</a></li>
-          <li><a href="#paketler">Paketler</a></li>
-          <li><a href="#sss">SSS</a></li>
-          <li><a href="#iletisim">İletişim</a></li>
-        </ul>
+      <div class="col-lg-4">
+        <h6 class="fw-semibold mb-2">Navigasyon</h6>
+        <div class="footer-nav">
+          <?php foreach ($footerNav as $nav): ?>
+            <a href="<?=h($nav['url'])?>"><?=h($nav['label'])?></a>
+          <?php endforeach; ?>
+        </div>
       </div>
     </div>
-    <div class="border-top border-secondary mt-4 pt-3 d-flex flex-column flex-md-row justify-content-between small text-secondary">
-      <span>© <?=date('Y')?> Zerosoft Teknoloji</span>
-      <span>Developed by Zerosoft — BİKARE Dijital Etkinlik Platformu</span>
+    <div class="border-top border-light mt-4 pt-3 d-flex flex-column flex-md-row justify-content-between gap-2 small">
+      <span><?=h($content['footer_disclaimer_left'])?></span>
+      <span><?=h($content['footer_disclaimer_right'])?></span>
     </div>
   </div>
 </footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body></html>

--- a/index.php
+++ b/index.php
@@ -63,6 +63,8 @@ unset($_SESSION['lead_success']);
   .input-rounded{border-radius:16px;border:1px solid #d7e4eb;padding:12px 16px;}
   .btn-brand{background:var(--brand);color:#fff;border:none;border-radius:18px;padding:14px 32px;font-weight:700;}
   .btn-brand:hover{background:var(--brand-dark);color:#fff;}
+  .btn-guest{border-radius:999px;border:1px solid rgba(14,165,181,0.3);color:var(--brand);font-weight:600;padding:10px 22px;background:rgba(14,165,181,0.08);}
+  .btn-guest:hover{color:#fff;background:var(--brand);border-color:var(--brand);}
   .muted{color:var(--muted);}
   footer{background:#0f172a;color:#e2e8f0;padding:36px 0;}
   footer a{color:#94a3b8;text-decoration:none;}
@@ -72,9 +74,14 @@ unset($_SESSION['lead_success']);
 </style>
 </head><body>
 <nav class="navbar navbar-expand-lg bg-white border-bottom shadow-sm py-3">
-  <div class="container">
-    <a class="navbar-brand fw-bold" href="#"><?=h(APP_NAME)?></a>
-    <span class="badge text-bg-info-subtle text-info-emphasis rounded-pill">Dijital Etkinlik Deneyimi</span>
+  <div class="container d-flex align-items-center justify-content-between gap-3">
+    <div class="d-flex align-items-center gap-3">
+      <a class="navbar-brand fw-bold" href="#"><?=h(APP_NAME)?></a>
+      <span class="badge text-bg-info-subtle text-info-emphasis rounded-pill">Dijital Etkinlik Deneyimi</span>
+    </div>
+    <div>
+      <a class="btn btn-guest" href="<?=BASE_URL?>/public/guest_login.php">Misafir Girişi</a>
+    </div>
   </div>
 </nav>
 

--- a/index.php
+++ b/index.php
@@ -66,6 +66,10 @@ unset($_SESSION['lead_success']);
   .btn-guest{border-radius:999px;border:1px solid rgba(14,165,181,0.3);color:var(--brand);font-weight:600;padding:10px 22px;background:rgba(14,165,181,0.08);}
   .btn-guest:hover{color:#fff;background:var(--brand);border-color:var(--brand);}
   .muted{color:var(--muted);}
+  .nav-link{font-weight:600;color:var(--muted)!important;}
+  .nav-link:hover,.nav-link:focus{color:var(--brand)!important;}
+  .cta-bar{display:flex;gap:12px;align-items:center;flex-wrap:wrap;}
+  .navbar-toggler{border:none;box-shadow:none;}
   footer{background:#0f172a;color:#e2e8f0;padding:36px 0;}
   footer a{color:#94a3b8;text-decoration:none;}
   footer a:hover{text-decoration:underline;}
@@ -73,14 +77,25 @@ unset($_SESSION['lead_success']);
   @media(max-width:768px){.form-section{padding:32px;}}
 </style>
 </head><body>
-<nav class="navbar navbar-expand-lg bg-white border-bottom shadow-sm py-3">
-  <div class="container d-flex align-items-center justify-content-between gap-3">
-    <div class="d-flex align-items-center gap-3">
-      <a class="navbar-brand fw-bold" href="#"><?=h(APP_NAME)?></a>
-      <span class="badge text-bg-info-subtle text-info-emphasis rounded-pill">Dijital Etkinlik Deneyimi</span>
-    </div>
-    <div>
-      <a class="btn btn-guest" href="<?=BASE_URL?>/public/guest_login.php">Misafir Girişi</a>
+<nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom shadow-sm py-3 sticky-top">
+  <div class="container">
+    <a class="navbar-brand fw-bold fs-3" href="#hero"><?=h(APP_NAME)?></a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Menüyü Aç">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="mainNav">
+      <ul class="navbar-nav ms-auto mb-3 mb-lg-0 align-items-lg-center gap-lg-3">
+        <li class="nav-item"><a class="nav-link" href="#hakkimizda">Hakkımızda</a></li>
+        <li class="nav-item"><a class="nav-link" href="#nasil">Nasıl Çalışıyoruz</a></li>
+        <li class="nav-item"><a class="nav-link" href="#paketler">Paketler</a></li>
+        <li class="nav-item"><a class="nav-link" href="#sss">SSS</a></li>
+        <li class="nav-item"><a class="nav-link" href="#iletisim">İletişim</a></li>
+      </ul>
+      <div class="cta-bar ms-lg-4">
+        <a class="btn btn-outline-secondary rounded-pill px-4" href="<?=BASE_URL?>/dealer/apply.php">Bayi Ol</a>
+        <a class="btn btn-guest" href="<?=BASE_URL?>/dealer/login.php">Bayi Girişi</a>
+        <a class="btn btn-brand" href="<?=BASE_URL?>/public/guest_login.php">Misafir Girişi</a>
+      </div>
     </div>
   </div>
 </nav>
@@ -129,7 +144,34 @@ unset($_SESSION['lead_success']);
   <?php endif; ?>
   <?php flash_box(); ?>
 
-  <section class="mb-5">
+  <section id="hakkimizda" class="mb-5">
+    <div class="row align-items-center g-5">
+      <div class="col-lg-6">
+        <img class="img-fluid rounded-4 shadow-lg" src="https://images.unsplash.com/photo-1511288590-34b0471af9b4?auto=compress&cs=tinysrgb&fit=crop&w=900&q=80" alt="Mutlu çift">
+      </div>
+      <div class="col-lg-6">
+        <span class="badge bg-light text-dark rounded-pill px-3 py-2 fw-semibold">BİKARE Hakkında</span>
+        <h2 class="fw-bold mt-3">Her anınızı dijital sahneye taşıyan çözüm ortağınız</h2>
+        <p class="muted">Zerosoft olarak düğün, nişan, kurumsal davet ve tüm özel etkinliklerinizde misafirlerinizle aynı anda nefes alan bir platform geliştirdik. BİKARE; yüksek yükleme kapasitesi, güçlü misafir etkileşim araçları ve otomatik QR kod altyapısıyla sizi teknik detaylardan kurtarır.</p>
+        <div class="row g-3">
+          <div class="col-sm-6">
+            <div class="feature-card h-100">
+              <h5 class="fw-semibold">Profesyonel destek</h5>
+              <p class="muted small mb-0">Kurulumdan canlı yayına kadar deneyimli ekibimizle yanınızdayız.</p>
+            </div>
+          </div>
+          <div class="col-sm-6">
+            <div class="feature-card h-100">
+              <h5 class="fw-semibold">Tamamen yerli altyapı</h5>
+              <p class="muted small mb-0">Verileriniz Türkiye lokasyonlu sunucularda güvenle saklanır.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="ozellikler" class="mb-5">
     <div class="row g-4">
       <div class="col-md-4">
         <div class="feature-card h-100">
@@ -155,7 +197,7 @@ unset($_SESSION['lead_success']);
     </div>
   </section>
 
-  <section class="mb-5">
+  <section id="nasil" class="mb-5">
     <div class="row g-4 align-items-center">
       <div class="col-lg-6">
         <h2 class="fw-bold mb-3">BİKARE nasıl çalışır?</h2>
@@ -210,6 +252,25 @@ unset($_SESSION['lead_success']);
     </div>
   </section>
 
+  <section id="bayi-avantaj" class="mb-5">
+    <div class="row g-4 align-items-center">
+      <div class="col-lg-6">
+        <span class="badge bg-info-subtle text-info-emphasis rounded-pill px-3 py-2 fw-semibold">Bayi Ağı</span>
+        <h2 class="fw-bold mt-3">Etkinlik sektöründeki iş ortaklarımız için kazandıran sistem</h2>
+        <p class="muted">Bayi panelinizden bakiye yönetebilir, PayTR entegrasyonlu paketler satın alabilir, etkinliklerinizi tek ekrandan yönetebilirsiniz. Referans kodu ile gerçekleştirdiğiniz satışlardan onay sonrası cashback kazanırsınız.</p>
+        <ul class="muted">
+          <li>Salon bazlı etkinlik yönetimi ve QR kod üretimi</li>
+          <li>Detaylı raporlama, bakiye ve cashback geçmişi</li>
+          <li>PayTR ile güvenli tahsilat ve hızlı aktivasyon</li>
+        </ul>
+        <a class="btn btn-brand" href="<?=BASE_URL?>/dealer/apply.php">Bayi Ağına Katıl</a>
+      </div>
+      <div class="col-lg-6 text-center">
+        <img class="img-fluid rounded-4 shadow-lg" src="https://images.unsplash.com/photo-1499951360447-b19be8fe80f5?auto=compress&cs=tinysrgb&fit=crop&w=900&q=80" alt="Bayi paneli">
+      </div>
+    </div>
+  </section>
+
   <section class="mb-5">
     <div class="row g-4 align-items-center">
       <div class="col-lg-5">
@@ -238,6 +299,82 @@ unset($_SESSION['lead_success']);
           <p class="mb-3">"Kurumsal lansmanımızda katılımcıların videolarını toplamak bu kadar kolay olmamıştı. BİKARE ekibi her detayla ilgilendi."</p>
           <div class="fw-semibold">Berna U.</div>
           <div class="small text-muted">Etkinlik Ajansı Sahibi</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="sss" class="mb-5">
+    <div class="row g-4">
+      <div class="col-lg-5">
+        <h2 class="fw-bold">Sıkça sorulan sorular</h2>
+        <p class="muted">BİKARE ile ilgili merak ettiğiniz konuları sizin için derledik. Daha fazlası için bizimle iletişime geçebilirsiniz.</p>
+      </div>
+      <div class="col-lg-7">
+        <div class="accordion" id="faqAccordion">
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="faqOne">
+              <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#faqOneCollapse" aria-expanded="true" aria-controls="faqOneCollapse">Ödeme sonrasında panel ne kadar sürede hazır olur?</button>
+            </h2>
+            <div id="faqOneCollapse" class="accordion-collapse collapse show" aria-labelledby="faqOne" data-bs-parent="#faqAccordion">
+              <div class="accordion-body">PayTR üzerinden ödemeniz tamamlandığında sistemimiz etkinliğinizi birkaç dakika içinde kurar. QR kodlar ve giriş bilgileri otomatik olarak e-posta ile gönderilir.</div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="faqTwo">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqTwoCollapse" aria-expanded="false" aria-controls="faqTwoCollapse">Misafirler hangi formatlarda dosya yükleyebilir?</button>
+            </h2>
+            <div id="faqTwoCollapse" class="accordion-collapse collapse" aria-labelledby="faqTwo" data-bs-parent="#faqAccordion">
+              <div class="accordion-body">BİKARE yüksek çözünürlüklü fotoğraf ve videoları destekler. Büyük dosyalar için otomatik sıkıştırma ve format uyumluluğu sunar.</div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="faqThree">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqThreeCollapse" aria-expanded="false" aria-controls="faqThreeCollapse">Etkinlik sonrası misafir galerisini kullanmaya devam edebilir miyiz?</button>
+            </h2>
+            <div id="faqThreeCollapse" class="accordion-collapse collapse" aria-labelledby="faqThree" data-bs-parent="#faqAccordion">
+              <div class="accordion-body">Evet. Galeriniz etkinlikten sonra da açık kalır. Yorumları, beğenileri ve sohbet geçmişini dilediğiniz zaman görüntüleyebilirsiniz.</div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="faqFour">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqFourCollapse" aria-expanded="false" aria-controls="faqFourCollapse">Bayi olmadan da BİKARE'yi kullanabilir miyiz?</button>
+            </h2>
+            <div id="faqFourCollapse" class="accordion-collapse collapse" aria-labelledby="faqFour" data-bs-parent="#faqAccordion">
+              <div class="accordion-body">Elbette. Web sitemiz üzerinden dilediğiniz paketi seçip saniyeler içinde satın alabilir, kendi etkinliğiniz için BİKARE panelini kurabilirsiniz.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="iletisim" class="mb-5">
+    <div class="row g-4 align-items-stretch">
+      <div class="col-lg-6">
+        <div class="feature-card h-100">
+          <h3 class="fw-bold mb-3">Bizimle iletişime geçin</h3>
+          <p class="muted">Projenizle ilgili sorularınızı, özel taleplerinizi veya demo isteğinizi paylaşın. Ekibimiz en kısa sürede dönüş yapacaktır.</p>
+          <ul class="list-unstyled d-flex flex-column gap-3">
+            <li><strong>Telefon:</strong> <a href="tel:+908502225566">+90 850 222 55 66</a></li>
+            <li><strong>E-posta:</strong> <a href="mailto:info@zerosoft.com.tr">info@zerosoft.com.tr</a></li>
+            <li><strong>Adres:</strong> Zerosoft Teknoloji, İzmir Teknopark</li>
+            <li><strong>Web:</strong> <a href="https://zerosoft.com.tr" target="_blank" rel="noopener">zerosoft.com.tr</a></li>
+          </ul>
+          <div class="d-flex flex-wrap gap-3">
+            <a class="btn btn-outline-secondary rounded-pill" href="mailto:info@zerosoft.com.tr">E-posta Gönder</a>
+            <a class="btn btn-brand" href="tel:+908502225566">Hemen Ara</a>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="hero position-relative text-white h-100" style="min-height:320px;">
+          <div class="position-relative" style="z-index:2;">
+            <span class="badge bg-light text-dark rounded-pill px-3 py-2 fw-semibold">Zerosoft ile tanışın</span>
+            <h3 class="fw-bold mt-3">Birlikte unutulmaz deneyimler tasarlayalım</h3>
+            <p>Etkinlik konseptiniz, katılımcı sayınız veya ihtiyaç duyduğunuz entegrasyonları konuşmak için randevu planlayalım. BİKARE ekibi tüm süreci sizin için yönetir.</p>
+            <a class="btn btn-light text-dark fw-semibold" href="#lead-form">Demo Talep Et</a>
+          </div>
         </div>
       </div>
     </div>
@@ -323,12 +460,35 @@ unset($_SESSION['lead_success']);
 </main>
 
 <footer>
-  <div class="container d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
-    <div>
-      <div class="fw-semibold mb-1">© <?=date('Y')?> <?=h(APP_NAME)?></div>
-      <div class="small text-muted">Anılarınızı güvenli bir şekilde dijitalleştirmenize yardımcı oluyoruz.</div>
+  <div class="container">
+    <div class="row gy-4">
+      <div class="col-md-4">
+        <h5 class="fw-bold">BİKARE</h5>
+        <p class="small">Misafir deneyimini dijitalleştirir, etkinliğinizin her anını tek karede toplarız. Zerosoft güvencesiyle geliştirilen BİKARE, modern etkinliklerin vazgeçilmezi.</p>
+      </div>
+      <div class="col-md-4">
+        <h6 class="fw-semibold">Zerosoft</h6>
+        <ul class="list-unstyled small">
+          <li>Telefon: <a href="tel:+908502225566">+90 850 222 55 66</a></li>
+          <li>E-posta: <a href="mailto:info@zerosoft.com.tr">info@zerosoft.com.tr</a></li>
+          <li>Web: <a href="https://zerosoft.com.tr" target="_blank" rel="noopener">zerosoft.com.tr</a></li>
+        </ul>
+      </div>
+      <div class="col-md-4">
+        <h6 class="fw-semibold">Navigasyon</h6>
+        <ul class="list-unstyled small">
+          <li><a href="#hakkimizda">Hakkımızda</a></li>
+          <li><a href="#nasil">Nasıl Çalışıyoruz</a></li>
+          <li><a href="#paketler">Paketler</a></li>
+          <li><a href="#sss">SSS</a></li>
+          <li><a href="#iletisim">İletişim</a></li>
+        </ul>
+      </div>
     </div>
-    <div class="small">Destek: <a href="mailto:support@demozerosoft.com.tr">support@demozerosoft.com.tr</a></div>
+    <div class="border-top border-secondary mt-4 pt-3 d-flex flex-column flex-md-row justify-content-between small text-secondary">
+      <span>© <?=date('Y')?> Zerosoft Teknoloji</span>
+      <span>Developed by Zerosoft — BİKARE Dijital Etkinlik Platformu</span>
+    </div>
   </div>
 </footer>
 </body></html>

--- a/order.php
+++ b/order.php
@@ -1,0 +1,95 @@
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/includes/db.php';
+require_once __DIR__.'/includes/functions.php';
+require_once __DIR__.'/includes/site.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+  session_start();
+}
+
+install_schema();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  redirect('index.php');
+}
+
+if (!csrf_check()) {
+  flash('err', 'Oturum doğrulaması başarısız oldu. Lütfen formu yeniden gönderin.');
+  $_SESSION['lead_form'] = $_POST;
+  redirect('index.php#lead-form');
+}
+
+$formData = [
+  'package_id' => (int)($_POST['package_id'] ?? 0),
+  'customer_name' => trim($_POST['customer_name'] ?? ''),
+  'customer_email' => trim($_POST['customer_email'] ?? ''),
+  'customer_phone' => trim($_POST['customer_phone'] ?? ''),
+  'event_title' => trim($_POST['event_title'] ?? ''),
+  'event_date' => trim($_POST['event_date'] ?? ''),
+  'referral_code' => trim($_POST['referral_code'] ?? ''),
+  'notes' => trim($_POST['notes'] ?? ''),
+];
+$_SESSION['lead_form'] = $formData;
+
+try {
+  $result = site_process_customer_order($formData);
+} catch (Throwable $e) {
+  flash('err', $e->getMessage());
+  redirect('index.php#lead-form');
+}
+
+unset($_SESSION['lead_form']);
+
+$event = $result['event'];
+$package = $result['package'];
+$dealer = $result['dealer'];
+$customer = $result['customer'];
+$cashbackCents = (int)$result['cashback_cents'];
+
+$uploadUrl = $event['upload_url'];
+$dynamicQrUrl = $event['qr_code'] ? BASE_URL.'/qr.php?code='.$event['qr_code'] : null;
+$qrImage = $dynamicQrUrl ?: $uploadUrl;
+$qrImageUrl = 'https://api.qrserver.com/v1/create-qr-code/?size=500x500&data='.rawurlencode($qrImage);
+$loginUrl = BASE_URL.'/couple/login.php?event='.$event['id'];
+
+$customerHtml = '<h2>'.h(APP_NAME).' — Etkinliğiniz Hazır</h2>'
+  .'<p>Merhaba '.h($customer['name']).',</p>'
+  .'<p>Etkinlik paneliniz oluşturuldu. Aşağıdaki bilgilerle giriş yapabilirsiniz:</p>'
+  .'<ul>'
+  .'<li><strong>Giriş adresi:</strong> <a href="'.h($loginUrl).'">'.h($loginUrl).'</a></li>'
+  .'<li><strong>Kullanıcı adı:</strong> '.h($customer['email']).'</li>'
+  .'<li><strong>Geçici şifre:</strong> '.h($event['plain_password']).'</li>'
+  .'</ul>'
+  .'<p>Misafir yükleme bağlantınız: <a href="'.h($uploadUrl).'">'.h($uploadUrl).'</a></p>'
+  .'<p>QR kodunuzu çıktı almak için aşağıdaki görseli kullanabilirsiniz:</p>'
+  .'<p><img src="'.h($qrImageUrl).'" alt="QR Kod" width="220" height="220"></p>'
+  .($dynamicQrUrl ? '<p>Kalıcı yönlendirme: <a href="'.h($dynamicQrUrl).'">'.h($dynamicQrUrl).'</a></p>' : '')
+  .'<p>Paketiniz: '.h($package['name']).' — '.h(format_currency((int)$package['price_cents'])).'</p>'
+  .'<p>İyi eğlenceler dileriz!<br>'.h(APP_NAME).' Ekibi</p>';
+
+send_mail_simple($customer['email'], 'Wedding Share etkinliğiniz hazır', $customerHtml);
+
+if ($dealer) {
+  $dealerHtml = '<h2>Yeni Web Satışı</h2>'
+    .'<p><strong>Müşteri:</strong> '.h($customer['name']).'<br>'
+    .'<strong>E-posta:</strong> '.h($customer['email']).'<br>'
+    .($customer['phone'] !== '' ? '<strong>Telefon:</strong> '.h($customer['phone']).'<br>' : '')
+    .'<strong>Paket:</strong> '.h($package['name']).' — '.h(format_currency((int)$package['price_cents'])).'</p>'
+    .'<p><strong>Etkinlik paneli:</strong> <a href="'.h($loginUrl).'">'.h($loginUrl).'</a><br>'
+    .'<strong>Misafir yükleme:</strong> <a href="'.h($uploadUrl).'">'.h($uploadUrl).'</a></p>'
+    .($dynamicQrUrl ? '<p><strong>QR 301 adresi:</strong> <a href="'.h($dynamicQrUrl).'">'.h($dynamicQrUrl).'</a></p>' : '')
+    .($cashbackCents > 0 ? '<p><strong>Cashback:</strong> '.h(format_currency($cashbackCents)).' hesabınıza tanımlandı.</p>' : '')
+    .'<p>Referans satışınız için teşekkür ederiz.</p>';
+  send_mail_simple($dealer['email'], 'Referans satışınız tamamlandı', $dealerHtml);
+}
+
+$_SESSION['lead_success'] = 'Talebiniz alındı! Giriş bilgileri '.$customer['email'].' adresine gönderildi.';
+$_SESSION['order_summary'] = [
+  'event_title' => $formData['event_title'] ?: $customer['name'].' Etkinliği',
+  'upload_url' => $uploadUrl,
+  'qr_dynamic' => $dynamicQrUrl,
+  'qr_image' => $qrImageUrl,
+];
+
+redirect('order_thanks.php');

--- a/order.php
+++ b/order.php
@@ -33,63 +33,15 @@ $formData = [
 $_SESSION['lead_form'] = $formData;
 
 try {
-  $result = site_process_customer_order($formData);
+  $created = site_create_customer_order($formData);
+  $order = $created['order'];
+  $paytr = site_ensure_order_paytr_token($order['id']);
 } catch (Throwable $e) {
   flash('err', $e->getMessage());
   redirect('index.php#lead-form');
 }
 
-unset($_SESSION['lead_form']);
+$_SESSION['current_order_id'] = $paytr['order']['id'];
+$_SESSION['current_order_oid'] = $paytr['merchant_oid'];
 
-$event = $result['event'];
-$package = $result['package'];
-$dealer = $result['dealer'];
-$customer = $result['customer'];
-$cashbackCents = (int)$result['cashback_cents'];
-
-$uploadUrl = $event['upload_url'];
-$dynamicQrUrl = $event['qr_code'] ? BASE_URL.'/qr.php?code='.$event['qr_code'] : null;
-$qrImage = $dynamicQrUrl ?: $uploadUrl;
-$qrImageUrl = 'https://api.qrserver.com/v1/create-qr-code/?size=500x500&data='.rawurlencode($qrImage);
-$loginUrl = BASE_URL.'/couple/login.php?event='.$event['id'];
-
-$customerHtml = '<h2>'.h(APP_NAME).' — Etkinliğiniz Hazır</h2>'
-  .'<p>Merhaba '.h($customer['name']).',</p>'
-  .'<p>Etkinlik paneliniz oluşturuldu. Aşağıdaki bilgilerle giriş yapabilirsiniz:</p>'
-  .'<ul>'
-  .'<li><strong>Giriş adresi:</strong> <a href="'.h($loginUrl).'">'.h($loginUrl).'</a></li>'
-  .'<li><strong>Kullanıcı adı:</strong> '.h($customer['email']).'</li>'
-  .'<li><strong>Geçici şifre:</strong> '.h($event['plain_password']).'</li>'
-  .'</ul>'
-  .'<p>Misafir yükleme bağlantınız: <a href="'.h($uploadUrl).'">'.h($uploadUrl).'</a></p>'
-  .'<p>QR kodunuzu çıktı almak için aşağıdaki görseli kullanabilirsiniz:</p>'
-  .'<p><img src="'.h($qrImageUrl).'" alt="QR Kod" width="220" height="220"></p>'
-  .($dynamicQrUrl ? '<p>Kalıcı yönlendirme: <a href="'.h($dynamicQrUrl).'">'.h($dynamicQrUrl).'</a></p>' : '')
-  .'<p>Paketiniz: '.h($package['name']).' — '.h(format_currency((int)$package['price_cents'])).'</p>'
-  .'<p>İyi eğlenceler dileriz!<br>'.h(APP_NAME).' Ekibi</p>';
-
-send_mail_simple($customer['email'], 'Wedding Share etkinliğiniz hazır', $customerHtml);
-
-if ($dealer) {
-  $dealerHtml = '<h2>Yeni Web Satışı</h2>'
-    .'<p><strong>Müşteri:</strong> '.h($customer['name']).'<br>'
-    .'<strong>E-posta:</strong> '.h($customer['email']).'<br>'
-    .($customer['phone'] !== '' ? '<strong>Telefon:</strong> '.h($customer['phone']).'<br>' : '')
-    .'<strong>Paket:</strong> '.h($package['name']).' — '.h(format_currency((int)$package['price_cents'])).'</p>'
-    .'<p><strong>Etkinlik paneli:</strong> <a href="'.h($loginUrl).'">'.h($loginUrl).'</a><br>'
-    .'<strong>Misafir yükleme:</strong> <a href="'.h($uploadUrl).'">'.h($uploadUrl).'</a></p>'
-    .($dynamicQrUrl ? '<p><strong>QR 301 adresi:</strong> <a href="'.h($dynamicQrUrl).'">'.h($dynamicQrUrl).'</a></p>' : '')
-    .($cashbackCents > 0 ? '<p><strong>Cashback:</strong> '.h(format_currency($cashbackCents)).' hesabınıza tanımlandı.</p>' : '')
-    .'<p>Referans satışınız için teşekkür ederiz.</p>';
-  send_mail_simple($dealer['email'], 'Referans satışınız tamamlandı', $dealerHtml);
-}
-
-$_SESSION['lead_success'] = 'Talebiniz alındı! Giriş bilgileri '.$customer['email'].' adresine gönderildi.';
-$_SESSION['order_summary'] = [
-  'event_title' => $formData['event_title'] ?: $customer['name'].' Etkinliği',
-  'upload_url' => $uploadUrl,
-  'qr_dynamic' => $dynamicQrUrl,
-  'qr_image' => $qrImageUrl,
-];
-
-redirect('order_thanks.php');
+redirect('order_paytr.php?order_id='.(int)$paytr['order']['id']);

--- a/order_paytr.php
+++ b/order_paytr.php
@@ -39,6 +39,20 @@ try {
   $order = $paytr['order'];
   $package = $paytr['package'];
   $token = $paytr['token'];
+  if (!empty($paytr['test_mode']) && !empty($paytr['result'])) {
+    $result = $paytr['result'];
+    $_SESSION['lead_success'] = 'Test modunda ödeme başarıyla işlendi.';
+    $_SESSION['order_summary'] = [
+      'event_title'    => $result['event']['title'],
+      'upload_url'     => $result['event']['upload_url'],
+      'qr_dynamic'     => $result['event']['qr_dynamic_url'],
+      'qr_image'       => $result['event']['qr_image_url'],
+      'login_url'      => $result['event']['login_url'],
+      'plain_password' => $result['event']['plain_password'],
+      'customer_email' => $result['customer']['email'],
+    ];
+    redirect('order_thanks.php');
+  }
 } catch (Throwable $e) {
   flash('err', $e->getMessage());
   redirect('index.php#lead-form');

--- a/order_paytr.php
+++ b/order_paytr.php
@@ -1,0 +1,121 @@
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/includes/db.php';
+require_once __DIR__.'/includes/functions.php';
+require_once __DIR__.'/includes/site.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+  session_start();
+}
+
+install_schema();
+
+$orderId = isset($_GET['order_id']) ? (int)$_GET['order_id'] : (int)($_SESSION['current_order_id'] ?? 0);
+if ($orderId <= 0) {
+  flash('err', 'Ödeme oturumu bulunamadı.');
+  redirect('index.php');
+}
+
+try {
+  $order = site_get_order($orderId);
+  if (!$order) {
+    throw new RuntimeException('Sipariş kaydı bulunamadı.');
+  }
+  if ($order['status'] === SITE_ORDER_STATUS_COMPLETED && $order['event_id']) {
+    $result = site_finalize_order($order['id']);
+    $_SESSION['lead_success'] = 'Ödemeniz alınmış, etkinliğiniz oluşturulmuş durumda.';
+    $_SESSION['order_summary'] = [
+      'event_title'    => $result['event']['title'],
+      'upload_url'     => $result['event']['upload_url'],
+      'qr_dynamic'     => $result['event']['qr_dynamic_url'],
+      'qr_image'       => $result['event']['qr_image_url'],
+      'login_url'      => $result['event']['login_url'],
+      'plain_password' => $result['event']['plain_password'],
+      'customer_email' => $result['customer']['email'],
+    ];
+    redirect('order_thanks.php');
+  }
+  $paytr = site_ensure_order_paytr_token($orderId);
+  $order = $paytr['order'];
+  $package = $paytr['package'];
+  $token = $paytr['token'];
+} catch (Throwable $e) {
+  flash('err', $e->getMessage());
+  redirect('index.php#lead-form');
+}
+
+$_SESSION['current_order_id'] = $order['id'];
+$_SESSION['current_order_oid'] = $paytr['merchant_oid'];
+
+?>
+<!doctype html><html lang="tr"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ödeme Adımı — <?=h(APP_NAME)?></title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:linear-gradient(180deg,#f3f7fb,#fff);font-family:'Inter',sans-serif;color:#0f172a;}
+  .checkout-card{border-radius:32px;background:#fff;box-shadow:0 24px 70px rgba(14,165,181,0.18);padding:48px;}
+  .summary-card{border-radius:24px;background:rgba(14,165,181,0.08);padding:24px;}
+  .step{display:flex;align-items:center;gap:12px;margin-bottom:12px;}
+  .step span{width:32px;height:32px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;background:#0ea5b5;color:#fff;}
+  .badge-soft{background:rgba(14,165,181,0.12);color:#0f766e;border-radius:999px;padding:6px 16px;font-weight:600;}
+  .price{font-size:1.8rem;font-weight:800;color:#0ea5b5;}
+  .iframe-wrapper{border-radius:24px;border:1px solid rgba(15,118,110,0.16);overflow:hidden;background:#f8fbfc;}
+  @media(max-width:768px){.checkout-card{padding:32px;}}
+</style>
+</head><body>
+<div class="container py-5">
+  <div class="checkout-card mx-auto" style="max-width:960px;">
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+      <div>
+        <div class="badge-soft mb-3">Ödeme Adımı</div>
+        <h1 class="fw-bold mb-2">Siparişinizi Güvenle Tamamlayın</h1>
+        <p class="text-muted mb-0">Ödemenizi tamamladıktan sonra etkinlik paneliniz otomatik olarak oluşturulacak ve giriş bilgileri e-posta adresinize gönderilecek.</p>
+      </div>
+      <div class="text-lg-end">
+        <div class="price mb-1"><?=h(format_currency((int)$order['price_cents']))?></div>
+        <div class="text-muted small">Paket: <?=h($package['name'])?></div>
+      </div>
+    </div>
+
+    <?php flash_box(); ?>
+
+    <div class="row g-4 align-items-start">
+      <div class="col-lg-7">
+        <div class="iframe-wrapper p-3">
+          <?php if ($token): ?>
+            <script src="https://www.paytr.com/js/iframeResizer.min.js"></script>
+            <iframe src="https://www.paytr.com/odeme/guvenli/<?=h($token)?>" id="paytriframe" frameborder="0" scrolling="no" style="width:100%;min-height:620px;"></iframe>
+            <script>iFrameResize({}, '#paytriframe');</script>
+          <?php else: ?>
+            <div class="alert alert-danger mb-0">Ödeme başlatılırken bir sorun oluştu. Lütfen tekrar deneyin.</div>
+          <?php endif; ?>
+        </div>
+      </div>
+      <div class="col-lg-5">
+        <div class="summary-card mb-4">
+          <h5 class="fw-semibold mb-3">Sipariş Özeti</h5>
+          <ul class="list-unstyled small text-muted mb-0">
+            <li class="mb-2"><strong>Paket:</strong> <?=h($package['name'])?></li>
+            <li class="mb-2"><strong>Ad Soyad:</strong> <?=h($order['customer_name'])?></li>
+            <li class="mb-2"><strong>E-posta:</strong> <?=h($order['customer_email'])?></li>
+            <?php if (!empty($order['customer_phone'])): ?>
+              <li class="mb-2"><strong>Telefon:</strong> <?=h($order['customer_phone'])?></li>
+            <?php endif; ?>
+            <li class="mb-2"><strong>Etkinlik:</strong> <?=h($order['event_title'])?></li>
+            <?php if (!empty($order['event_date'])): ?>
+              <li><strong>Tarih:</strong> <?=h(date('d.m.Y', strtotime($order['event_date'])))?></li>
+            <?php endif; ?>
+          </ul>
+        </div>
+        <div>
+          <h6 class="fw-semibold mb-3">Sonraki Adımlar</h6>
+          <div class="step"><span>1</span><div><strong>Ödeme</strong><br><small class="text-muted">Kart bilgileriniz PayTR güvenli altyapısı ile alınır.</small></div></div>
+          <div class="step"><span>2</span><div><strong>Otomatik Kurulum</strong><br><small class="text-muted">Ödeme onaylanır onaylanmaz etkinlik paneliniz oluşturulur.</small></div></div>
+          <div class="step"><span>3</span><div><strong>E-posta Bilgilendirmesi</strong><br><small class="text-muted">QR kodunuz ve giriş bilgileriniz e-postanıza ve varsa bayinize gönderilir.</small></div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body></html>

--- a/order_paytr.php
+++ b/order_paytr.php
@@ -27,7 +27,6 @@ try {
     $_SESSION['order_summary'] = [
       'event_title'    => $result['event']['title'],
       'upload_url'     => $result['event']['upload_url'],
-      'qr_dynamic'     => $result['event']['qr_dynamic_url'],
       'qr_image'       => $result['event']['qr_image_url'],
       'login_url'      => $result['event']['login_url'],
       'plain_password' => $result['event']['plain_password'],
@@ -45,7 +44,6 @@ try {
     $_SESSION['order_summary'] = [
       'event_title'    => $result['event']['title'],
       'upload_url'     => $result['event']['upload_url'],
-      'qr_dynamic'     => $result['event']['qr_dynamic_url'],
       'qr_image'       => $result['event']['qr_image_url'],
       'login_url'      => $result['event']['login_url'],
       'plain_password' => $result['event']['plain_password'],

--- a/order_paytr_fail.php
+++ b/order_paytr_fail.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/includes/functions.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+  session_start();
+}
+
+$orderId = isset($_SESSION['current_order_id']) ? (int)$_SESSION['current_order_id'] : 0;
+flash('err', 'Ödeme işlemi iptal edildi veya başarısız oldu. Dilerseniz yeniden deneyebilirsiniz.');
+
+if ($orderId > 0) {
+  redirect('order_paytr.php?order_id='.$orderId);
+}
+
+redirect('index.php#lead-form');

--- a/order_paytr_ok.php
+++ b/order_paytr_ok.php
@@ -26,7 +26,6 @@ try {
   $_SESSION['order_summary'] = [
     'event_title'    => $result['event']['title'],
     'upload_url'     => $result['event']['upload_url'],
-    'qr_dynamic'     => $result['event']['qr_dynamic_url'],
     'qr_image'       => $result['event']['qr_image_url'],
     'login_url'      => $result['event']['login_url'],
     'plain_password' => $result['event']['plain_password'],

--- a/order_paytr_ok.php
+++ b/order_paytr_ok.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/includes/db.php';
+require_once __DIR__.'/includes/functions.php';
+require_once __DIR__.'/includes/site.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+  session_start();
+}
+
+install_schema();
+
+$merchantOid = $_GET['merchant_oid'] ?? ($_SESSION['current_order_oid'] ?? null);
+if (!$merchantOid) {
+  flash('err', 'Ödeme işlemi doğrulanamadı.');
+  redirect('index.php#lead-form');
+}
+
+try {
+  $order = site_get_order_by_oid($merchantOid);
+  if (!$order) {
+    throw new RuntimeException('Sipariş kaydı bulunamadı.');
+  }
+  $result = site_finalize_order($order['id']);
+  $_SESSION['lead_success'] = 'Ödemeniz başarıyla alındı! Giriş bilgileri '.h($result['customer']['email']).' adresine gönderildi.';
+  $_SESSION['order_summary'] = [
+    'event_title'    => $result['event']['title'],
+    'upload_url'     => $result['event']['upload_url'],
+    'qr_dynamic'     => $result['event']['qr_dynamic_url'],
+    'qr_image'       => $result['event']['qr_image_url'],
+    'login_url'      => $result['event']['login_url'],
+    'plain_password' => $result['event']['plain_password'],
+    'customer_email' => $result['customer']['email'],
+  ];
+  $_SESSION['current_order_id'] = $result['order']['id'];
+  $_SESSION['current_order_oid'] = $merchantOid;
+} catch (Throwable $e) {
+  flash('err', $e->getMessage());
+  redirect('index.php#lead-form');
+}
+
+redirect('order_thanks.php');

--- a/order_thanks.php
+++ b/order_thanks.php
@@ -35,13 +35,24 @@ unset($_SESSION['lead_success'], $_SESSION['order_summary']);
         <h5 class="fw-semibold">Etkinlik Bilgileriniz</h5>
         <ul class="list-unstyled small text-muted mb-3">
           <li><strong>Etkinlik:</strong> <?=h($summary['event_title'])?></li>
-          <li><strong>Misafir bağlantısı:</strong><br><a href="<?=h($summary['upload_url'])?>" target="_blank"><?=h($summary['upload_url'])?></a></li>
+          <li><strong>Misafir bağlantısı:</strong><br><a href="<?=h($summary['upload_url'])?>" target="_blank" rel="noopener"><?=h($summary['upload_url'])?></a></li>
           <?php if (!empty($summary['qr_dynamic'])): ?>
-            <li class="mt-2"><strong>Kalıcı QR adresi:</strong><br><a href="<?=h($summary['qr_dynamic'])?>" target="_blank"><?=h($summary['qr_dynamic'])?></a></li>
+            <li class="mt-2"><strong>Kalıcı QR adresi:</strong><br><a href="<?=h($summary['qr_dynamic'])?>" target="_blank" rel="noopener"><?=h($summary['qr_dynamic'])?></a></li>
+          <?php endif; ?>
+          <?php if (!empty($summary['login_url'])): ?>
+            <li class="mt-2"><strong>Çift paneli:</strong><br><a href="<?=h($summary['login_url'])?>" target="_blank" rel="noopener"><?=h($summary['login_url'])?></a></li>
+          <?php endif; ?>
+          <?php if (!empty($summary['plain_password'])): ?>
+            <li class="mt-2"><strong>Geçici şifre:</strong> <?=h($summary['plain_password'])?> <span class="badge bg-warning-subtle text-warning-emphasis ms-2">İlk girişte değiştirin</span></li>
           <?php endif; ?>
         </ul>
-        <a class="btn btn-outline-info" href="<?=h($summary['upload_url'])?>" target="_blank">Misafir Sayfasını Aç</a>
-        <a class="btn btn-link" href="index.php">Anasayfaya Dön</a>
+        <div class="d-flex flex-wrap gap-2">
+          <a class="btn btn-outline-info" href="<?=h($summary['upload_url'])?>" target="_blank" rel="noopener">Misafir Sayfasını Aç</a>
+          <?php if (!empty($summary['login_url'])): ?>
+            <a class="btn btn-outline-primary" href="<?=h($summary['login_url'])?>" target="_blank" rel="noopener">Panelde Oturum Aç</a>
+          <?php endif; ?>
+          <a class="btn btn-link" href="index.php">Anasayfaya Dön</a>
+        </div>
       </div>
       <div class="col-md-6 text-center qr-preview">
         <p class="text-muted small">QR kodu yazdırmak için görsele sağ tıklayıp kaydedebilirsiniz.</p>

--- a/order_thanks.php
+++ b/order_thanks.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/includes/functions.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+  session_start();
+}
+
+$success = $_SESSION['lead_success'] ?? null;
+$summary = $_SESSION['order_summary'] ?? null;
+if (!$success || !$summary) {
+  redirect('index.php');
+}
+unset($_SESSION['lead_success'], $_SESSION['order_summary']);
+?>
+<!doctype html><html lang="tr"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Siparişiniz Alındı — <?=h(APP_NAME)?></title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  body{background:linear-gradient(180deg,#f5fbfd,#fff);font-family:'Inter',sans-serif;color:#0f172a;}
+  .card{border-radius:24px;border:none;box-shadow:0 24px 70px rgba(14,165,181,0.18);padding:40px;}
+  .qr-preview img{max-width:220px;border-radius:18px;box-shadow:0 12px 40px rgba(15,118,110,0.25);}
+</style>
+</head><body>
+<div class="container py-5">
+  <div class="card mx-auto" style="max-width:720px;">
+    <div class="text-center mb-4">
+      <div class="badge bg-success-subtle text-success-emphasis rounded-pill px-3 py-2">Teşekkürler</div>
+      <h1 class="fw-bold mt-3">Talebiniz Başarıyla Alındı</h1>
+      <p class="text-muted mb-0"><?=h($success)?></p>
+    </div>
+    <div class="row g-4 align-items-center">
+      <div class="col-md-6">
+        <h5 class="fw-semibold">Etkinlik Bilgileriniz</h5>
+        <ul class="list-unstyled small text-muted mb-3">
+          <li><strong>Etkinlik:</strong> <?=h($summary['event_title'])?></li>
+          <li><strong>Misafir bağlantısı:</strong><br><a href="<?=h($summary['upload_url'])?>" target="_blank"><?=h($summary['upload_url'])?></a></li>
+          <?php if (!empty($summary['qr_dynamic'])): ?>
+            <li class="mt-2"><strong>Kalıcı QR adresi:</strong><br><a href="<?=h($summary['qr_dynamic'])?>" target="_blank"><?=h($summary['qr_dynamic'])?></a></li>
+          <?php endif; ?>
+        </ul>
+        <a class="btn btn-outline-info" href="<?=h($summary['upload_url'])?>" target="_blank">Misafir Sayfasını Aç</a>
+        <a class="btn btn-link" href="index.php">Anasayfaya Dön</a>
+      </div>
+      <div class="col-md-6 text-center qr-preview">
+        <p class="text-muted small">QR kodu yazdırmak için görsele sağ tıklayıp kaydedebilirsiniz.</p>
+        <img src="<?=h($summary['qr_image'])?>" alt="QR Önizleme">
+      </div>
+    </div>
+  </div>
+</div>
+</body></html>

--- a/order_thanks.php
+++ b/order_thanks.php
@@ -36,9 +36,6 @@ unset($_SESSION['lead_success'], $_SESSION['order_summary']);
         <ul class="list-unstyled small text-muted mb-3">
           <li><strong>Etkinlik:</strong> <?=h($summary['event_title'])?></li>
           <li><strong>Misafir bağlantısı:</strong><br><a href="<?=h($summary['upload_url'])?>" target="_blank" rel="noopener"><?=h($summary['upload_url'])?></a></li>
-          <?php if (!empty($summary['qr_dynamic'])): ?>
-            <li class="mt-2"><strong>Kalıcı QR adresi:</strong><br><a href="<?=h($summary['qr_dynamic'])?>" target="_blank" rel="noopener"><?=h($summary['qr_dynamic'])?></a></li>
-          <?php endif; ?>
           <?php if (!empty($summary['login_url'])): ?>
             <li class="mt-2"><strong>Çift paneli:</strong><br><a href="<?=h($summary['login_url'])?>" target="_blank" rel="noopener"><?=h($summary['login_url'])?></a></li>
           <?php endif; ?>

--- a/public/guest_login.php
+++ b/public/guest_login.php
@@ -92,89 +92,121 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <html lang="tr">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Misafir Girişi — <?=h(APP_NAME)?></title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
-    body{background:#f1f5f9;font-family:'Inter',sans-serif;color:#0f172a;}
-    .card{border:none;border-radius:24px;box-shadow:0 28px 70px rgba(14,165,181,0.18);}
-    .brand-badge{display:inline-flex;align-items:center;gap:8px;padding:8px 14px;border-radius:999px;background:rgba(14,165,181,0.12);color:#0ea5b5;font-weight:600;font-size:0.9rem;}
-    .btn-brand{background:#0ea5b5;color:#fff;border:none;border-radius:14px;padding:12px 24px;font-weight:600;}
-    .btn-brand:hover{background:#0c8d9a;color:#fff;}
-    .event-option{border:1px solid rgba(148,163,184,0.2);border-radius:18px;padding:18px 20px;transition:transform .2s ease,box-shadow .2s ease;}
-    .event-option:hover{transform:translateY(-2px);box-shadow:0 18px 45px rgba(148,163,184,0.25);}
+    :root{ --brand:#0ea5b5; --brand-dark:#0b8b98; --ink:#0f172a; --muted:#526070; }
+    *{box-sizing:border-box;}
+    body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:2.5rem;background:linear-gradient(135deg,rgba(14,165,181,.12),rgba(148,163,184,.08));font-family:'Inter','Segoe UI',system-ui,-apple-system,sans-serif;color:var(--ink);}
+    .auth-shell{width:100%;max-width:1080px;background:#fff;border-radius:30px;box-shadow:0 40px 120px -55px rgba(15,23,42,.5);display:flex;overflow:hidden;border:1px solid rgba(148,163,184,.18);}
+    .auth-visual{flex:1.05;position:relative;padding:3.1rem;background:linear-gradient(150deg,rgba(14,165,181,.88),rgba(99,102,241,.7)),url('https://images.unsplash.com/photo-1519744346363-69e9faebabd1?auto=format&fit=crop&w=1200&q=80') center/cover;color:#fff;display:flex;flex-direction:column;justify-content:space-between;}
+    .auth-visual::after{content:"";position:absolute;inset:0;background:linear-gradient(160deg,rgba(15,23,42,.15),rgba(15,23,42,.45));}
+    .auth-visual > *{position:relative;z-index:1;}
+    .badge{display:inline-flex;align-items:center;gap:.6rem;padding:.45rem 1.2rem;border-radius:999px;background:rgba(255,255,255,.18);font-weight:600;letter-spacing:.08em;text-transform:uppercase;font-size:.78rem;}
+    .visual-title{font-size:2.2rem;font-weight:800;line-height:1.2;margin:1.6rem 0 1rem;max-width:440px;}
+    .visual-text{font-size:1.04rem;line-height:1.7;color:rgba(255,255,255,.9);max-width:440px;}
+    .feature-list{list-style:none;padding:0;margin:1.8rem 0 0;display:flex;flex-direction:column;gap:1rem;}
+    .feature-list li{display:flex;align-items:flex-start;gap:.75rem;font-weight:600;color:rgba(255,255,255,.92);}
+    .feature-list span{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:50%;background:rgba(255,255,255,.2);font-size:1rem;}
+    .visual-footer{font-size:.84rem;color:rgba(255,255,255,.78);max-width:360px;margin-top:2.7rem;}
+    .auth-form{flex:.95;padding:3rem 3.1rem;display:flex;flex-direction:column;justify-content:center;gap:1.8rem;}
+    .brand{font-weight:800;font-size:1.65rem;letter-spacing:.15rem;margin-bottom:.25rem;}
+    .brand span{display:block;font-size:.95rem;font-weight:600;color:var(--muted);margin-top:.35rem;letter-spacing:0;}
+    .form-note{color:var(--muted);font-size:.95rem;line-height:1.6;}
+    .form-control{border-radius:14px;border:1px solid rgba(148,163,184,.32);padding:.8rem 1rem;font-size:1rem;}
+    .form-control:focus{border-color:var(--brand);box-shadow:0 0 0 .25rem rgba(14,165,181,.18);}
+    .btn-brand{background:var(--brand);color:#fff;border:none;border-radius:14px;padding:.85rem 1rem;font-weight:700;font-size:1rem;transition:transform .2s ease,box-shadow .2s ease;background-image:linear-gradient(135deg,#0ea5b5,#0b8b98);}
+    .btn-brand:hover{transform:translateY(-1px);box-shadow:0 20px 36px -24px rgba(14,165,181,.65);color:#fff;}
+    .alert{border-radius:14px;font-weight:500;}
+    .option-grid{display:flex;flex-direction:column;gap:1rem;}
+    .option-card{border:1px solid rgba(148,163,184,.24);border-radius:18px;padding:1.25rem 1.4rem;display:flex;align-items:center;justify-content:space-between;gap:1rem;transition:transform .2s ease,box-shadow .2s ease;border-left:4px solid transparent;}
+    .option-card:hover{transform:translateY(-2px);box-shadow:0 22px 50px -30px rgba(15,23,42,.3);border-left-color:var(--brand);}
+    .option-card h3{margin:0;font-size:1.1rem;font-weight:700;color:var(--ink);}
+    .option-card time{display:block;font-size:.9rem;color:var(--muted);margin-top:.25rem;}
+    .option-card button{min-width:160px;}
+    .footer-links{display:flex;flex-wrap:wrap;gap:.75rem;font-weight:600;}
+    .footer-links a{color:var(--brand);text-decoration:none;}
+    .footer-links a:hover{text-decoration:underline;color:var(--brand-dark);}
+    .muted-tip{font-size:.85rem;color:var(--muted);}
+    @media(max-width:992px){body{padding:1.5rem;} .auth-shell{flex-direction:column;} .auth-visual{padding:2.6rem;} .auth-form{padding:2.4rem;}}
+    @media(max-width:576px){.auth-form{padding:2rem;} .visual-title{font-size:1.75rem;}}
   </style>
 </head>
 <body>
-  <div class="container py-5">
-    <div class="row justify-content-center">
-      <div class="col-lg-5 col-md-7">
-        <div class="text-center mb-4">
-          <a class="brand-badge text-decoration-none" href="<?=BASE_URL?>"><?=h(APP_NAME)?></a>
-        </div>
-        <div class="card p-4 p-lg-5 bg-white">
-          <?php if ($stage === 'form'): ?>
-            <div class="mb-4 text-center">
-              <h1 class="h3 fw-bold mb-2">Misafir girişi</h1>
-              <p class="text-muted mb-0">E-postanızı doğrulayıp şifrenizi belirledikten sonra bu panel üzerinden etkinliklerinize ulaşabilirsiniz.</p>
-            </div>
-            <?php flash_box(); ?>
-            <form method="post" class="d-flex flex-column gap-3">
-              <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-              <input type="hidden" name="action" value="login">
-              <div>
-                <label class="form-label fw-semibold">E-posta Adresi</label>
-                <input type="email" name="email" value="<?=h($emailPrefill)?>" class="form-control form-control-lg" placeholder="ornek@eposta.com" required>
-              </div>
-              <div>
-                <label class="form-label fw-semibold">Şifre</label>
-                <input type="password" name="password" class="form-control form-control-lg" placeholder="Şifrenizi yazın" required>
-              </div>
-              <button type="submit" class="btn btn-brand mt-2">Giriş Yap</button>
-            </form>
-            <div class="mt-4 text-center small text-muted">
-              Henüz şifrenizi oluşturmadıysanız doğrulama e-postasındaki bağlantıyı kullanarak şifre belirleyebilirsiniz.
-            </div>
-          <?php else: ?>
-            <div class="mb-4 text-center">
-              <h1 class="h4 fw-bold mb-2">Etkinlik seçin</h1>
-              <p class="text-muted mb-3">Bu e-posta adresiyle birden fazla etkinliğe davetlisiniz. Girmek istediğiniz etkinliği seçin.</p>
-            </div>
-            <?php flash_box(); ?>
-            <div class="d-flex flex-column gap-3">
-              <?php foreach ($choices as $profileId => $event): ?>
-                <?php
-                  $eventDateLabel = null;
-                  if (!empty($event['event_date'])) {
-                    $ts = strtotime($event['event_date']);
-                    if ($ts) {
-                      $eventDateLabel = date('d.m.Y', $ts);
-                    }
-                  }
-                ?>
-                <form method="post" class="event-option">
-                  <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-                  <input type="hidden" name="action" value="choose">
-                  <input type="hidden" name="profile_id" value="<?=intval($profileId)?>">
-                  <div class="d-flex justify-content-between align-items-center gap-3">
-                    <div>
-                      <div class="fw-semibold"><?=h($event['event_title'] ?? 'Etkinlik')?> </div>
-                      <?php if ($eventDateLabel): ?>
-                        <div class="small text-muted"><?=h($eventDateLabel)?></div>
-                      <?php endif; ?>
-                    </div>
-                    <button type="submit" class="btn btn-brand">Paneli Aç</button>
-                  </div>
-                </form>
-              <?php endforeach; ?>
-            </div>
-            <div class="mt-4 text-center">
-              <a href="<?=BASE_URL?>/public/guest_login.php?reset=1" class="text-decoration-none" style="color:#0ea5b5;">Farklı bir hesapla giriş yap</a>
-            </div>
-          <?php endif; ?>
-        </div>
+  <div class="auth-shell">
+    <aside class="auth-visual">
+      <div>
+        <span class="badge">Misafir Paneli</span>
+        <h1 class="visual-title">Etkinliğe ait fotoğraf ve videolar burada buluşuyor.</h1>
+        <p class="visual-text">BİKARE misafir paneli, etkinlik sahipleriyle anılarınızı kolayca paylaşmanızı, diğer davetlilerle sohbet etmenizi ve özel içeriklere erişmenizi sağlar.</p>
+        <ul class="feature-list">
+          <li><span>✓</span>Fotoğraf ve videoları yüksek çözünürlükte yükleyin</li>
+          <li><span>✓</span>Sevdiklerinizle sohbet edin, yorum yapın, beğeni bırakın</li>
+          <li><span>✓</span>Etkinlik programını ve önemli duyuruları kaçırmayın</li>
+        </ul>
       </div>
-    </div>
+      <p class="visual-footer">Misafir deneyimi Zerosoft güvencesiyle geliştirilen BİKARE ekibi tarafından desteklenmektedir.</p>
+    </aside>
+    <section class="auth-form">
+      <div>
+        <div class="brand">BİKARE <span>Misafir Girişi</span></div>
+        <p class="form-note">E-posta adresinizi doğruladıktan sonra belirlediğiniz şifre ile etkinlik paneline ulaşabilirsiniz.</p>
+      </div>
+      <?php if ($stage === 'form'): ?>
+        <?php flash_box(); ?>
+        <form method="post" class="d-flex flex-column gap-3">
+          <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+          <input type="hidden" name="action" value="login">
+          <div>
+            <label class="form-label fw-semibold">E-posta Adresi</label>
+            <input type="email" name="email" value="<?=h($emailPrefill)?>" class="form-control" placeholder="ornek@eposta.com" required>
+          </div>
+          <div>
+            <label class="form-label fw-semibold">Şifre</label>
+            <input type="password" name="password" class="form-control" placeholder="Şifrenizi yazın" required>
+          </div>
+          <button type="submit" class="btn btn-brand mt-2">Misafir Paneline Gir</button>
+        </form>
+        <div class="muted-tip">Doğrulama bağlantısındaki şifre oluşturma adımını tamamladıktan sonra panel erişiminiz aktifleşir.</div>
+      <?php else: ?>
+        <?php flash_box(); ?>
+        <div class="option-grid">
+          <?php foreach ($choices as $profileId => $event): ?>
+            <?php
+              $eventDateLabel = null;
+              if (!empty($event['event_date'])) {
+                $ts = strtotime($event['event_date']);
+                if ($ts) {
+                  $eventDateLabel = date('d.m.Y', $ts);
+                }
+              }
+            ?>
+            <form method="post" class="option-card">
+              <div>
+                <h3><?=h($event['event_title'] ?? 'Etkinlik')?></h3>
+                <?php if ($eventDateLabel): ?>
+                  <time><?=h($eventDateLabel)?></time>
+                <?php endif; ?>
+              </div>
+              <div>
+                <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+                <input type="hidden" name="action" value="choose">
+                <input type="hidden" name="profile_id" value="<?=intval($profileId)?>">
+                <button type="submit" class="btn btn-brand">Paneli Aç</button>
+              </div>
+            </form>
+          <?php endforeach; ?>
+        </div>
+        <div class="muted-tip">Farklı bir e-posta adresiyle giriş yapmak isterseniz aşağıdaki bağlantıyı kullanabilirsiniz.</div>
+      <?php endif; ?>
+      <div class="footer-links">
+        <a href="<?=BASE_URL?>">← Anasayfaya dön</a>
+        <?php if ($stage !== 'form'): ?>
+          <a href="<?=BASE_URL?>/public/guest_login.php?reset=1">Farklı hesapla giriş yap</a>
+        <?php endif; ?>
+      </div>
+    </section>
   </div>
 </body>
 </html>

--- a/public/guest_login.php
+++ b/public/guest_login.php
@@ -1,0 +1,180 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/guests.php';
+
+install_schema();
+
+if (isset($_GET['reset'])) {
+  unset($_SESSION['guest_login_choices'], $_SESSION['guest_login_stage']);
+  header('Location: '.BASE_URL.'/public/guest_login.php');
+  exit;
+}
+
+$emailPrefill = guest_profile_normalize_email($_GET['email'] ?? '');
+$stage = $_SESSION['guest_login_stage'] ?? 'form';
+$choices = $_SESSION['guest_login_choices'] ?? [];
+if ($stage !== 'choose' || !$choices) {
+  $stage = 'form';
+  $choices = [];
+  unset($_SESSION['guest_login_stage'], $_SESSION['guest_login_choices']);
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  csrf_or_die();
+  $action = $_POST['action'] ?? 'login';
+  if ($action === 'login') {
+    $email = guest_profile_normalize_email($_POST['email'] ?? '');
+    $password = trim($_POST['password'] ?? '');
+    $emailPrefill = $email;
+    if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+      flash('err', 'Geçerli bir e-posta adresi yazın.');
+      header('Location: '.BASE_URL.'/public/guest_login.php?email='.rawurlencode($email));
+      exit;
+    }
+    if ($password === '') {
+      flash('err', 'Şifrenizi yazın.');
+      header('Location: '.BASE_URL.'/public/guest_login.php?email='.rawurlencode($email));
+      exit;
+    }
+    $matches = guest_profile_authenticate($email, $password);
+    if (!$matches) {
+      flash('err', 'E-posta veya şifre hatalı ya da henüz doğrulama tamamlanmadı.');
+      header('Location: '.BASE_URL.'/public/guest_login.php?email='.rawurlencode($email));
+      exit;
+    }
+    if (count($matches) === 1) {
+      $match = $matches[0];
+      $profileId = (int)$match['profile']['id'];
+      $eventId = (int)$match['event']['id'];
+      guest_profile_set_session($eventId, $profileId);
+      guest_profile_record_login($profileId);
+      guest_profile_touch($profileId);
+      flash('ok', 'Misafir paneline giriş yapıldı.');
+      header('Location: '.public_upload_url($eventId));
+      exit;
+    }
+    $store = [];
+    foreach ($matches as $match) {
+      $profileId = (int)$match['profile']['id'];
+      $store[$profileId] = [
+        'event_id' => (int)$match['event']['id'],
+        'event_title' => $match['event']['title'],
+        'event_date' => $match['event']['event_date'],
+      ];
+    }
+    $_SESSION['guest_login_choices'] = $store;
+    $_SESSION['guest_login_stage'] = 'choose';
+    header('Location: '.BASE_URL.'/public/guest_login.php');
+    exit;
+  }
+  if ($action === 'choose') {
+    $choices = $_SESSION['guest_login_choices'] ?? [];
+    $profileId = (int)($_POST['profile_id'] ?? 0);
+    if (!$choices || !isset($choices[$profileId])) {
+      flash('err', 'Seçim geçersiz veya süresi doldu. Lütfen tekrar giriş yapın.');
+      header('Location: '.BASE_URL.'/public/guest_login.php');
+      exit;
+    }
+    $eventId = (int)$choices[$profileId]['event_id'];
+    unset($_SESSION['guest_login_choices'], $_SESSION['guest_login_stage']);
+    guest_profile_set_session($eventId, $profileId);
+    guest_profile_record_login($profileId);
+    guest_profile_touch($profileId);
+    flash('ok', 'Misafir paneline giriş yapıldı.');
+    header('Location: '.public_upload_url($eventId));
+    exit;
+  }
+}
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Misafir Girişi — <?=h(APP_NAME)?></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body{background:#f1f5f9;font-family:'Inter',sans-serif;color:#0f172a;}
+    .card{border:none;border-radius:24px;box-shadow:0 28px 70px rgba(14,165,181,0.18);}
+    .brand-badge{display:inline-flex;align-items:center;gap:8px;padding:8px 14px;border-radius:999px;background:rgba(14,165,181,0.12);color:#0ea5b5;font-weight:600;font-size:0.9rem;}
+    .btn-brand{background:#0ea5b5;color:#fff;border:none;border-radius:14px;padding:12px 24px;font-weight:600;}
+    .btn-brand:hover{background:#0c8d9a;color:#fff;}
+    .event-option{border:1px solid rgba(148,163,184,0.2);border-radius:18px;padding:18px 20px;transition:transform .2s ease,box-shadow .2s ease;}
+    .event-option:hover{transform:translateY(-2px);box-shadow:0 18px 45px rgba(148,163,184,0.25);}
+  </style>
+</head>
+<body>
+  <div class="container py-5">
+    <div class="row justify-content-center">
+      <div class="col-lg-5 col-md-7">
+        <div class="text-center mb-4">
+          <a class="brand-badge text-decoration-none" href="<?=BASE_URL?>"><?=h(APP_NAME)?></a>
+        </div>
+        <div class="card p-4 p-lg-5 bg-white">
+          <?php if ($stage === 'form'): ?>
+            <div class="mb-4 text-center">
+              <h1 class="h3 fw-bold mb-2">Misafir girişi</h1>
+              <p class="text-muted mb-0">E-postanızı doğrulayıp şifrenizi belirledikten sonra bu panel üzerinden etkinliklerinize ulaşabilirsiniz.</p>
+            </div>
+            <?php flash_box(); ?>
+            <form method="post" class="d-flex flex-column gap-3">
+              <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+              <input type="hidden" name="action" value="login">
+              <div>
+                <label class="form-label fw-semibold">E-posta Adresi</label>
+                <input type="email" name="email" value="<?=h($emailPrefill)?>" class="form-control form-control-lg" placeholder="ornek@eposta.com" required>
+              </div>
+              <div>
+                <label class="form-label fw-semibold">Şifre</label>
+                <input type="password" name="password" class="form-control form-control-lg" placeholder="Şifrenizi yazın" required>
+              </div>
+              <button type="submit" class="btn btn-brand mt-2">Giriş Yap</button>
+            </form>
+            <div class="mt-4 text-center small text-muted">
+              Henüz şifrenizi oluşturmadıysanız doğrulama e-postasındaki bağlantıyı kullanarak şifre belirleyebilirsiniz.
+            </div>
+          <?php else: ?>
+            <div class="mb-4 text-center">
+              <h1 class="h4 fw-bold mb-2">Etkinlik seçin</h1>
+              <p class="text-muted mb-3">Bu e-posta adresiyle birden fazla etkinliğe davetlisiniz. Girmek istediğiniz etkinliği seçin.</p>
+            </div>
+            <?php flash_box(); ?>
+            <div class="d-flex flex-column gap-3">
+              <?php foreach ($choices as $profileId => $event): ?>
+                <?php
+                  $eventDateLabel = null;
+                  if (!empty($event['event_date'])) {
+                    $ts = strtotime($event['event_date']);
+                    if ($ts) {
+                      $eventDateLabel = date('d.m.Y', $ts);
+                    }
+                  }
+                ?>
+                <form method="post" class="event-option">
+                  <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+                  <input type="hidden" name="action" value="choose">
+                  <input type="hidden" name="profile_id" value="<?=intval($profileId)?>">
+                  <div class="d-flex justify-content-between align-items-center gap-3">
+                    <div>
+                      <div class="fw-semibold"><?=h($event['event_title'] ?? 'Etkinlik')?> </div>
+                      <?php if ($eventDateLabel): ?>
+                        <div class="small text-muted"><?=h($eventDateLabel)?></div>
+                      <?php endif; ?>
+                    </div>
+                    <button type="submit" class="btn btn-brand">Paneli Aç</button>
+                  </div>
+                </form>
+              <?php endforeach; ?>
+            </div>
+            <div class="mt-4 text-center">
+              <a href="<?=BASE_URL?>/public/guest_login.php?reset=1" class="text-decoration-none" style="color:#0ea5b5;">Farklı bir hesapla giriş yap</a>
+            </div>
+          <?php endif; ?>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/public/guest_password.php
+++ b/public/guest_password.php
@@ -1,0 +1,104 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/guests.php';
+
+install_schema();
+
+$token = trim($_POST['token'] ?? ($_GET['token'] ?? ''));
+if ($token === '') {
+  flash('err', 'Şifre belirleme bağlantısı geçersiz.');
+  header('Location: '.BASE_URL);
+  exit;
+}
+
+$profile = guest_profile_find_by_password_token($token);
+if (!$profile) {
+  flash('err', 'Bu bağlantının süresi dolmuş olabilir. Lütfen e-postanızı doğrulayarak yeni bir bağlantı isteyin.');
+  header('Location: '.BASE_URL.'/public/guest_login.php');
+  exit;
+}
+
+$eventStmt = pdo()->prepare('SELECT title FROM events WHERE id=? LIMIT 1');
+$eventStmt->execute([(int)$profile['event_id']]);
+$eventTitle = $eventStmt->fetchColumn() ?: 'Etkinliğiniz';
+
+$errors = [];
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  csrf_or_die();
+  $password = trim($_POST['password'] ?? '');
+  $confirm  = trim($_POST['password_confirm'] ?? '');
+  if (mb_strlen($password, 'UTF-8') < 8) {
+    $errors[] = 'Şifreniz en az 8 karakter olmalıdır.';
+  }
+  if ($password !== $confirm) {
+    $errors[] = 'Şifre ve şifre tekrarı eşleşmiyor.';
+  }
+  if (!$errors) {
+    guest_profile_set_password((int)$profile['id'], $password);
+    guest_profile_set_session((int)$profile['event_id'], (int)$profile['id']);
+    guest_profile_record_login((int)$profile['id']);
+    guest_profile_touch((int)$profile['id']);
+    flash('ok', 'Şifreniz başarıyla kaydedildi. Keyifli paylaşımlar!');
+    header('Location: '.public_upload_url((int)$profile['event_id']));
+    exit;
+  }
+}
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Şifrenizi Belirleyin — <?=h(APP_NAME)?></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body{background:#f1f5f9;font-family:'Inter',sans-serif;color:#0f172a;}
+    .card{border:none;border-radius:24px;box-shadow:0 28px 70px rgba(14,165,181,0.18);}
+    .brand-badge{display:inline-flex;align-items:center;gap:8px;padding:8px 14px;border-radius:999px;background:rgba(14,165,181,0.12);color:#0ea5b5;font-weight:600;font-size:0.9rem;}
+    .btn-brand{background:#0ea5b5;color:#fff;border:none;border-radius:14px;padding:12px 24px;font-weight:600;}
+    .btn-brand:hover{background:#0c8d9a;color:#fff;}
+  </style>
+</head>
+<body>
+  <div class="container py-5">
+    <div class="row justify-content-center">
+      <div class="col-lg-5 col-md-7">
+        <div class="text-center mb-4">
+          <a class="brand-badge text-decoration-none" href="<?=BASE_URL?>"><?=h(APP_NAME)?></a>
+        </div>
+        <div class="card p-4 p-lg-5 bg-white">
+          <div class="mb-4 text-center">
+            <h1 class="h3 fw-bold mb-2">Şifrenizi belirleyin</h1>
+            <p class="text-muted mb-0"><?=h($eventTitle)?> etkinliğinin misafir paneline güvenle giriş yapmak için yeni şifrenizi oluşturun.</p>
+          </div>
+          <?php if ($errors): ?>
+            <div class="alert alert-danger">
+              <?=implode('<br>', array_map('h', $errors))?>
+            </div>
+          <?php endif; ?>
+          <?php flash_box(); ?>
+          <form method="post" class="d-flex flex-column gap-3">
+            <input type="hidden" name="token" value="<?=h($token)?>">
+            <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+            <div>
+              <label class="form-label fw-semibold">Yeni Şifre</label>
+              <input type="password" name="password" class="form-control form-control-lg" placeholder="En az 8 karakter" required>
+            </div>
+            <div>
+              <label class="form-label fw-semibold">Şifre Tekrarı</label>
+              <input type="password" name="password_confirm" class="form-control form-control-lg" placeholder="Şifrenizi tekrar yazın" required>
+            </div>
+            <div class="small text-muted">Bu şifre ile doğrulama gerekmeksizin panelinize tekrar giriş yapabilirsiniz.</div>
+            <button type="submit" class="btn btn-brand mt-2">Şifremi Kaydet</button>
+          </form>
+          <div class="mt-4 text-center small text-muted">
+            Bağlantı süresi dolduysa <a href="<?=BASE_URL?>/public/upload.php?event=<?=intval($profile['event_id'])?>" class="text-decoration-none" style="color:#0ea5b5;">misafir sayfasından</a> e-posta doğrulamasını tekrar talep edebilirsiniz.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/public/guest_verify.php
+++ b/public/guest_verify.php
@@ -4,6 +4,8 @@ require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/guests.php';
 
+install_schema();
+
 $token = trim($_GET['token'] ?? '');
 if ($token === '') {
   flash('err','Doğrulama bağlantısı geçersiz.');
@@ -11,14 +13,36 @@ if ($token === '') {
   exit;
 }
 
-$profile = guest_profile_verify_token($token);
-if (!$profile) {
+$result = guest_profile_verify_token($token);
+if (!$result || empty($result['profile'])) {
   flash('err','Doğrulama bağlantısı geçersiz veya süresi dolmuş olabilir.');
   header('Location: '.BASE_URL);
   exit;
 }
 
-guest_profile_set_session((int)$profile['event_id'], (int)$profile['id']);
+$profile = $result['profile'];
+$eventId = (int)$profile['event_id'];
+$eventStmt = pdo()->prepare('SELECT id, title FROM events WHERE id=? LIMIT 1');
+$eventStmt->execute([$eventId]);
+$event = $eventStmt->fetch();
+if (!$event) {
+  $event = ['id' => $eventId, 'title' => 'Etkinliğiniz'];
+}
+
+$shouldSendPanelMail = ($result['just_verified'] ?? false) || empty($profile['password_hash']);
+if ($shouldSendPanelMail) {
+  guest_profile_send_panel_access($profile, $event);
+}
+
+guest_profile_set_session($eventId, (int)$profile['id']);
+$passwordToken = $result['password_token'] ?? ($profile['password_token'] ?? null);
+
+if ($passwordToken) {
+  flash('ok','E-posta adresiniz doğrulandı! Şifrenizi belirleyip misafir panelinize giriş yapabilirsiniz.');
+  header('Location: '.BASE_URL.'/public/guest_password.php?token='.rawurlencode($passwordToken));
+  exit;
+}
+
 flash('ok','E-posta adresiniz doğrulandı! Misafir alanına hoş geldiniz.');
-header('Location: '.public_upload_url((int)$profile['event_id']));
+header('Location: '.public_upload_url($eventId));
 exit;

--- a/public/guest_verify.php
+++ b/public/guest_verify.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__.'/../config.php';
+require_once __DIR__.'/../includes/db.php';
+require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/guests.php';
+
+$token = trim($_GET['token'] ?? '');
+if ($token === '') {
+  flash('err','Doğrulama bağlantısı geçersiz.');
+  header('Location: '.BASE_URL);
+  exit;
+}
+
+$profile = guest_profile_verify_token($token);
+if (!$profile) {
+  flash('err','Doğrulama bağlantısı geçersiz veya süresi dolmuş olabilir.');
+  header('Location: '.BASE_URL);
+  exit;
+}
+
+guest_profile_set_session((int)$profile['event_id'], (int)$profile['id']);
+flash('ok','E-posta adresiniz doğrulandı! Misafir alanına hoş geldiniz.');
+header('Location: '.public_upload_url((int)$profile['event_id']));
+exit;

--- a/public/upload.php
+++ b/public/upload.php
@@ -603,13 +603,13 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
 .dropzone.drag{ border-color:var(--zs); background:rgba(14,165,181,.08); }
 .form-text{ color:var(--muted); }
 .gallery-card{ padding:28px; }
-.gallery-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(240px,1fr)); gap:24px; }
-@media(min-width:768px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(260px,1fr)); } }
-@media(min-width:1400px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(300px,1fr)); } }
+.gallery-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(220px,1fr)); gap:24px; }
+@media(min-width:768px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(240px,1fr)); } }
+@media(min-width:1400px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(260px,1fr)); } }
 .gallery-item{ display:flex; flex-direction:column; border-radius:22px; overflow:hidden; background:#fff; border:1px solid rgba(148,163,184,.18); box-shadow:0 16px 32px rgba(15,23,42,.08); transition:transform .2s ease, box-shadow .2s ease; }
 .gallery-item:hover{ transform:translateY(-4px); box-shadow:0 20px 44px rgba(15,23,42,.12); }
-.gallery-media{ position:relative; width:100%; aspect-ratio:4/5; background:#020617; }
-.gallery-media img,.gallery-media video{ width:100%; height:100%; display:block; object-fit:cover; }
+.gallery-media{ position:relative; width:100%; background:#020617; display:flex; align-items:center; justify-content:center; padding:16px; min-height:160px; }
+.gallery-media img,.gallery-media video{ width:100%; height:auto; max-height:320px; display:block; object-fit:contain; border-radius:14px; box-shadow:0 6px 18px rgba(15,23,42,.22); }
 .gallery-header{ display:flex; align-items:center; gap:12px; padding:18px 20px 12px; }
 .avatar{ width:46px; height:46px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:700; letter-spacing:.5px; }
 .gallery-actions{ display:flex; align-items:center; justify-content:space-between; padding:12px 20px 4px; gap:12px; }

--- a/public/upload.php
+++ b/public/upload.php
@@ -1,13 +1,10 @@
 <?php
-// public/upload.php — Misafir yükleme + galeri + Çift panelle birebir 960x540 ölçekli önizleme
 require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
 require_once __DIR__.'/../includes/dealers.php';
+require_once __DIR__.'/../includes/guests.php';
 
-if (session_status() === PHP_SESSION_NONE) session_start();
-
-/* ---- CSRF (shim) ---- */
 if (!function_exists('csrf_token')) {
   function csrf_token(){ if(empty($_SESSION['csrf'])) $_SESSION['csrf']=bin2hex(random_bytes(16)); return $_SESSION['csrf']; }
 }
@@ -15,7 +12,6 @@ if (!function_exists('csrf_or_die')) {
   function csrf_or_die(){ $t=$_POST['csrf']??$_POST['_csrf']??''; if(!$t || !hash_equals($_SESSION['csrf']??'', $t)){ http_response_code(400); exit('CSRF'); } }
 }
 
-/* ---- Yardımcılar ---- */
 function client_ip(){
   if(isset($_SERVER['HTTP_CLIENT_IP'])) return $_SERVER['HTTP_CLIENT_IP'];
   if(isset($_SERVER['HTTP_X_FORWARDED_FOR'])) return explode(',', $_SERVER['HTTP_X_FORWARDED_FOR'])[0];
@@ -23,20 +19,40 @@ function client_ip(){
 }
 function is_image_mime($m){ return (bool)preg_match('~^image/(jpeg|png|webp|gif)$~i',$m); }
 function is_video_mime($m){ return (bool)preg_match('~^video/(mp4|quicktime|webm)$~i',$m); }
+function relative_time($dt){
+  if(!$dt) return '';
+  $ts = is_numeric($dt) ? (int)$dt : strtotime($dt);
+  if(!$ts) return '';
+  $diff = time() - $ts;
+  if($diff < 60) return 'az önce';
+  if($diff < 3600) return floor($diff/60).' dk önce';
+  if($diff < 86400) return floor($diff/3600).' sa önce';
+  if($diff < 172800) return 'dün';
+  return date('d.m.Y H:i', $ts);
+}
+function avatar_colors(string $seed): array {
+  $palette = ['#0ea5b5','#6366f1','#f97316','#ec4899','#14b8a6','#9333ea','#ef4444','#22d3ee'];
+  $text = ['#fff','#fff','#fff','#fff','#073042','#fff','#fff','#0f172a'];
+  $idx = hexdec(substr($seed,0,2)) % count($palette);
+  return [$palette[$idx], $text[$idx] ?? '#fff'];
+}
+function avatar_initial(string $name): string {
+  $name = trim($name);
+  if($name==='') return 'M';
+  return mb_strtoupper(mb_substr($name,0,1,'UTF-8'),'UTF-8');
+}
 
-/* ---- Parametreler ---- */
 $event_id = (int)($_GET['event'] ?? 0);
 $token    = trim($_GET['t'] ?? '');
 if ($event_id <= 0){ http_response_code(400); exit('Geçersiz istek'); }
 
-/* ---- Etkinlik satırı ---- */
 $st = pdo()->prepare("SELECT * FROM events WHERE id=? LIMIT 1");
 $st->execute([$event_id]);
 $ev = $st->fetch();
 if (!$ev || (int)$ev['is_active']!==1){ http_response_code(404); exit('Etkinlik bulunamadı veya pasif.'); }
 
 $VID      = (int)$ev['venue_id'];
-$TITLE    = $ev['guest_title'] ?: 'Düğünümüze Hoş Geldiniz';
+$TITLE    = $ev['guest_title'] ?: 'BİKARE Etkinliğimize Hoş Geldiniz';
 $SUBTITLE = $ev['guest_subtitle'] ?: 'En güzel anlarınızı bizimle paylaşın';
 $PROMPT   = $ev['guest_prompt'] ?: 'Adınızı yazıp anınızı yükleyin.';
 $PRIMARY  = $ev['theme_primary'] ?: '#0ea5b5';
@@ -44,7 +60,6 @@ $ACCENT   = $ev['theme_accent']  ?: '#e0f7fb';
 $CAN_VIEW = (int)$ev['allow_guest_view']===1;
 $CAN_DOWN = (int)$ev['allow_guest_download']===1;
 
-/* ---- Çift panelden gelen layout/sticker ---- */
 $layout   = $ev['layout_json'] ?: '{"title":{"x":24,"y":24},"subtitle":{"x":24,"y":60},"prompt":{"x":24,"y":396}}';
 $stickers = $ev['stickers_json'] ?: '[]';
 $layoutArr   = json_decode($layout,true);
@@ -57,221 +72,567 @@ $tPos = isset($layoutArr['title'])    ? $layoutArr['title']    : array('x'=>24,'
 $sPos = isset($layoutArr['subtitle']) ? $layoutArr['subtitle'] : array('x'=>24,'y'=>60);
 $pPos = isset($layoutArr['prompt'])   ? $layoutArr['prompt']   : array('x'=>24,'y'=>396);
 
-/* ---- Dinamik QR token doğrulama ---- */
 $token_ok = token_valid($event_id, $token);
+$guestProfile = guest_profile_current($event_id);
 
-/* ---- Yükleme ---- */
-$errors=[]; $okCount=0;
-if($_SERVER['REQUEST_METHOD']==='POST' && ($_POST['do']??'')==='upload'){
+if($_SERVER['REQUEST_METHOD']==='POST'){
   csrf_or_die();
-  $p_token = trim($_POST['t']??'');
-  if(!token_valid($event_id,$p_token)){
-    $errors[]='Güvenlik anahtarı zaman aşımına uğradı. Lütfen QR’ı yeniden okutun.';
-  }else{
-    $guest = trim($_POST['guest_name']??'');
-    if($guest===''){ $errors[]='Lütfen adınızı yazın.'; }
-    if(!isset($_FILES['files'])){ $errors[]='Dosya seçilmedi.'; }
-    else{
-      $f=$_FILES['files'];
-      $n=is_array($f['name'])?count($f['name']):0;
-      if($n<=0) $errors[]='Dosya seçilmedi.';
+  $action = $_POST['do'] ?? '';
+  $redirect = BASE_URL.'/public/upload.php?event='.$event_id.'&t='.rawurlencode($token);
+  if($action === 'upload'){
+    $errors=[]; $okCount=0; $verificationFlash=null;
+    $p_token = trim($_POST['t']??'');
+    if(!token_valid($event_id,$p_token)){
+      $errors[]='Güvenlik anahtarı zaman aşımına uğradı. Lütfen QR’ı yeniden okutun.';
+    }else{
+      $guest = trim($_POST['guest_name']??'');
+      $guestEmail = trim($_POST['guest_email']??'');
+      if($guest===''){ $errors[]='Lütfen adınızı yazın.'; }
+      if($guestEmail!==''){ if(!filter_var($guestEmail, FILTER_VALIDATE_EMAIL)){ $errors[]='Geçerli bir e-posta adresi yazın.'; } }
+      $marketingOpt = isset($_POST['marketing_opt_in']);
+      $profileForUpload = $guestProfile;
+      if($guestEmail!=='' && !$errors){
+        try {
+          $profileForUpload = guest_profile_upsert($event_id, $guest, $guestEmail, $marketingOpt);
+          if($profileForUpload){
+            if((int)$profileForUpload['is_verified']===1){
+              guest_profile_set_session($event_id, (int)$profileForUpload['id']);
+              $guestProfile = $profileForUpload;
+            }else{
+              $lastSent = $profileForUpload['last_verification_sent_at'] ?? null;
+              if(!$lastSent || strtotime($lastSent) < time()-600){
+                guest_profile_send_verification($profileForUpload, $ev);
+                $verificationFlash = 'Profilinizi doğrulayabilmeniz için e-posta gönderildi.';
+              }
+            }
+          }
+        } catch(Throwable $e){
+          $errors[]='Profil oluşturulurken bir hata oluştu: '.$e->getMessage();
+        }
+      }
+      if(!isset($_FILES['files'])){ $errors[]='Dosya seçilmedi.'; }
       else{
-        $dir=ensure_upload_dir($VID,$event_id);
-        for($i=0;$i<$n;$i++){
-          if($f['error'][$i]!==UPLOAD_ERR_OK){ $errors[]='Yükleme hatası (kod '.$f['error'][$i].')'; continue; }
-          $tmp=$f['tmp_name'][$i]; $nm=$f['name'][$i]; $sz=(int)$f['size'][$i];
-          if($sz<=0 || $sz>MAX_UPLOAD_BYTES){ $errors[]=h($nm).': limit '.round(MAX_UPLOAD_BYTES/1048576).' MB'; continue; }
-          $fi=finfo_open(FILEINFO_MIME_TYPE); $mime=finfo_file($fi,$tmp); finfo_close($fi);
-          if(!isset(ALLOWED_MIMES[$mime])){ $errors[]=h($nm).': desteklenmeyen tür ('.$mime.')'; continue; }
-          $ext=ALLOWED_MIMES[$mime];
-          $base=preg_replace('~[^a-zA-Z0-9-_]+~','_', pathinfo($nm,PATHINFO_FILENAME)); if($base==='') $base='file';
-          $final=$base.'_'.date('Ymd_His').'_'.$i.'_'.bin2hex(random_bytes(3)).'.'.$ext;
-          $dest=$dir.'/'.$final;
-          if(!move_uploaded_file($tmp,$dest)){ $errors[]=h($nm).': taşınamadı'; continue; }
-          $rel='uploads/v'.$VID.'/'.$event_id.'/'.$final;
-          pdo()->prepare("INSERT INTO uploads (venue_id,event_id,guest_name,file_path,mime,file_size,ip,created_at)
-                          VALUES (?,?,?,?,?,?,?,?)")
-              ->execute([$VID,$event_id,$guest,$rel,$mime,$sz,client_ip(),now()]);
-          $okCount++;
+        $f=$_FILES['files'];
+        $n=is_array($f['name'])?count($f['name']):0;
+        if($n<=0) $errors[]='Dosya seçilmedi.';
+        else{
+          $dir=ensure_upload_dir($VID,$event_id);
+          $profileId = $profileForUpload['id'] ?? ($guestProfile['id'] ?? null);
+          $profileEmail = $profileForUpload['email'] ?? ($guestProfile['email'] ?? null);
+          for($i=0;$i<$n;$i++){
+            if($f['error'][$i]!==UPLOAD_ERR_OK){ $errors[]='Yükleme hatası (kod '.$f['error'][$i].')'; continue; }
+            $tmp=$f['tmp_name'][$i]; $nm=$f['name'][$i]; $sz=(int)$f['size'][$i];
+            if($sz<=0 || $sz>MAX_UPLOAD_BYTES){ $errors[]=h($nm).': limit '.round(MAX_UPLOAD_BYTES/1048576).' MB'; continue; }
+            $fi=finfo_open(FILEINFO_MIME_TYPE); $mime=finfo_file($fi,$tmp); finfo_close($fi);
+            if(!isset(ALLOWED_MIMES[$mime])){ $errors[]=h($nm).': desteklenmeyen tür ('.$mime.')'; continue; }
+            $ext=ALLOWED_MIMES[$mime];
+            $base=preg_replace('~[^a-zA-Z0-9-_]+~','_', pathinfo($nm,PATHINFO_FILENAME)); if($base==='') $base='file';
+            $final=$base.'_'.date('Ymd_His').'_'.$i.'_'.bin2hex(random_bytes(3)).'.'.$ext;
+            $dest=$dir.'/'.$final;
+            if(!move_uploaded_file($tmp,$dest)){ $errors[]=h($nm).': taşınamadı'; continue; }
+            $rel='uploads/v'.$VID.'/'.$event_id.'/'.$final;
+            pdo()->prepare("INSERT INTO uploads (venue_id,event_id,guest_name,profile_id,guest_email,file_path,mime,file_size,ip,created_at)
+                            VALUES (?,?,?,?,?,?,?,?,?,?)")
+                ->execute([$VID,$event_id,$guest,$profileId,$profileEmail,$rel,$mime,$sz,client_ip(),now()]);
+            $okCount++;
+          }
         }
       }
     }
-  }
-  if ($okCount > 0 && !empty($ev['dealer_id'])) {
-    $pdo = pdo();
-    $ownTxn = !$pdo->inTransaction();
-    if ($ownTxn) {
-      $pdo->beginTransaction();
-    }
-    try {
-      $lock = $pdo->prepare("SELECT dealer_id, dealer_credit_consumed_at FROM events WHERE id=? FOR UPDATE");
-      $lock->execute([$event_id]);
-      if ($row = $lock->fetch()) {
-        $dealerId = (int)$row['dealer_id'];
-        $consumedAt = $row['dealer_credit_consumed_at'];
-        if ($dealerId > 0 && empty($consumedAt)) {
-          dealer_consume_event_credit($dealerId, $event_id);
-          $stamp = now();
-          $pdo->prepare("UPDATE events SET dealer_credit_consumed_at=?, updated_at=? WHERE id=?")
-              ->execute([$stamp, $stamp, $event_id]);
-          $ev['dealer_credit_consumed_at'] = $stamp;
+    if ($okCount > 0 && !empty($ev['dealer_id'])) {
+      $pdo = pdo();
+      $ownTxn = !$pdo->inTransaction();
+      if ($ownTxn) { $pdo->beginTransaction(); }
+      try {
+        $lock = $pdo->prepare("SELECT dealer_id, dealer_credit_consumed_at FROM events WHERE id=? FOR UPDATE");
+        $lock->execute([$event_id]);
+        if ($row = $lock->fetch()) {
+          $dealerId = (int)$row['dealer_id'];
+          $consumedAt = $row['dealer_credit_consumed_at'];
+          if ($dealerId > 0 && empty($consumedAt)) {
+            dealer_consume_event_credit($dealerId, $event_id);
+            $stamp = now();
+            $pdo->prepare("UPDATE events SET dealer_credit_consumed_at=?, updated_at=? WHERE id=?")
+                ->execute([$stamp, $stamp, $event_id]);
+            $ev['dealer_credit_consumed_at'] = $stamp;
+          }
         }
+        if ($ownTxn) { $pdo->commit(); }
+      } catch (Throwable $consumeErr) {
+        if ($ownTxn && $pdo->inTransaction()) { $pdo->rollBack(); }
+        error_log('Dealer credit consumption failed for event '.$event_id.': '.$consumeErr->getMessage());
       }
-      if ($ownTxn) {
-        $pdo->commit();
-      }
-    } catch (Throwable $consumeErr) {
-      if ($ownTxn && $pdo->inTransaction()) {
-        $pdo->rollBack();
-      }
-      error_log('Dealer credit consumption failed for event '.$event_id.': '.$consumeErr->getMessage());
     }
+    if($okCount>0){
+      $msg = $okCount.' dosya yüklendi. Teşekkürler!';
+      if($verificationFlash) $msg .= '<br>'.$verificationFlash;
+      flash('ok',$msg);
+      header('Location:'.$redirect); exit;
+    }
+    if($errors){ flash('err',implode('<br>',array_map('h',$errors))); header('Location:'.$redirect); exit; }
+    header('Location:'.$redirect); exit;
   }
-  $to=BASE_URL.'/public/upload.php?event='.$event_id.'&t='.rawurlencode($token);
-  if($okCount>0){ flash('ok',$okCount.' dosya yüklendi. Teşekkürler!'); header('Location:'.$to); exit; }
-  if($errors){ flash('err',implode('<br>',array_map('h',$errors))); header('Location:'.$to); exit; }
+  if($action === 'like' || $action === 'unlike'){
+    $uploadId = (int)($_POST['upload_id'] ?? 0);
+    if(!$guestProfile || (int)$guestProfile['is_verified']!==1){
+      flash('err','Beğenmek için e-postanızı doğrulayın.');
+      header('Location:'.$redirect); exit;
+    }
+    $st = pdo()->prepare('SELECT id FROM uploads WHERE id=? AND event_id=? LIMIT 1');
+    $st->execute([$uploadId,$event_id]);
+    if(!$st->fetch()){ flash('err','Kayıt bulunamadı.'); header('Location:'.$redirect); exit; }
+    if($action==='like'){ guest_upload_like($uploadId, (int)$guestProfile['id']); }
+    else{ guest_upload_unlike($uploadId, (int)$guestProfile['id']); }
+    guest_profile_touch((int)$guestProfile['id']);
+    header('Location:'.$redirect.'#media-'.$uploadId); exit;
+  }
+  if($action === 'comment'){
+    $uploadId = (int)($_POST['upload_id'] ?? 0);
+    $body = trim($_POST['comment_body'] ?? '');
+    if(!$guestProfile || (int)$guestProfile['is_verified']!==1){
+      flash('err','Yorum yapmak için e-postanızı doğrulayın.');
+      header('Location:'.$redirect); exit;
+    }
+    $st = pdo()->prepare('SELECT id FROM uploads WHERE id=? AND event_id=? LIMIT 1');
+    $st->execute([$uploadId,$event_id]);
+    if(!$st->fetch()){ flash('err','Kayıt bulunamadı.'); header('Location:'.$redirect); exit; }
+    if($body===''){ flash('err','Yorum metni boş olamaz.'); header('Location:'.$redirect.'#media-'.$uploadId); exit; }
+    guest_upload_comment_add($uploadId, $guestProfile, $body);
+    guest_profile_touch((int)$guestProfile['id']);
+    flash('ok','Yorumunuz paylaşıldı.');
+    header('Location:'.$redirect.'#media-'.$uploadId); exit;
+  }
+  if($action === 'chat'){
+    if(!$guestProfile || (int)$guestProfile['is_verified']!==1){
+      flash('err','Sohbete katılmak için e-postanızı doğrulayın.');
+      header('Location:'.$redirect.'#chat'); exit;
+    }
+    $message = trim($_POST['chat_message'] ?? '');
+    if($message===''){ flash('err','Mesaj boş olamaz.'); header('Location:'.$redirect.'#chat'); exit; }
+    guest_chat_add_message($event_id, $guestProfile, $message, null);
+    flash('ok','Mesajın paylaşıldı.');
+    header('Location:'.$redirect.'#chat'); exit;
+  }
+  if($action === 'profile'){
+    if(!$guestProfile){ flash('err','Profilinizi düzenlemek için önce e-posta adresinizle kayıt olun.'); header('Location:'.$redirect.'#profile'); exit; }
+    $display = trim($_POST['display_name'] ?? '');
+    $bio = trim($_POST['bio'] ?? '');
+    $avatar = trim($_POST['avatar_token'] ?? '');
+    $marketing = isset($_POST['profile_marketing']);
+    guest_profile_update((int)$guestProfile['id'], $display, $bio, $avatar, $marketing);
+    flash('ok','Profiliniz güncellendi.');
+    header('Location:'.$redirect.'#profile'); exit;
+  }
+  if($action === 'resend_verification'){
+    if(!$guestProfile){ flash('err','Önce e-posta adresinizle bir içerik yükleyin.'); header('Location:'.$redirect); exit; }
+    if((int)$guestProfile['is_verified']===1){ flash('ok','Profiliniz zaten doğrulandı.'); header('Location:'.$redirect); exit; }
+    $lastSent = $guestProfile['last_verification_sent_at'] ?? null;
+    if($lastSent && strtotime($lastSent) > time()-300){
+      flash('err','Yeni bir bağlantı göndermeden önce birkaç dakika bekleyin.');
+      header('Location:'.$redirect); exit;
+    }
+    guest_profile_send_verification($guestProfile, $ev);
+    flash('ok','Doğrulama bağlantısı e-posta adresinize gönderildi.');
+    header('Location:'.$redirect); exit;
+  }
 }
 
-/* ---- Galeri ---- */
-$uploads=[];
+$guestProfile = guest_profile_current($event_id);
+$profileVerified = $guestProfile && (int)$guestProfile['is_verified']===1;
+
+$uploads=[]; $uploadLikes=[]; $uploadLikedByMe=[]; $uploadComments=[]; $commentCounts=[];
 if($CAN_VIEW){
-  $st=pdo()->prepare("SELECT id,guest_name,file_path,mime,file_size,created_at
-                      FROM uploads WHERE venue_id=? AND event_id=? ORDER BY id DESC LIMIT 300");
+  $st=pdo()->prepare("SELECT u.id,u.guest_name,u.profile_id,u.guest_email,u.file_path,u.mime,u.file_size,u.created_at,
+                             gp.display_name AS profile_display_name,gp.avatar_token AS profile_avatar_token,gp.is_verified AS profile_verified
+                      FROM uploads u
+                      LEFT JOIN guest_profiles gp ON gp.id=u.profile_id
+                      WHERE u.venue_id=? AND u.event_id=?
+                      ORDER BY u.id DESC LIMIT 300");
   $st->execute([$VID,$event_id]);
   $uploads=$st->fetchAll();
+  $uploadIds = array_column($uploads,'id');
+  if($uploadIds){
+    $placeholders = implode(',', array_fill(0,count($uploadIds),'?'));
+    $st=pdo()->prepare("SELECT upload_id, COUNT(*) AS cnt FROM guest_upload_likes WHERE upload_id IN ($placeholders) GROUP BY upload_id");
+    $st->execute($uploadIds);
+    foreach($st->fetchAll() as $row){ $uploadLikes[(int)$row['upload_id']] = (int)$row['cnt']; }
+    if($profileVerified){
+      $params = array_merge([(int)$guestProfile['id']], $uploadIds);
+      $st=pdo()->prepare("SELECT upload_id FROM guest_upload_likes WHERE profile_id=? AND upload_id IN ($placeholders)");
+      $st->execute($params);
+      foreach($st->fetchAll() as $row){ $uploadLikedByMe[(int)$row['upload_id']] = true; }
+    }
+    $st=pdo()->prepare("SELECT c.*, gp.display_name AS profile_display_name, gp.avatar_token AS profile_avatar_token
+                         FROM guest_upload_comments c
+                         LEFT JOIN guest_profiles gp ON gp.id=c.profile_id
+                         WHERE c.upload_id IN ($placeholders)
+                         ORDER BY c.created_at ASC");
+    $st->execute($uploadIds);
+    foreach($st->fetchAll() as $c){
+      $uid = (int)$c['upload_id'];
+      if(!isset($uploadComments[$uid])) $uploadComments[$uid]=[];
+      $uploadComments[$uid][] = $c;
+      $commentCounts[$uid] = ($commentCounts[$uid] ?? 0) + 1;
+    }
+  }
 }
+
+$chatMessages=[];
+$st = pdo()->prepare("SELECT m.*, gp.display_name, gp.avatar_token FROM guest_chat_messages m
+                      LEFT JOIN guest_profiles gp ON gp.id=m.profile_id
+                      WHERE m.event_id=? ORDER BY m.id DESC LIMIT 60");
+$st->execute([$event_id]);
+$chatMessages = array_reverse($st->fetchAll());
 ?>
 <!doctype html>
 <html lang="tr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title><?=h($ev['title'])?> — Misafir Yükleme</title>
+<title><?=h($ev['title'])?> — Misafir Sosyal Alanı</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <style>
-:root{ --zs:<?=h($PRIMARY)?>; --zs-soft:<?=h($ACCENT)?>; --ink:#111827; --muted:#6b7280 }
-body{ background:linear-gradient(180deg,var(--zs-soft),#fff) }
-.card-lite{ border:1px solid #eef2f7; border-radius:18px; background:#fff; box-shadow:0 6px 20px rgba(17,24,39,.05) }
-.btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:12px; padding:.65rem 1rem; font-weight:700 }
-.btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:12px; font-weight:700 }
-.dropzone{ border:2px dashed #cbd5e1; border-radius:16px; padding:24px; text-align:center; background:#fff; transition:.2s }
-.dropzone.drag{ border-color:var(--zs); background:#f0fbfd }
-.smallmuted{ color:var(--muted) }
-.thumb{ overflow:hidden; border-radius:12px; border:1px solid #e5e7eb; background:#f8fafc }
-.thumb img,.thumb video{ width:100%; height:180px; object-fit:cover; display:block }
-.badge-soft{ background:#eef2ff; color:#334155 }
-
-/* === 960×540 ölçekli sahne (çift panelle birebir) === */
-.preview-shell{ width:min(100%,980px); margin:0 auto }
-.preview-stage{ position:relative; width:100%; border:1px dashed #cbd5e1; border-radius:16px; background:#fff; overflow:hidden }
-.stage-scale{ position:absolute; left:0; top:0; width:960px; height:540px; transform-origin:top left; transform:scale(var(--s,1)) }
-.preview-canvas{ position:absolute; inset:0; background:linear-gradient(180deg,var(--zs-soft),#fff) }
-.pv-title{ position:absolute; font-size:28px; font-weight:800; color:#111 }
-.pv-sub{ position:absolute; color:#334155; font-size:16px }
-.pv-prompt{ position:absolute; color:#0f172a; font-size:16px }
-.sticker{ position:absolute; user-select:none; pointer-events:none }
+:root{ --zs:<?=h($PRIMARY)?>; --zs-soft:<?=h($ACCENT)?>; --ink:#0f172a; --muted:#64748b }
+body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter','Helvetica Neue',Arial,sans-serif; color:var(--ink); }
+.card-lite{ border:1px solid rgba(148,163,184,.25); border-radius:22px; background:#fff; box-shadow:0 18px 45px rgba(15,23,42,.08); }
+.btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:999px; padding:.65rem 1.2rem; font-weight:600; }
+.btn-zs:disabled{ background:rgba(148,163,184,.6); }
+.btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:999px; font-weight:600; }
+.hero{ background:#fff; border-radius:26px; padding:32px; position:relative; overflow:hidden; }
+.hero::after{ content:""; position:absolute; inset:auto -40px -120px auto; width:320px; height:320px; background:radial-gradient(circle at center, rgba(14,165,181,.35), transparent 70%); }
+.hero-badge{ display:inline-flex; align-items:center; gap:8px; background:rgba(14,165,181,.12); color:var(--zs); padding:6px 14px; border-radius:999px; font-size:14px; font-weight:600; }
+.page-grid{ display:grid; gap:24px; margin-top:32px; }
+@media(min-width:992px){ .page-grid{ grid-template-columns:2fr 1fr; } }
+.upload-card{ padding:28px; }
+.upload-card h5{ font-weight:700; }
+.dropzone{ border:2px dashed rgba(148,163,184,.45); border-radius:24px; padding:36px; text-align:center; background:rgba(241,245,249,.6); transition:.2s; }
+.dropzone.drag{ border-color:var(--zs); background:rgba(14,165,181,.08); }
+.form-text{ color:var(--muted); }
+.gallery-card{ padding:28px; }
+.gallery-masonry{ column-count:1; column-gap:24px; }
+@media(min-width:768px){ .gallery-masonry{ column-count:2; } }
+@media(min-width:1200px){ .gallery-masonry{ column-count:3; } }
+.gallery-item{ break-inside:avoid; margin-bottom:24px; border-radius:20px; overflow:hidden; background:#fff; border:1px solid rgba(148,163,184,.2); box-shadow:0 12px 30px rgba(15,23,42,.08); position:relative; }
+.gallery-media img,.gallery-media video{ width:100%; display:block; object-fit:cover; }
+.gallery-header{ display:flex; align-items:center; gap:12px; padding:18px 20px 12px; }
+.avatar{ width:46px; height:46px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:700; letter-spacing:.5px; }
+.gallery-actions{ display:flex; align-items:center; justify-content:space-between; padding:12px 20px 4px; gap:12px; }
+.action-buttons{ display:flex; gap:10px; }
+.icon-btn{ border:none; background:rgba(248,250,252,.9); border-radius:999px; padding:8px 16px; display:flex; align-items:center; gap:8px; font-weight:600; color:var(--muted); cursor:pointer; }
+.icon-btn.active{ background:rgba(14,165,181,.12); color:var(--zs); }
+.icon-btn:hover{ background:rgba(14,165,181,.18); color:var(--zs); }
+.gallery-meta{ font-size:13px; color:var(--muted); }
+.gallery-body{ padding:8px 20px 20px; }
+.comment{ padding:10px 14px; border-radius:14px; background:rgba(241,245,249,.6); margin-top:8px; }
+.comment strong{ display:block; font-size:13px; color:var(--ink); }
+.comment p{ margin:4px 0 0; font-size:13px; color:var(--muted); }
+.comment-form textarea{ resize:vertical; border-radius:16px; }
+.badge-soft{ background:rgba(14,165,181,.12); color:var(--zs); border-radius:999px; padding:4px 12px; font-size:12px; font-weight:600; }
+.profile-card{ padding:28px; }
+.profile-card h5{ font-weight:700; }
+.chat-card{ padding:28px; }
+.chat-stream{ max-height:420px; overflow:auto; display:flex; flex-direction:column; gap:12px; }
+.chat-bubble{ padding:14px 18px; border-radius:18px; background:rgba(241,245,249,.8); }
+.chat-author{ font-weight:600; font-size:14px; color:var(--ink); }
+.chat-time{ font-size:12px; color:var(--muted); }
+.preview-shell{ width:min(100%,980px); margin:0 auto; }
+.preview-stage{ position:relative; width:100%; border:1px dashed #cbd5e1; border-radius:20px; background:#fff; overflow:hidden; }
+.stage-scale{ position:absolute; left:0; top:0; width:960px; height:540px; transform-origin:top left; transform:scale(var(--s,1)); }
+.preview-canvas{ position:absolute; inset:0; background:linear-gradient(180deg,var(--zs-soft),#fff); }
+.pv-title{ position:absolute; font-size:28px; font-weight:800; color:#111; }
+.pv-sub{ position:absolute; color:#334155; font-size:16px; }
+.pv-prompt{ position:absolute; color:#0f172a; font-size:16px; }
+.sticker{ position:absolute; user-select:none; pointer-events:none; }
+.smallmuted{ color:var(--muted); font-size:13px; }
+.share-toast{ position:fixed; left:50%; bottom:32px; transform:translateX(-50%); background:#0ea5b5; color:#fff; padding:12px 20px; border-radius:999px; font-weight:600; box-shadow:0 18px 30px rgba(14,165,181,.3); opacity:0; transition:.4s; pointer-events:none; }
+.share-toast.show{ opacity:1; }
 </style>
 </head>
 <body>
 <div class="container py-4">
   <?php flash_box(); ?>
+  <section class="hero mb-4">
+    <div class="d-flex flex-column flex-lg-row align-items-start align-items-lg-center justify-content-between gap-3">
+      <div>
+        <span class="hero-badge">BİKARE Misafir Alanı</span>
+        <h1 class="mt-3 mb-2" style="font-weight:800; font-size:32px; color:var(--ink);"><?=h($TITLE)?></h1>
+        <p class="mb-3" style="font-size:16px; color:var(--muted); max-width:560px;"><?=h($SUBTITLE)?></p>
+        <?php if($guestProfile): ?>
+          <?php if($profileVerified): ?>
+            <div class="badge-soft">Hoş geldin, <?=h($guestProfile['display_name'] ?: $guestProfile['name'])?>! Profilin doğrulandı.</div>
+          <?php else: ?>
+            <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-2">
+              <div class="badge-soft">E-posta doğrulaması bekleniyor</div>
+              <form method="post" class="d-flex">
+                <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+                <input type="hidden" name="do" value="resend_verification">
+                <button class="btn btn-zs-outline btn-sm">Bağlantıyı tekrar gönder</button>
+              </form>
+            </div>
+          <?php endif; ?>
+        <?php else: ?>
+          <div class="badge-soft">Adınızı ve e-postanızı paylaşarak misafir topluluğuna katılın.</div>
+        <?php endif; ?>
+      </div>
+      <div class="text-end smallmuted">
+        <div>Etkinlik Tarihi: <?= $ev['event_date'] ? date('d.m.Y', strtotime($ev['event_date'])) : 'Belirtilmedi' ?></div>
+        <div>Misafir bağlantısı bu sayfadır.</div>
+      </div>
+    </div>
+  </section>
+  <div class="page-grid">
+    <div class="vstack gap-4">
+      <div class="card-lite upload-card">
+        <h5 class="mb-3">Anınızı Yükleyin</h5>
+        <p class="smallmuted mb-4">Fotoğraflar, videolar ve GIF’ler yüksek kalitede saklanır. Yükledikten sonra topluluk beğenebilir, yorum yapabilir ve paylaşabilir.</p>
+        <form method="post" enctype="multipart/form-data" id="upForm" class="vstack gap-4">
+          <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+          <input type="hidden" name="do" value="upload">
+          <input type="hidden" name="t" value="<?=h($token)?>">
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label class="form-label">Adınız Soyadınız *</label>
+              <input class="form-control" name="guest_name" placeholder="Ör. Ayşe Yılmaz" required <?= !$token_ok?'disabled':'' ?>>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">E-posta (opsiyonel)</label>
+              <input class="form-control" type="email" name="guest_email" placeholder="ornek@mail.com" <?= !$token_ok?'disabled':'' ?>>
+              <div class="form-text">Düğün sonrasında size gönderilecek kullanıcı adı ve şifreniz için e-posta adresinizi paylaşabilirsiniz.</div>
+            </div>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" name="marketing_opt_in" value="1" id="marketingOpt" <?= !$token_ok?'disabled':'' ?>>
+            <label class="form-check-label" for="marketingOpt">BİKARE’den kampanya ve yenilik bildirimleri almak istiyorum.</label>
+          </div>
+          <div class="dropzone" id="drop" <?= !$token_ok?'data-disabled="1"':'' ?>>
+            <p class="m-0">
+              <strong>Dosyalarınızı buraya sürükleyin</strong> veya
+              <label class="text-decoration-underline" style="cursor:pointer">cihazınızdan seçin
+                <input type="file" name="files[]" id="fileI" accept="<?=implode(',',array_keys(ALLOWED_MIMES))?>" multiple hidden <?= !$token_ok?'disabled':'' ?>>
+              </label>
+            </p>
+            <div class="form-text mt-2">İzinli formatlar: jpg, png, webp, gif, mp4, mov, webm. Maksimum <?=round(MAX_UPLOAD_BYTES/1048576)?> MB / dosya.</div>
+          </div>
+          <div id="list" class="smallmuted"></div>
+          <div class="d-grid d-sm-flex align-items-center gap-3">
+            <button class="btn btn-zs" <?= !$token_ok?'disabled':'' ?>>Anımı Paylaş</button>
+            <?php if(!$token_ok): ?><span class="text-danger small">Güvenlik anahtarınızın süresi doldu. Lütfen QR kodu yeniden okutun.</span><?php endif; ?>
+          </div>
+        </form>
+      </div>
 
-  <div class="card-lite p-3 mb-4">
-    <div class="preview-shell">
-      <div class="preview-stage" id="pvStage">
-        <div class="stage-scale" id="scaleBox">
-          <div class="preview-canvas">
-            <div class="pv-title"  style="left:<?= (int)$tPos['x']?>px; top:<?= (int)$tPos['y']?>px;"><?=h($TITLE)?></div>
-            <div class="pv-sub"    style="left:<?= (int)$sPos['x']?>px; top:<?= (int)$sPos['y']?>px;"><?=h($SUBTITLE)?></div>
-            <div class="pv-prompt" style="left:<?= (int)$pPos['x']?>px; top:<?= (int)$pPos['y']?>px;"><?=h($PROMPT)?></div>
-            <?php foreach($stickersArr as $st){
-              $txt = isset($st['txt'])?$st['txt']:'💍';
-              $x   = isset($st['x'])?(int)$st['x']:20;
-              $y   = isset($st['y'])?(int)$st['y']:90;
-              $sz  = isset($st['size'])?(int)$st['size']:32; ?>
-              <div class="sticker" style="left:<?=$x?>px; top:<?=$y?>px; font-size:<?=$sz?>px"><?=$txt?></div>
-            <?php } ?>
+      <div class="card-lite p-3">
+        <div class="preview-shell">
+          <div class="preview-stage" id="pvStage">
+            <div class="stage-scale" id="scaleBox">
+              <div class="preview-canvas">
+                <div class="pv-title"  style="left:<?= (int)$tPos['x']?>px; top:<?= (int)$tPos['y']?>px;"><?=h($TITLE)?></div>
+                <div class="pv-sub"    style="left:<?= (int)$sPos['x']?>px; top:<?= (int)$sPos['y']?>px;"><?=h($SUBTITLE)?></div>
+                <div class="pv-prompt" style="left:<?= (int)$pPos['x']?>px; top:<?= (int)$pPos['y']?>px;"><?=h($PROMPT)?></div>
+                <?php foreach($stickersArr as $st){
+                  $txt = isset($st['txt'])?$st['txt']:'💍';
+                  $x   = isset($st['x'])?(int)$st['x']:20;
+                  $y   = isset($st['y'])?(int)$st['y']:90;
+                  $sz  = isset($st['size'])?(int)$st['size']:32; ?>
+                  <div class="sticker" style="left:<?=$x?>px; top:<?=$y?>px; font-size:<?=$sz?>px"><?=$txt?></div>
+                <?php } ?>
+              </div>
+            </div>
           </div>
         </div>
+        <div class="smallmuted mt-2 text-center">Bu önizleme çift panelinde kayıtlı tasarımın birebir halidir.</div>
       </div>
-    </div>
-    <div class="smallmuted mt-2">Önizleme, çift panelde kaydettiğiniz düzenin birebir yansımasıdır.</div>
-  </div>
 
-  <?php if(!$token_ok): ?>
-    <div class="alert alert-warning" style="border-radius:14px">Güvenlik anahtarı süresi dolmuş. Lütfen QR’ı yeniden okutun.</div>
-  <?php endif; ?>
-
-  <!-- Yükleme formu -->
-  <div class="card-lite p-3 mb-4">
-    <h5 class="mb-3">Anınızı Yükleyin</h5>
-    <form method="post" enctype="multipart/form-data" id="upForm" class="vstack gap-3">
-      <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-      <input type="hidden" name="do" value="upload">
-      <input type="hidden" name="t" value="<?=h($token)?>">
-      <div>
-        <label class="form-label">Adınız</label>
-        <input class="form-control" name="guest_name" placeholder="Ad Soyad" required <?= !$token_ok?'disabled':'' ?>>
-      </div>
-      <div class="dropzone" id="drop">
-        <p class="m-0">
-          <b>Dosyalarınızı buraya sürükleyin</b> veya
-          <label class="text-decoration-underline" style="cursor:pointer">bilgisayardan seçin
-            <input type="file" name="files[]" id="fileI" accept="<?=implode(',',array_keys(ALLOWED_MIMES))?>" multiple hidden <?= !$token_ok?'disabled':'' ?>>
-          </label>
-        </p>
-        <div class="smallmuted mt-2">İzinli: jpg, png, webp, gif, mp4, mov, webm — Maks: <?=round(MAX_UPLOAD_BYTES/1048576)?> MB/dosya</div>
-      </div>
-      <div id="list" class="smallmuted"></div>
-      <div class="d-grid"><button class="btn btn-zs" <?= !$token_ok?'disabled':'' ?>>Yükle</button></div>
-    </form>
-  </div>
-
-  <!-- Galeri -->
-  <div class="card-lite p-3">
-    <div class="d-flex justify-content-between align-items-center mb-2">
-      <h5 class="m-0">Galeri</h5>
-      <?php if(!$CAN_VIEW): ?><span class="badge bg-secondary">Gizli</span>
-      <?php else: ?><?= $CAN_DOWN?'<span class="badge badge-soft">İndirme açık</span>':'<span class="badge bg-secondary">İndirme kapalı</span>' ?><?php endif; ?>
-    </div>
-    <?php if(!$CAN_VIEW): ?>
-      <div class="smallmuted">Galeri bu etkinlikte gizli.</div>
-    <?php else: ?>
-      <?php if(!$uploads): ?>
-        <div class="smallmuted">Henüz yükleme yok.</div>
-      <?php else: ?>
-        <div class="row g-3">
-          <?php foreach($uploads as $u):
-            $path = '/'.$u['file_path'];
-            $isImg=is_image_mime($u['mime']); $isVid=is_video_mime($u['mime']); ?>
-            <div class="col-6 col-md-4 col-lg-3">
-              <div class="thumb">
+      <div class="card-lite gallery-card" id="galeri">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <div>
+            <h5 class="mb-0">Topluluk Galerisi</h5>
+            <div class="smallmuted">Paylaşılan tüm fotoğraf ve videolar burada toplanır.</div>
+          </div>
+          <div>
+            <?php if(!$CAN_VIEW): ?><span class="badge bg-secondary">Galeri gizli</span>
+            <?php else: ?>
+              <span class="badge-soft"><?= $CAN_DOWN ? 'İndirme açık' : 'İndirme kapalı' ?></span>
+            <?php endif; ?>
+          </div>
+        </div>
+        <?php if(!$CAN_VIEW): ?>
+          <div class="smallmuted">Galeri bu etkinlikte sadece çift tarafından görüntülenebilir.</div>
+        <?php elseif(!$uploads): ?>
+          <div class="smallmuted">Henüz yükleme yapılmadı. İlk paylaşımı siz yapın!</div>
+        <?php else: ?>
+          <div class="gallery-masonry">
+            <?php foreach($uploads as $u):
+              $path = '/'.$u['file_path'];
+              $isImg=is_image_mime($u['mime']); $isVid=is_video_mime($u['mime']);
+              $name = $u['profile_display_name'] ?: $u['guest_name'];
+              $seed = guest_profile_avatar_seed([
+                'avatar_token'=>$u['profile_avatar_token'],
+                'email'=>$u['guest_email'] ?? ('upload'.$u['id'].'@guest'),
+                'id'=> $u['profile_id'] ? (int)$u['profile_id'] : (int)$u['id']
+              ]);
+              [$bg,$fg] = avatar_colors($seed);
+              $liked = !empty($uploadLikedByMe[$u['id']]);
+              $likes = $uploadLikes[$u['id']] ?? 0;
+              $comments = $uploadComments[$u['id']] ?? [];
+              $commentCount = $commentCounts[$u['id']] ?? 0;
+            ?>
+            <div class="gallery-item" id="media-<?=$u['id']?>">
+              <div class="gallery-header">
+                <div class="avatar" style="background:<?=$bg?>;color:<?=$fg?>;">
+                  <?=h(avatar_initial($name))?>
+                </div>
+                <div>
+                  <div style="font-weight:600; color:var(--ink);"><?=h($name)?></div>
+                  <div class="gallery-meta"><?=relative_time($u['created_at'])?></div>
+                </div>
+              </div>
+              <div class="gallery-media">
                 <?php if($isImg): ?><img src="<?=h($path)?>" alt="">
-                <?php elseif($isVid): ?><video src="<?=h($path)?>" muted></video>
+                <?php elseif($isVid): ?><video src="<?=h($path)?>" controls playsinline></video>
                 <?php else: ?><div class="p-4 text-center smallmuted">Dosya</div><?php endif; ?>
               </div>
-              <div class="d-flex justify-content-between align-items-center mt-1">
-                <span class="small text-truncate" title="<?=h($u['guest_name'])?>"><?=h($u['guest_name'])?></span>
-                <?php if($CAN_DOWN): ?><a class="btn btn-sm btn-zs-outline" href="<?=h($path)?>" download>İndir</a><?php endif; ?>
+              <div class="gallery-actions">
+                <div class="action-buttons">
+                  <form method="post" class="d-inline">
+                    <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+                    <input type="hidden" name="do" value="<?= $liked ? 'unlike' : 'like' ?>">
+                    <input type="hidden" name="upload_id" value="<?=$u['id']?>">
+                    <button type="submit" class="icon-btn <?= $liked?'active':'' ?>" <?= !$profileVerified?'disabled title="Beğenmek için e-posta doğrulaması gerekir"':'' ?>>
+                      <span><?= $liked ? '❤️' : '🤍' ?></span>
+                      <span><?= $likes ?></span>
+                    </button>
+                  </form>
+                  <button class="icon-btn share-btn" type="button" data-share="<?=h(BASE_URL.$path)?>"><span>🔗</span>Paylaş</button>
+                </div>
+                <?php if($CAN_DOWN): ?>
+                  <a class="btn btn-sm btn-zs-outline" href="<?=h($path)?>" download>İndir</a>
+                <?php endif; ?>
               </div>
-              <div class="small smallmuted"><?=number_format($u['file_size']/1048576,1)?> MB • <?=date('d.m.Y H:i', strtotime($u['created_at']))?></div>
+              <div class="gallery-body">
+                <div class="smallmuted">Yorumlar (<?=$commentCount?>)</div>
+                <?php foreach($comments as $c):
+                  $cName = $c['profile_display_name'] ?: ($c['guest_name'] ?: 'Misafir');
+                  $cSeed = guest_profile_avatar_seed([
+                    'avatar_token'=>$c['profile_avatar_token'],
+                    'email'=>$c['guest_email'] ?? ('comment'.($c['id'] ?? '0').'@guest'),
+                    'id'=> $c['profile_id'] ? (int)$c['profile_id'] : (int)($c['id'] ?? 0)
+                  ]);
+                  [$cbg,$cfg] = avatar_colors($cSeed);
+                ?>
+                  <div class="comment">
+                    <strong><?=h($cName)?></strong>
+                    <div class="smallmuted"><?=relative_time($c['created_at'])?></div>
+                    <p><?=nl2br(h($c['body']))?></p>
+                  </div>
+                <?php endforeach; ?>
+                <?php if($profileVerified): ?>
+                <form method="post" class="comment-form mt-3">
+                  <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+                  <input type="hidden" name="do" value="comment">
+                  <input type="hidden" name="upload_id" value="<?=$u['id']?>">
+                  <textarea class="form-control" name="comment_body" rows="2" placeholder="Güzel bir not bırak..." required></textarea>
+                  <div class="text-end mt-2"><button class="btn btn-sm btn-zs">Yorumu Gönder</button></div>
+                </form>
+                <?php elseif($guestProfile && !$profileVerified): ?>
+                  <div class="comment mt-3">Yorum yapabilmek için e-posta adresinizi doğrulayın.</div>
+                <?php else: ?>
+                  <div class="comment mt-3">Yorum yapmak için önce e-postanızı paylaşarak içerik yükleyin.</div>
+                <?php endif; ?>
+              </div>
             </div>
-          <?php endforeach; ?>
+            <?php endforeach; ?>
+          </div>
+        <?php endif; ?>
+      </div>
+    </div>
+    <div class="vstack gap-4">
+      <div class="card-lite profile-card" id="profile">
+        <h5 class="mb-3">Profiliniz</h5>
+        <?php if($guestProfile): ?>
+          <form method="post" class="vstack gap-3">
+            <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="do" value="profile">
+            <div>
+              <label class="form-label">Görünen Ad</label>
+              <input class="form-control" name="display_name" value="<?=h($guestProfile['display_name'] ?: $guestProfile['name'])?>">
+            </div>
+            <div>
+              <label class="form-label">Hakkınızda</label>
+              <textarea class="form-control" name="bio" rows="3" placeholder="Misafir defterine kısa bir not bırakın."><?=h($guestProfile['bio'] ?? '')?></textarea>
+            </div>
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" name="profile_marketing" value="1" id="profileMarketing" <?= !empty($guestProfile['marketing_opt_in'])?'checked':'' ?>>
+              <label class="form-check-label" for="profileMarketing">BİKARE’den kampanya ve yenilik bildirimleri almak istiyorum.</label>
+            </div>
+            <div class="d-flex justify-content-between align-items-center">
+              <div class="smallmuted">E-postanız: <?=h($guestProfile['email'] ?? '—')?> <?= $profileVerified ? '<span class="badge-soft ms-2">Doğrulandı</span>' : '' ?></div>
+              <button class="btn btn-sm btn-zs">Kaydet</button>
+            </div>
+          </form>
+        <?php else: ?>
+          <div class="smallmuted">E-posta adresinizle içerik yüklediğinizde profilinizi düzenleyebilir ve topluluk özelliklerini kullanabilirsiniz.</div>
+        <?php endif; ?>
+      </div>
+
+      <div class="card-lite chat-card" id="chat">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <h5 class="m-0">Misafir Sohbeti</h5>
+          <span class="badge-soft"><?=count($chatMessages)?> mesaj</span>
         </div>
-      <?php endif; ?>
-    <?php endif; ?>
+        <div class="chat-stream mb-3">
+          <?php if(!$chatMessages): ?>
+            <div class="smallmuted">Sohbeti başlatmak için ilk mesajınızı yazın.</div>
+          <?php else: ?>
+            <?php foreach($chatMessages as $msg):
+              $display = $msg['display_name'] ?: 'Misafir';
+              $seed = guest_profile_avatar_seed([
+                'avatar_token'=>$msg['avatar_token'],
+                'email'=>$msg['profile_id'] ? ('profile'.$msg['profile_id'].'@chat') : ('chat'.$msg['id'].'@guest'),
+                'id'=> $msg['profile_id'] ? (int)$msg['profile_id'] : (int)$msg['id']
+              ]);
+              [$bg,$fg] = avatar_colors($seed);
+            ?>
+              <div class="chat-bubble">
+                <div class="d-flex align-items-center gap-2">
+                  <div class="avatar" style="width:38px;height:38px;background:<?=$bg?>;color:<?=$fg?>;font-size:13px;">
+                    <?=h(avatar_initial($display))?>
+                  </div>
+                  <div>
+                    <div class="chat-author"><?=h($display)?></div>
+                    <div class="chat-time"><?=relative_time($msg['created_at'])?></div>
+                  </div>
+                </div>
+                <div class="mt-2" style="white-space:pre-wrap; font-size:14px; color:var(--muted);"><?=nl2br(h($msg['message']))?></div>
+              </div>
+            <?php endforeach; ?>
+          <?php endif; ?>
+        </div>
+        <?php if($profileVerified): ?>
+          <form method="post" class="vstack gap-3">
+            <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+            <input type="hidden" name="do" value="chat">
+            <textarea class="form-control" name="chat_message" rows="2" placeholder="Kutlama mesajınızı yazın" required></textarea>
+            <div class="text-end"><button class="btn btn-sm btn-zs">Gönder</button></div>
+          </form>
+        <?php elseif($guestProfile && !$profileVerified): ?>
+          <div class="smallmuted">Sohbete katılmak için e-posta adresinizi doğrulayın.</div>
+        <?php else: ?>
+          <div class="smallmuted">Sohbete katılmak için önce e-posta adresinizle içerik yükleyin.</div>
+        <?php endif; ?>
+      </div>
+    </div>
   </div>
 </div>
+<div class="share-toast" id="shareToast">Bağlantı kopyalandı!</div>
 
 <script>
-// 960x540 sahneyi container'a orantılı sığdır
 (function(){
   const stage=document.getElementById('pvStage'), box=document.getElementById('scaleBox');
   function fit(){ if(!stage||!box) return; const W=stage.clientWidth, S=W/960; box.style.setProperty('--s',S); stage.style.height=(540*S)+'px'; }
   window.addEventListener('resize',fit,{passive:true}); new ResizeObserver(fit).observe(stage); fit();
 })();
 
-// Drag&Drop
 const dz=document.getElementById('drop'), fi=document.getElementById('fileI'), lst=document.getElementById('list'), fm=document.getElementById('upForm');
-if(dz){
+if(dz && !dz.dataset.disabled){
   ['dragenter','dragover'].forEach(ev=>dz.addEventListener(ev,e=>{e.preventDefault();dz.classList.add('drag');}));
   ['dragleave','drop'].forEach(ev=>dz.addEventListener(ev,e=>{e.preventDefault();dz.classList.remove('drag');}));
   dz.addEventListener('drop',e=>{ const fs=e.dataTransfer.files; if(fs&&fi){ fi.files=fs; renderList(fs); } });
@@ -280,5 +641,13 @@ fi?.addEventListener('change',e=>renderList(e.target.files));
 function renderList(files){ if(!files||!files.length){ lst.innerHTML=''; return; } let out='<ul class="m-0 ps-3">'; for(let i=0;i<files.length;i++){ const f=files[i]; out+=`<li>${esc(f.name)} — ${(f.size/1048576).toFixed(1)} MB</li>`; } lst.innerHTML=out+'</ul>'; }
 function esc(s){return s.replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[m]));}
 fm?.addEventListener('submit',e=>{ const name=fm.querySelector('[name=guest_name]').value.trim(); if(!name){e.preventDefault(); alert('Lütfen adınızı yazın.');} const fs=fi?.files||[]; if(!fs.length){e.preventDefault(); alert('Lütfen dosya seçin.');} });
+
+const shareButtons=document.querySelectorAll('.share-btn');
+const toast=document.getElementById('shareToast');
+shareButtons.forEach(btn=>btn.addEventListener('click',async()=>{
+  const url=btn.dataset.share;
+  if(navigator.share){ try{ await navigator.share({url:url}); return;}catch(err){} }
+  try{ await navigator.clipboard.writeText(url); toast?.classList.add('show'); setTimeout(()=>toast?.classList.remove('show'),2000);}catch(err){ alert('Bağlantı kopyalanamadı: '+err); }
+}));
 </script>
 </body></html>

--- a/public/upload.php
+++ b/public/upload.php
@@ -32,8 +32,8 @@ function relative_time($dt){
   return date('d.m.Y H:i', $ts);
 }
 function avatar_colors(string $seed): array {
-  $palette = ['#0ea5b5','#6366f1','#f97316','#ec4899','#14b8a6','#9333ea','#ef4444','#22d3ee'];
-  $text = ['#fff','#fff','#fff','#fff','#073042','#fff','#fff','#0f172a'];
+  $palette = ['#0ea5b5','#0b8d9b','#13b8c9','#0a6c78'];
+  $text = ['#ffffff','#ffffff','#044047','#e6fffb'];
   $idx = hexdec(substr($seed,0,2)) % count($palette);
   return [$palette[$idx], $text[$idx] ?? '#fff'];
 }
@@ -119,6 +119,11 @@ $st->execute([$event_id]);
 $ev = $st->fetch();
 if (!$ev || (int)$ev['is_active']!==1){ http_response_code(404); exit('Etkinlik bulunamadı veya pasif.'); }
 
+$eventTimestamp = !empty($ev['event_date']) ? strtotime($ev['event_date']) : null;
+$uploadDeadline = $eventTimestamp ? strtotime('+10 days', $eventTimestamp) : null;
+if($uploadDeadline === false){ $uploadDeadline = null; }
+$uploadsLocked  = ($uploadDeadline !== null && $uploadDeadline !== false && time() > $uploadDeadline);
+
 $VID      = (int)$ev['venue_id'];
 $TITLE    = $ev['guest_title'] ?: 'BİKARE Etkinliğimize Hoş Geldiniz';
 $SUBTITLE = $ev['guest_subtitle'] ?: 'En güzel anlarınızı bizimle paylaşın';
@@ -157,6 +162,9 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
 
   if($action === 'upload'){
     $errors=[]; $okCount=0; $verificationFlash=null;
+    if($uploadsLocked){
+      $errors[]='Bu etkinlik için yüklemeler kapatıldı.';
+    }
     $p_token = trim($_POST['t']??'');
     if(!token_valid($event_id,$p_token)){
       $errors[]='Güvenlik anahtarı zaman aşımına uğradı. Lütfen QR’ı yeniden okutun.';
@@ -606,36 +614,46 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
 .gallery-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(280px,1fr)); gap:28px; }
 @media(min-width:768px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(320px,1fr)); } }
 @media(min-width:1400px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(360px,1fr)); } }
-.gallery-item{ display:flex; flex-direction:column; border-radius:26px; overflow:hidden; background:linear-gradient(172deg, rgba(6,66,82,.94) 0%, rgba(8,104,124,.88) 45%, rgba(12,146,170,.82) 100%); border:1px solid rgba(14,165,181,.35); box-shadow:0 28px 60px rgba(4,31,45,.28); color:#f1fbfd; position:relative; transition:transform .25s ease, box-shadow .25s ease; }
-.gallery-item:hover{ transform:translateY(-6px); box-shadow:0 32px 70px rgba(4,31,45,.35); }
-.gallery-media{ position:relative; width:100%; background:rgba(2,27,36,.7); display:flex; align-items:center; justify-content:center; padding:10px; }
-.gallery-media img,.gallery-media video{ width:100%; height:auto; max-height:420px; display:block; object-fit:contain; border-radius:18px; box-shadow:0 18px 38px rgba(1,14,20,.45); }
-.gallery-header{ display:flex; align-items:center; gap:14px; padding:18px 22px; background:rgba(3,23,31,.45); border-bottom:1px solid rgba(255,255,255,.08); }
-.gallery-author{ font-weight:700; font-size:15px; color:#fff; letter-spacing:.02em; }
-.avatar{ width:46px; height:46px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:700; letter-spacing:.5px; box-shadow:0 8px 18px rgba(4,31,45,.35); border:2px solid rgba(255,255,255,.2); }
-.gallery-actions{ display:flex; align-items:center; justify-content:space-between; padding:14px 22px 12px; gap:18px; background:rgba(3,23,31,.45); border-top:1px solid rgba(255,255,255,.08); }
+.gallery-item{ display:flex; flex-direction:column; border-radius:26px; overflow:hidden; background:#ffffff; border:1px solid rgba(14,165,181,.22); box-shadow:0 24px 48px rgba(14,165,181,.12); color:var(--ink); position:relative; transition:transform .25s ease, box-shadow .25s ease; }
+.gallery-item:hover{ transform:translateY(-6px); box-shadow:0 28px 60px rgba(14,165,181,.18); }
+.gallery-media{ position:relative; width:100%; background:#f1fbfc; display:flex; align-items:center; justify-content:center; padding:10px; }
+.gallery-media img,.gallery-media video{ width:100%; height:auto; max-height:380px; display:block; object-fit:contain; border-radius:18px; box-shadow:0 16px 34px rgba(14,165,181,.15); }
+.gallery-header{ display:flex; align-items:center; gap:14px; padding:18px 22px; background:#f3fbfc; border-bottom:1px solid rgba(14,165,181,.16); }
+.gallery-author{ font-weight:700; font-size:15px; color:#0f172a; letter-spacing:.02em; }
+.avatar{ width:46px; height:46px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:700; letter-spacing:.5px; box-shadow:0 8px 18px rgba(14,165,181,.18); border:2px solid rgba(14,165,181,.25); }
+.gallery-actions{ display:flex; align-items:center; justify-content:space-between; padding:14px 22px 12px; gap:18px; background:#f7fdfd; border-top:1px solid rgba(14,165,181,.16); }
 .action-buttons{ display:flex; align-items:center; gap:12px; }
-.icon-btn{ border:none; background:rgba(255,255,255,.12); border-radius:999px; padding:9px 18px; display:flex; align-items:center; gap:8px; font-weight:600; color:#e0f6f9; cursor:pointer; transition:background .2s ease, color .2s ease; }
+.icon-btn{ border:none; background:rgba(14,165,181,.12); border-radius:999px; padding:9px 18px; display:flex; align-items:center; gap:8px; font-weight:600; color:#0b5f6c; cursor:pointer; transition:background .2s ease, color .2s ease; }
 .icon-btn span{ display:inline-flex; align-items:center; }
 .icon-btn .like-count{ font-variant-numeric:tabular-nums; }
-.icon-btn.active{ background:rgba(255,255,255,.22); color:#fff; }
-.icon-btn:hover{ background:rgba(255,255,255,.26); color:#fff; }
+.icon-btn.active{ background:#0ea5b5; color:#fff; }
+.icon-btn:hover{ background:rgba(14,165,181,.2); color:#053f49; }
 .icon-btn:disabled{ cursor:not-allowed; opacity:.55; }
-.gallery-actions .btn{ border-radius:999px; border:1px solid rgba(255,255,255,.28); color:#fff; background:transparent; font-weight:600; }
-.gallery-actions .btn:hover{ background:rgba(255,255,255,.18); color:#fff; }
-.gallery-meta{ font-size:13px; color:rgba(226,248,250,.8); }
-.gallery-body{ padding:16px 22px 24px; background:rgba(3,23,31,.32); color:#f1fbfd; }
-.gallery-body p{ color:rgba(226,248,250,.88); }
-.gallery-body .smallmuted{ color:rgba(226,248,250,.82); }
-.comment{ padding:12px 16px; border-radius:18px; background:rgba(255,255,255,.12); margin-top:10px; color:#f1fbfd; }
-.gallery-item .comment strong{ display:block; font-size:13px; color:#fff; }
-.gallery-item .comment p{ margin:6px 0 0; font-size:13px; color:rgba(226,248,250,.88); }
-.gallery-item .comment .smallmuted{ color:rgba(226,248,250,.65); }
-.gallery-item .comment.smallmuted{ color:rgba(226,248,250,.82); }
+.gallery-actions .btn{ border-radius:999px; border:1px solid rgba(14,165,181,.35); color:#0a4d58; background:transparent; font-weight:600; }
+.gallery-actions .btn:hover{ background:#0ea5b5; color:#fff; }
+.gallery-meta{ font-size:13px; color:#537082; }
+.gallery-body{ padding:16px 22px 24px; background:#ffffff; color:var(--ink); }
+.gallery-body p{ color:#365562; }
+.gallery-body .smallmuted{ color:#57758a; }
+.comment{ padding:12px 16px; border-radius:18px; background:rgba(14,165,181,.12); margin-top:0; color:#0a4550; }
+.gallery-item .comment strong{ display:block; font-size:13px; color:#0a4550; }
+.gallery-item .comment p{ margin:6px 0 0; font-size:13px; color:#0b5f6c; }
+.gallery-item .comment .smallmuted{ color:#57758a; }
+.gallery-item .comment.smallmuted{ color:#57758a; }
 .comment-form textarea{ resize:vertical; border-radius:16px; }
-.gallery-item .comment-form textarea{ background:rgba(255,255,255,.08); border-color:rgba(255,255,255,.18); color:#fff; }
-.gallery-item .comment-form textarea::placeholder{ color:rgba(226,248,250,.6); }
-.gallery-item .comment-form textarea:focus{ background:rgba(3,23,31,.6); border-color:rgba(255,255,255,.45); box-shadow:0 0 0 .25rem rgba(14,165,181,.35); }
+.gallery-item .comment-form textarea{ background:#f7fdfd; border-color:rgba(14,165,181,.2); color:var(--ink); }
+.gallery-item .comment-form textarea::placeholder{ color:#7fa7b3; }
+.gallery-item .comment-form textarea:focus{ background:#ecfcff; border-color:rgba(14,165,181,.5); box-shadow:0 0 0 .25rem rgba(14,165,181,.25); }
+.comment-form{ display:flex; flex-direction:column; gap:10px; }
+.comment-form .btn{ align-self:flex-end; }
+.comment-section{ margin-top:16px; padding-top:12px; border-top:1px solid rgba(14,165,181,.15); }
+.comment-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; }
+.comment-toggle{ border:none; background:rgba(14,165,181,.12); color:#0b5f6c; font-weight:600; padding:6px 14px; border-radius:999px; cursor:pointer; transition:background .2s ease, color .2s ease; }
+.comment-toggle:hover{ background:rgba(14,165,181,.2); color:#053f49; }
+.comment-body{ margin-top:14px; display:flex; flex-direction:column; gap:14px; }
+.comment-section.collapsed .comment-body{ display:none; }
+.comment-list{ display:flex; flex-direction:column; gap:10px; }
+.comment-body .icon-btn{ align-self:flex-start; }
 .note-card textarea{ min-height:140px; }
 .form-feedback{ color:var(--zs); font-weight:600; }
 .form-feedback.error{ color:#ef4444; }
@@ -704,6 +722,9 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
       </div>
       <div class="text-end smallmuted">
         <div>Etkinlik Tarihi: <?= $ev['event_date'] ? date('d.m.Y', strtotime($ev['event_date'])) : 'Belirtilmedi' ?></div>
+        <?php if($uploadDeadline): ?>
+          <div>Yükleme Süresi: <?= date('d.m.Y', $uploadDeadline) ?><?= $uploadsLocked ? ' • Kapalı' : '' ?></div>
+        <?php endif; ?>
         <div>Misafir bağlantısı bu sayfadır.</div>
       </div>
     </div>
@@ -713,38 +734,42 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
       <div class="card-lite upload-card">
         <h5 class="mb-3">Anınızı Yükleyin</h5>
         <p class="smallmuted mb-4">Fotoğraflar, videolar ve GIF’ler yüksek kalitede saklanır. Yükledikten sonra topluluk beğenebilir, yorum yapabilir ve paylaşabilir.</p>
-        <form method="post" enctype="multipart/form-data" id="upForm" class="vstack gap-4">
+        <?php if($uploadsLocked): ?>
+          <div class="alert alert-warning" role="alert">Bu etkinlik için yüklemeler etkinlik tarihinden 10 gün sonra otomatik olarak kapanır. Yeni içerik ekleyemezsiniz.</div>
+        <?php endif; ?>
+        <form method="post" enctype="multipart/form-data" id="upForm" class="vstack gap-4" <?= $uploadsLocked ? 'data-locked="1"' : '' ?>>
           <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
           <input type="hidden" name="do" value="upload">
           <input type="hidden" name="t" value="<?=h($token)?>">
           <div class="row g-3">
             <div class="col-md-6">
               <label class="form-label">Adınız Soyadınız *</label>
-              <input class="form-control" name="guest_name" placeholder="Ör. Ayşe Yılmaz" required <?= !$token_ok?'disabled':'' ?>>
+              <input class="form-control" name="guest_name" placeholder="Ör. Ayşe Yılmaz" required <?= (!$token_ok || $uploadsLocked)?'disabled':'' ?>>
             </div>
             <div class="col-md-6">
               <label class="form-label">E-posta (opsiyonel)</label>
-              <input class="form-control" type="email" name="guest_email" placeholder="ornek@mail.com" <?= !$token_ok?'disabled':'' ?>>
+              <input class="form-control" type="email" name="guest_email" placeholder="ornek@mail.com" <?= (!$token_ok || $uploadsLocked)?'disabled':'' ?>>
               <div class="form-text">Düğün sonrasında size gönderilecek kullanıcı adı ve şifreniz için e-posta adresinizi paylaşabilirsiniz.</div>
             </div>
           </div>
           <div class="form-check">
-            <input class="form-check-input" type="checkbox" name="marketing_opt_in" value="1" id="marketingOpt" <?= !$token_ok?'disabled':'' ?>>
+            <input class="form-check-input" type="checkbox" name="marketing_opt_in" value="1" id="marketingOpt" <?= (!$token_ok || $uploadsLocked)?'disabled':'' ?>>
             <label class="form-check-label" for="marketingOpt">BİKARE’den kampanya ve yenilik bildirimleri almak istiyorum.</label>
           </div>
-          <div class="dropzone" id="drop" <?= !$token_ok?'data-disabled="1"':'' ?>>
+          <div class="dropzone" id="drop" <?= (!$token_ok || $uploadsLocked)?'data-disabled="1"':'' ?>>
             <p class="m-0">
               <strong>Dosyalarınızı buraya sürükleyin</strong> veya
               <label class="text-decoration-underline" style="cursor:pointer">cihazınızdan seçin
-                <input type="file" name="files[]" id="fileI" accept="<?=implode(',',array_keys(ALLOWED_MIMES))?>" multiple hidden <?= !$token_ok?'disabled':'' ?>>
+                <input type="file" name="files[]" id="fileI" accept="<?=implode(',',array_keys(ALLOWED_MIMES))?>" multiple hidden <?= (!$token_ok || $uploadsLocked)?'disabled':'' ?>>
               </label>
             </p>
             <div class="form-text mt-2">İzinli formatlar: jpg, png, webp, gif, mp4, mov, webm. Maksimum <?=round(MAX_UPLOAD_BYTES/1048576)?> MB / dosya.</div>
           </div>
           <div id="list" class="smallmuted"></div>
           <div class="d-grid d-sm-flex align-items-center gap-3">
-            <button class="btn btn-zs" <?= !$token_ok?'disabled':'' ?>>Anımı Paylaş</button>
+            <button class="btn btn-zs" <?= (!$token_ok || $uploadsLocked)?'disabled':'' ?>>Anımı Paylaş</button>
             <?php if(!$token_ok): ?><span class="text-danger small">Güvenlik anahtarınızın süresi doldu. Lütfen QR kodu yeniden okutun.</span><?php endif; ?>
+            <?php if($uploadsLocked): ?><span class="text-danger small">Yükleme süresi sona erdi.</span><?php endif; ?>
           </div>
         </form>
       </div>
@@ -838,37 +863,44 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
                 <?php endif; ?>
               </div>
               <div class="gallery-body">
-                <div class="smallmuted">Yorumlar (<span class="comment-count" data-upload="<?=$u['id']?>"><?=$commentCount?></span>)</div>
-                <div class="comment-list" data-upload="<?=$u['id']?>">
-                  <?php foreach($comments as $c): ?>
-                    <?=render_comment_block($c)?>
-                  <?php endforeach; ?>
+                <div class="comment-section collapsed" data-upload="<?=$u['id']?>">
+                  <div class="comment-header">
+                    <div class="comment-meta smallmuted">Yorumlar (<span class="comment-count" data-upload="<?=$u['id']?>"><?=$commentCount?></span>)</div>
+                    <button class="comment-toggle" type="button" data-upload="<?=$u['id']?>" data-label-collapsed="<?=h($commentCount>0 ? 'Yorumları Göster' : 'Yorum Yaz')?>" data-label-expanded="<?=h('Yorumları Gizle')?>"><?= $commentCount>0 ? 'Yorumları Göster' : 'Yorum Yaz' ?></button>
+                  </div>
+                  <div class="comment-body">
+                    <div class="comment-list" data-upload="<?=$u['id']?>">
+                      <?php foreach($comments as $c): ?>
+                        <?=render_comment_block($c)?>
+                      <?php endforeach; ?>
+                    </div>
+                    <?php if($profileVerified): ?>
+                      <form method="post" class="comment-form ajax-comment" data-upload="<?=$u['id']?>">
+                        <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+                        <input type="hidden" name="do" value="comment">
+                        <input type="hidden" name="upload_id" value="<?=$u['id']?>">
+                        <textarea class="form-control" name="comment_body" rows="2" placeholder="Güzel bir not bırak..." required></textarea>
+                        <div class="text-end mt-2"><button class="btn btn-sm btn-zs">Yorumu Gönder</button></div>
+                      </form>
+                      <?php
+                        $isOwnUpload = $u['profile_id'] && isset($guestProfile['id']) && (int)$u['profile_id'] === (int)$guestProfile['id'];
+                        $canMessageGuest = !$isOwnUpload && (int)$u['profile_id'] > 0;
+                        $targetName = $u['profile_display_name'] ?: ($u['guest_name'] ?: 'Misafir');
+                      ?>
+                      <?php if($canMessageGuest): ?>
+                        <button type="button" class="icon-btn message-open" data-target-profile="<?=$u['profile_id']?>" data-target-name="<?=h($targetName)?>" data-upload-id="<?=$u['id']?>">💬 Mesaj Gönder</button>
+                      <?php elseif($isOwnUpload): ?>
+                        <div class="comment smallmuted">Bu içerik size ait. Sohbet alanından diğer misafirlerle iletişim kurabilirsiniz.</div>
+                      <?php else: ?>
+                        <div class="comment smallmuted">Bu misafir henüz iletişim bilgisi paylaşmadı.</div>
+                      <?php endif; ?>
+                    <?php elseif($guestProfile && !$profileVerified): ?>
+                      <div class="comment">Yorum yapabilmek için e-posta adresinizi doğrulayın.</div>
+                    <?php else: ?>
+                      <div class="comment">Yorum yapmak için önce e-posta adresinizi paylaşarak içerik yükleyin.</div>
+                    <?php endif; ?>
+                  </div>
                 </div>
-                <?php if($profileVerified): ?>
-                  <form method="post" class="comment-form mt-3 ajax-comment" data-upload="<?=$u['id']?>">
-                    <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-                    <input type="hidden" name="do" value="comment">
-                    <input type="hidden" name="upload_id" value="<?=$u['id']?>">
-                    <textarea class="form-control" name="comment_body" rows="2" placeholder="Güzel bir not bırak..." required></textarea>
-                    <div class="text-end mt-2"><button class="btn btn-sm btn-zs">Yorumu Gönder</button></div>
-                  </form>
-                  <?php
-                    $isOwnUpload = $u['profile_id'] && isset($guestProfile['id']) && (int)$u['profile_id'] === (int)$guestProfile['id'];
-                    $canMessageGuest = !$isOwnUpload && (int)$u['profile_id'] > 0;
-                    $targetName = $u['profile_display_name'] ?: ($u['guest_name'] ?: 'Misafir');
-                  ?>
-                  <?php if($canMessageGuest): ?>
-                    <button type="button" class="icon-btn message-open mt-3" data-target-profile="<?=$u['profile_id']?>" data-target-name="<?=h($targetName)?>" data-upload-id="<?=$u['id']?>">💬 Mesaj Gönder</button>
-                  <?php elseif($isOwnUpload): ?>
-                    <div class="comment mt-3 smallmuted">Bu içerik size ait. Sohbet alanından diğer misafirlerle iletişim kurabilirsiniz.</div>
-                  <?php else: ?>
-                    <div class="comment mt-3 smallmuted">Bu misafir henüz iletişim bilgisi paylaşmadı.</div>
-                  <?php endif; ?>
-                <?php elseif($guestProfile && !$profileVerified): ?>
-                  <div class="comment mt-3">Yorum yapabilmek için e-posta adresinizi doğrulayın.</div>
-                <?php else: ?>
-                  <div class="comment mt-3">Yorum yapmak için önce e-posta adresinizi paylaşarak içerik yükleyin.</div>
-                <?php endif; ?>
               </div>
             </div>
             <?php endforeach; ?>
@@ -1054,15 +1086,28 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
 })();
 
 const dz=document.getElementById('drop'), fi=document.getElementById('fileI'), lst=document.getElementById('list'), fm=document.getElementById('upForm');
-if(dz && !dz.dataset.disabled){
+const uploadsLocked = fm?.dataset.locked === '1';
+if(dz && !dz.dataset.disabled && !uploadsLocked){
   ['dragenter','dragover'].forEach(ev=>dz.addEventListener(ev,e=>{e.preventDefault();dz.classList.add('drag');}));
   ['dragleave','drop'].forEach(ev=>dz.addEventListener(ev,e=>{e.preventDefault();dz.classList.remove('drag');}));
   dz.addEventListener('drop',e=>{ const fs=e.dataTransfer.files; if(fs&&fi){ fi.files=fs; renderList(fs); } });
 }
-fi?.addEventListener('change',e=>renderList(e.target.files));
+fi?.addEventListener('change',e=>{ if(uploadsLocked){ e.target.value=''; return; } renderList(e.target.files); });
 function renderList(files){ if(!files||!files.length){ lst.innerHTML=''; return; } let out='<ul class="m-0 ps-3">'; for(let i=0;i<files.length;i++){ const f=files[i]; out+=`<li>${esc(f.name)} — ${(f.size/1048576).toFixed(1)} MB</li>`; } lst.innerHTML=out+'</ul>'; }
 function esc(s){return s.replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[m]));}
-fm?.addEventListener('submit',e=>{ const name=fm.querySelector('[name=guest_name]').value.trim(); if(!name){e.preventDefault(); alert('Lütfen adınızı yazın.');} const fs=fi?.files||[]; if(!fs.length){e.preventDefault(); alert('Lütfen dosya seçin.');} });
+fm?.addEventListener('submit',e=>{ if(uploadsLocked){ e.preventDefault(); alert('Bu etkinlik için yüklemeler kapatıldı.'); return; } const name=fm.querySelector('[name=guest_name]').value.trim(); if(!name){e.preventDefault(); alert('Lütfen adınızı yazın.');} const fs=fi?.files||[]; if(!fs.length){e.preventDefault(); alert('Lütfen dosya seçin.');} });
+
+document.querySelectorAll('.comment-section').forEach(section=>{
+  const toggle=section.querySelector('.comment-toggle');
+  if(!toggle) return;
+  const collapsedLabel=toggle.dataset.labelCollapsed || 'Yorumları Göster';
+  const expandedLabel=toggle.dataset.labelExpanded || 'Yorumları Gizle';
+  toggle.textContent=collapsedLabel;
+  toggle.addEventListener('click',()=>{
+    const isCollapsed=section.classList.toggle('collapsed');
+    toggle.textContent=isCollapsed?collapsedLabel:expandedLabel;
+  });
+});
 
 const csrfToken='<?=h(csrf_token())?>';
 const shareButtons=document.querySelectorAll('.share-btn');
@@ -1148,13 +1193,21 @@ document.querySelectorAll('.ajax-comment').forEach(form=>{
     submit?.setAttribute('disabled','disabled');
     try{
       const data=await sendAjax(form);
-      const container=form.closest('.gallery-body');
-      const list=container?.querySelector('.comment-list');
+      const section=form.closest('.comment-section');
+      const list=section?.querySelector('.comment-list');
       if(list && data.html){ list.insertAdjacentHTML('beforeend', data.html); }
-      const countEl=container?.querySelector('.comment-count');
+      const countEl=section?.querySelector('.comment-count');
       if(countEl && typeof data.count!=='undefined'){ countEl.textContent=data.count; }
       const textarea=form.querySelector('textarea');
       if(textarea) textarea.value='';
+      if(section){
+        section.classList.remove('collapsed');
+        const toggle=section.querySelector('.comment-toggle');
+        if(toggle){
+          const expandedLabel=toggle.dataset.labelExpanded || 'Yorumları Gizle';
+          toggle.textContent=expandedLabel;
+        }
+      }
       showToast('Yorumun paylaşıldı!');
     }catch(err){
       showToast(err.message || 'Yorum gönderilemedi.');

--- a/public/upload.php
+++ b/public/upload.php
@@ -611,17 +611,18 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
 .dropzone.drag{ border-color:var(--zs); background:rgba(14,165,181,.08); }
 .form-text{ color:var(--muted); }
 .gallery-card{ padding:28px; }
-.gallery-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(280px,1fr)); gap:28px; }
-@media(min-width:768px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(320px,1fr)); } }
-@media(min-width:1400px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(360px,1fr)); } }
-.gallery-item{ display:flex; flex-direction:column; border-radius:26px; overflow:hidden; background:#ffffff; border:1px solid rgba(14,165,181,.22); box-shadow:0 24px 48px rgba(14,165,181,.12); color:var(--ink); position:relative; transition:transform .25s ease, box-shadow .25s ease; }
+.gallery-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(300px,1fr)); gap:32px; align-items:stretch; }
+@media(min-width:992px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(360px,1fr)); } }
+@media(min-width:1400px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(420px,1fr)); } }
+@media(min-width:1680px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(460px,1fr)); } }
+.gallery-item{ display:flex; flex-direction:column; border-radius:26px; overflow:hidden; background:#ffffff; border:1px solid rgba(14,165,181,.24); box-shadow:0 26px 52px rgba(14,165,181,.14); color:var(--ink); position:relative; transition:transform .25s ease, box-shadow .25s ease; height:100%; }
 .gallery-item:hover{ transform:translateY(-6px); box-shadow:0 28px 60px rgba(14,165,181,.18); }
-.gallery-media{ position:relative; width:100%; background:#f1fbfc; display:flex; align-items:center; justify-content:center; padding:10px; }
-.gallery-media img,.gallery-media video{ width:100%; height:auto; max-height:380px; display:block; object-fit:contain; border-radius:18px; box-shadow:0 16px 34px rgba(14,165,181,.15); }
+.gallery-media{ position:relative; width:100%; background:#f1fbfc; display:flex; align-items:center; justify-content:center; padding:16px 18px 0; }
+.gallery-media img,.gallery-media video{ width:100%; height:auto; max-height:360px; display:block; object-fit:contain; border-radius:22px; box-shadow:0 18px 36px rgba(14,165,181,.16); }
 .gallery-header{ display:flex; align-items:center; gap:14px; padding:18px 22px; background:#f3fbfc; border-bottom:1px solid rgba(14,165,181,.16); }
 .gallery-author{ font-weight:700; font-size:15px; color:#0f172a; letter-spacing:.02em; }
 .avatar{ width:46px; height:46px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:700; letter-spacing:.5px; box-shadow:0 8px 18px rgba(14,165,181,.18); border:2px solid rgba(14,165,181,.25); }
-.gallery-actions{ display:flex; align-items:center; justify-content:space-between; padding:14px 22px 12px; gap:18px; background:#f7fdfd; border-top:1px solid rgba(14,165,181,.16); }
+.gallery-actions{ display:flex; align-items:center; justify-content:space-between; padding:18px 24px 16px; gap:18px; background:#f7fdfd; border-top:1px solid rgba(14,165,181,.16); }
 .action-buttons{ display:flex; align-items:center; gap:12px; }
 .icon-btn{ border:none; background:rgba(14,165,181,.12); border-radius:999px; padding:9px 18px; display:flex; align-items:center; gap:8px; font-weight:600; color:#0b5f6c; cursor:pointer; transition:background .2s ease, color .2s ease; }
 .icon-btn span{ display:inline-flex; align-items:center; }
@@ -632,7 +633,8 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
 .gallery-actions .btn{ border-radius:999px; border:1px solid rgba(14,165,181,.35); color:#0a4d58; background:transparent; font-weight:600; }
 .gallery-actions .btn:hover{ background:#0ea5b5; color:#fff; }
 .gallery-meta{ font-size:13px; color:#537082; }
-.gallery-body{ padding:16px 22px 24px; background:#ffffff; color:var(--ink); }
+.gallery-body{ padding:20px 24px 24px; background:#ffffff; color:var(--ink); display:flex; flex-direction:column; gap:18px; flex:1; }
+.gallery-body .comment-section{ margin-top:auto; }
 .gallery-body p{ color:#365562; }
 .gallery-body .smallmuted{ color:#57758a; }
 .comment{ padding:12px 16px; border-radius:18px; background:rgba(14,165,181,.12); margin-top:0; color:#0a4550; }
@@ -670,10 +672,15 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
 .conversation-bubble.mine{ margin-left:auto; background:var(--zs); color:#fff; box-shadow:0 18px 36px rgba(14,165,181,.22); }
 .conversation-bubble .meta{ font-size:11px; opacity:.8; margin-bottom:4px; }
 .conversation-bubble.mine .meta{ color:rgba(255,255,255,.8); }
+.bubble-placeholder{ display:inline-flex; align-items:center; gap:12px; background:rgba(14,165,181,.12); color:#0b5f6c; padding:14px 18px; border-radius:18px; font-weight:600; }
+.bubble-placeholder::before{ content:""; width:16px; height:16px; border:3px solid rgba(14,165,181,.35); border-top-color:var(--zs); border-radius:50%; animation:spin 1s linear infinite; }
+.bubble-placeholder.error{ background:rgba(239,68,68,.12); color:#b91c1c; }
+.bubble-placeholder.error::before{ border-color:rgba(239,68,68,.3); border-top-color:#ef4444; }
+.bubble-placeholder.empty::before{ display:none; }
+@keyframes spin{ from{ transform:rotate(0deg);} to{ transform:rotate(360deg);} }
 .conversation-footer{ display:flex; gap:12px; align-items:flex-end; padding-top:16px; }
 .conversation-footer textarea{ flex:1; border-radius:18px; resize:none; min-height:80px; }
 .conversation-footer button{ border:none; background:var(--zs); color:#fff; border-radius:16px; padding:10px 18px; font-weight:600; }
-.bubble-loading{ text-align:center; font-size:13px; color:var(--muted); padding:14px 0; }
 .profile-card{ padding:28px; }
 .profile-card h5{ font-weight:700; }
 .chat-card{ padding:28px; }
@@ -1065,7 +1072,7 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
       </div>
       <div class="modal-body" style="padding:0 28px 28px;">
         <div class="conversation-stream" id="conversationStream">
-          <div class="bubble-loading">Bir misafir seçerek sohbeti başlatabilirsiniz.</div>
+          <div class="bubble-placeholder empty">Bir misafir seçerek sohbeti başlatabilirsiniz.</div>
         </div>
         <form class="conversation-footer" id="conversationForm" autocomplete="off">
           <textarea class="form-control" name="message_body" placeholder="Kutlama mesajınızı yazın" required></textarea>
@@ -1145,10 +1152,10 @@ async function postFormData(fd){
   let data=null;
   try{ data=await response.json(); }catch(err){}
   if(!response.ok || !data){
-    throw new Error(data && data.error ? data.error : 'İşlem tamamlanamadı.');
+    throw new Error(data && data.error ? data.error : 'Bir sorun oluştu. Lütfen tekrar deneyin.');
   }
   if(data.success===false){
-    throw new Error(data.error || 'İşlem tamamlanamadı.');
+    throw new Error(data.error || 'Bir sorun oluştu. Lütfen tekrar deneyin.');
   }
   return data;
 }
@@ -1177,7 +1184,7 @@ document.querySelectorAll('.ajax-like').forEach(form=>{
         if(count && typeof data.likes!=='undefined') count.textContent=data.likes;
       }
     }catch(err){
-      showToast(err.message || 'İşlem tamamlanamadı.');
+      showToast(err.message || 'Bir sorun oluştu. Lütfen tekrar deneyin.');
     }finally{
       btn?.removeAttribute('disabled');
       delete form.dataset.loading;
@@ -1224,9 +1231,16 @@ function handleFeedback(form, message, isError=false){
   feedback.hidden=false;
   feedback.classList.toggle('error',!!isError);
 }
-function setConversationState(message){
+function setConversationState(message, variant='info'){
   if(!conversationStream) return;
-  conversationStream.innerHTML=`<div class="bubble-loading">${esc(message)}</div>`;
+  const el=document.createElement('div');
+  const classes=['bubble-placeholder'];
+  if(variant==='error'){ classes.push('error'); }
+  if(variant==='empty'){ classes.push('empty'); }
+  el.className=classes.join(' ');
+  el.textContent=message;
+  conversationStream.innerHTML='';
+  conversationStream.appendChild(el);
 }
 function buildConversationBubble(entry){
   const bubble=document.createElement('div');
@@ -1251,7 +1265,7 @@ function renderConversation(entries){
   if(!conversationStream) return;
   conversationStream.innerHTML='';
   if(!entries || !entries.length){
-    setConversationState('Henüz mesaj yok. İlk mesajı siz gönderebilirsiniz.');
+    setConversationState('Henüz mesaj yok. İlk mesajı siz gönderebilirsiniz.', 'empty');
     return;
   }
   entries.forEach(entry=>{
@@ -1261,7 +1275,7 @@ function renderConversation(entries){
 }
 function appendConversationEntry(entry){
   if(!conversationStream) return;
-  const placeholder=conversationStream.querySelector('.bubble-loading');
+  const placeholder=conversationStream.querySelector('.bubble-placeholder');
   if(placeholder){
     conversationStream.innerHTML='';
   }
@@ -1294,7 +1308,7 @@ async function loadConversation(recipientId){
     const data=await requestAction('conversation',{target_profile_id:recipientId});
     renderConversation(data.messages || []);
   }catch(err){
-    setConversationState(err.message || 'Mesajlar getirilemedi.');
+    setConversationState(err.message || 'Mesajlar getirilemedi.', 'error');
   }
 }
 
@@ -1349,7 +1363,7 @@ conversationForm?.addEventListener('submit',async e=>{
 
 messageModalEl?.addEventListener('hidden.bs.modal',()=>{
   activeRecipient=null;
-  setConversationState('Bir misafir seçerek sohbeti başlatabilirsiniz.');
+  setConversationState('Bir misafir seçerek sohbeti başlatabilirsiniz.', 'empty');
 });
 document.querySelectorAll('.ajax-host-note').forEach(form=>{
   form.addEventListener('submit',async e=>{

--- a/public/upload.php
+++ b/public/upload.php
@@ -601,102 +601,314 @@ $chatMessages = array_reverse($st->fetchAll());
 <title><?=h($ev['title'])?> — Misafir Sosyal Alanı</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <style>
-:root{ --zs:<?=h($PRIMARY)?>; --zs-soft:<?=h($ACCENT)?>; --ink:#0f172a; --muted:#64748b }
-body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter','Helvetica Neue',Arial,sans-serif; color:var(--ink); }
-.card-lite{ border:1px solid rgba(148,163,184,.25); border-radius:22px; background:#fff; box-shadow:0 18px 45px rgba(15,23,42,.08); }
-.btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:999px; padding:.65rem 1.2rem; font-weight:600; }
-.btn-zs:disabled{ background:rgba(148,163,184,.6); }
-.btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:999px; font-weight:600; }
-.hero{ background:#fff; border-radius:26px; padding:32px; position:relative; overflow:hidden; }
-.hero::after{ content:""; position:absolute; inset:auto -40px -120px auto; width:320px; height:320px; background:radial-gradient(circle at center, rgba(14,165,181,.35), transparent 70%); }
-.hero-badge{ display:inline-flex; align-items:center; gap:8px; background:rgba(14,165,181,.12); color:var(--zs); padding:6px 14px; border-radius:999px; font-size:14px; font-weight:600; }
-.page-grid{ display:grid; gap:24px; margin-top:32px; }
-@media(min-width:992px){ .page-grid{ grid-template-columns:2fr 1fr; } }
+:root{
+  --zs:<?=h($PRIMARY)?>;
+  --zs-soft:<?=h($ACCENT)?>;
+  --ink:#0f172a;
+  --muted:#5f6b7e;
+  --line:rgba(15,23,42,.08);
+  --surface:#ffffff;
+}
+body{
+  background:#f5f9fa;
+  font-family:'Inter','Helvetica Neue',Arial,sans-serif;
+  color:var(--ink);
+}
+.page-wrap{ max-width:1200px; margin:0 auto; }
+.card-lite{
+  border:1px solid var(--line);
+  border-radius:18px;
+  background:var(--surface);
+  box-shadow:0 12px 28px rgba(15,23,42,.04);
+}
+.btn-zs{
+  background:var(--zs);
+  border:none;
+  color:#fff;
+  border-radius:12px;
+  padding:.6rem 1.1rem;
+  font-weight:600;
+  transition:background .2s ease, box-shadow .2s ease;
+}
+.btn-zs:disabled{ background:rgba(148,163,184,.5); }
+.btn-zs:not(:disabled):hover{ background:#0b8d9b; color:#fff; box-shadow:0 10px 18px rgba(14,165,181,.18); }
+.btn-zs-outline{
+  background:transparent;
+  border:1px solid var(--zs);
+  color:var(--zs);
+  border-radius:12px;
+  font-weight:600;
+  padding:.55rem 1.1rem;
+  transition:all .2s ease;
+}
+.btn-zs-outline:hover{ background:var(--zs); color:#fff; }
+.hero{
+  background:var(--surface);
+  border:1px solid var(--line);
+  border-radius:20px;
+  padding:32px;
+}
+.hero-badge{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  background:rgba(14,165,181,.14);
+  color:var(--zs);
+  padding:6px 14px;
+  border-radius:999px;
+  font-size:14px;
+  font-weight:600;
+}
+.page-grid{ display:grid; gap:28px; margin-top:32px; }
+@media (min-width:992px){ .page-grid{ grid-template-columns:2fr 1fr; } }
 .upload-card{ padding:28px; }
 .upload-card h5{ font-weight:700; }
-.dropzone{ border:2px dashed rgba(148,163,184,.45); border-radius:24px; padding:36px; text-align:center; background:rgba(241,245,249,.6); transition:.2s; }
-.dropzone.drag{ border-color:var(--zs); background:rgba(14,165,181,.08); }
+.dropzone{
+  border:2px dashed rgba(15,23,42,.12);
+  border-radius:18px;
+  padding:32px;
+  text-align:center;
+  background:#f2fafb;
+  transition:all .2s ease;
+}
+.dropzone.drag{ border-color:var(--zs); background:rgba(14,165,181,.12); }
 .form-text{ color:var(--muted); }
 .gallery-card{ padding:28px; }
-.gallery-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(300px,1fr)); gap:32px; align-items:stretch; }
-@media(min-width:992px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(360px,1fr)); } }
-@media(min-width:1400px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(420px,1fr)); } }
-@media(min-width:1680px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(460px,1fr)); } }
-.gallery-item{ display:flex; flex-direction:column; border-radius:26px; overflow:hidden; background:#ffffff; border:1px solid rgba(14,165,181,.24); box-shadow:0 26px 52px rgba(14,165,181,.14); color:var(--ink); position:relative; transition:transform .25s ease, box-shadow .25s ease; height:100%; }
-.gallery-item:hover{ transform:translateY(-6px); box-shadow:0 28px 60px rgba(14,165,181,.18); }
-.gallery-media{ position:relative; width:100%; background:#f1fbfc; display:flex; align-items:center; justify-content:center; padding:16px 18px 0; }
-.gallery-media img,.gallery-media video{ width:100%; height:auto; max-height:360px; display:block; object-fit:contain; border-radius:22px; box-shadow:0 18px 36px rgba(14,165,181,.16); }
-.gallery-header{ display:flex; align-items:center; gap:14px; padding:18px 22px; background:#f3fbfc; border-bottom:1px solid rgba(14,165,181,.16); }
-.gallery-author{ font-weight:700; font-size:15px; color:#0f172a; letter-spacing:.02em; }
-.avatar{ width:46px; height:46px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:700; letter-spacing:.5px; box-shadow:0 8px 18px rgba(14,165,181,.18); border:2px solid rgba(14,165,181,.25); }
-.gallery-actions{ display:flex; align-items:center; justify-content:space-between; padding:18px 24px 16px; gap:18px; background:#f7fdfd; border-top:1px solid rgba(14,165,181,.16); }
-.action-buttons{ display:flex; align-items:center; gap:12px; }
-.icon-btn{ border:none; background:rgba(14,165,181,.12); border-radius:999px; padding:9px 18px; display:flex; align-items:center; gap:8px; font-weight:600; color:#0b5f6c; cursor:pointer; transition:background .2s ease, color .2s ease; }
+.gallery-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fill,minmax(280px,1fr));
+  gap:28px;
+  align-items:stretch;
+}
+@media (min-width:1200px){ .gallery-grid{ grid-template-columns:repeat(auto-fill,minmax(340px,1fr)); } }
+.gallery-item{
+  display:flex;
+  flex-direction:column;
+  border-radius:18px;
+  overflow:hidden;
+  background:var(--surface);
+  border:1px solid var(--line);
+  box-shadow:0 10px 28px rgba(15,23,42,.05);
+  transition:transform .2s ease, box-shadow .2s ease;
+  height:100%;
+}
+.gallery-item:hover{ transform:translateY(-4px); box-shadow:0 16px 34px rgba(15,23,42,.08); }
+.gallery-media{
+  position:relative;
+  width:100%;
+  background:#edf7f8;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:18px 18px 0;
+}
+.gallery-media img,
+.gallery-media video{
+  width:100%;
+  height:auto;
+  max-height:360px;
+  display:block;
+  object-fit:contain;
+  border-radius:14px;
+  box-shadow:none;
+}
+.gallery-header{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  padding:18px 22px;
+  background:#f7fbfc;
+  border-bottom:1px solid var(--line);
+}
+.gallery-author{ font-weight:700; font-size:15px; color:#0f172a; letter-spacing:.01em; }
+.avatar{
+  width:44px;
+  height:44px;
+  border-radius:50%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:700;
+  letter-spacing:.4px;
+  border:2px solid rgba(14,165,181,.18);
+  box-shadow:none;
+}
+.gallery-actions{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:16px 22px 14px;
+  gap:16px;
+  background:#fff;
+  border-top:1px solid var(--line);
+}
+.action-buttons{ display:flex; align-items:center; gap:10px; }
+.icon-btn{
+  border:none;
+  background:#eef6f7;
+  border-radius:999px;
+  padding:8px 16px;
+  display:flex;
+  align-items:center;
+  gap:8px;
+  font-weight:600;
+  color:#0a5160;
+  cursor:pointer;
+  transition:background .2s ease, color .2s ease;
+}
 .icon-btn span{ display:inline-flex; align-items:center; }
 .icon-btn .like-count{ font-variant-numeric:tabular-nums; }
-.icon-btn.active{ background:#0ea5b5; color:#fff; }
-.icon-btn:hover{ background:rgba(14,165,181,.2); color:#053f49; }
-.icon-btn:disabled{ cursor:not-allowed; opacity:.55; }
-.gallery-actions .btn{ border-radius:999px; border:1px solid rgba(14,165,181,.35); color:#0a4d58; background:transparent; font-weight:600; }
-.gallery-actions .btn:hover{ background:#0ea5b5; color:#fff; }
-.gallery-meta{ font-size:13px; color:#537082; }
-.gallery-body{ padding:20px 24px 24px; background:#ffffff; color:var(--ink); display:flex; flex-direction:column; gap:18px; flex:1; }
+.icon-btn.active{ background:var(--zs); color:#fff; }
+.icon-btn:not(.active):hover{ background:rgba(14,165,181,.18); color:#064752; }
+.icon-btn:disabled{ cursor:not-allowed; opacity:.6; }
+.gallery-actions .btn{
+  border-radius:12px;
+  border:1px solid rgba(14,165,181,.28);
+  color:#0a4d58;
+  background:transparent;
+  font-weight:600;
+  padding:.5rem 1rem;
+}
+.gallery-actions .btn:hover{ background:var(--zs); color:#fff; }
+.gallery-meta{ font-size:13px; color:#5f7a8a; }
+.gallery-body{
+  padding:20px 22px 24px;
+  background:var(--surface);
+  color:var(--ink);
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+  flex:1;
+}
 .gallery-body .comment-section{ margin-top:auto; }
-.gallery-body p{ color:#365562; }
-.gallery-body .smallmuted{ color:#57758a; }
-.comment{ padding:12px 16px; border-radius:18px; background:rgba(14,165,181,.12); margin-top:0; color:#0a4550; }
+.gallery-body p{ color:#2f4f5d; }
+.gallery-body .smallmuted{ color:#5f7a8a; }
+.comment{
+  padding:12px 14px;
+  border-radius:14px;
+  background:#edf7f8;
+  margin-top:0;
+  color:#0a4550;
+}
 .gallery-item .comment strong{ display:block; font-size:13px; color:#0a4550; }
 .gallery-item .comment p{ margin:6px 0 0; font-size:13px; color:#0b5f6c; }
-.gallery-item .comment .smallmuted{ color:#57758a; }
-.gallery-item .comment.smallmuted{ color:#57758a; }
-.comment-form textarea{ resize:vertical; border-radius:16px; }
-.gallery-item .comment-form textarea{ background:#f7fdfd; border-color:rgba(14,165,181,.2); color:var(--ink); }
-.gallery-item .comment-form textarea::placeholder{ color:#7fa7b3; }
-.gallery-item .comment-form textarea:focus{ background:#ecfcff; border-color:rgba(14,165,181,.5); box-shadow:0 0 0 .25rem rgba(14,165,181,.25); }
+.gallery-item .comment .smallmuted{ color:#5f7a8a; }
+.comment-form textarea{ resize:vertical; border-radius:14px; }
+.gallery-item .comment-form textarea{ background:#f4fbfc; border-color:rgba(14,165,181,.25); color:var(--ink); }
+.gallery-item .comment-form textarea::placeholder{ color:#86aab2; }
+.gallery-item .comment-form textarea:focus{ background:#ecfbfd; border-color:rgba(14,165,181,.4); box-shadow:0 0 0 .25rem rgba(14,165,181,.18); }
 .comment-form{ display:flex; flex-direction:column; gap:10px; }
 .comment-form .btn{ align-self:flex-end; }
-.comment-section{ margin-top:16px; padding-top:12px; border-top:1px solid rgba(14,165,181,.15); }
+.comment-section{ margin-top:16px; padding-top:12px; border-top:1px solid var(--line); }
 .comment-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; }
-.comment-toggle{ border:none; background:rgba(14,165,181,.12); color:#0b5f6c; font-weight:600; padding:6px 14px; border-radius:999px; cursor:pointer; transition:background .2s ease, color .2s ease; }
-.comment-toggle:hover{ background:rgba(14,165,181,.2); color:#053f49; }
-.comment-body{ margin-top:14px; display:flex; flex-direction:column; gap:14px; }
+.comment-toggle{
+  border:none;
+  background:#eef6f7;
+  color:#0a5160;
+  font-weight:600;
+  padding:6px 14px;
+  border-radius:999px;
+  cursor:pointer;
+  transition:background .2s ease, color .2s ease;
+}
+.comment-toggle:hover{ background:rgba(14,165,181,.18); color:#064752; }
+.comment-body{ margin-top:12px; display:flex; flex-direction:column; gap:12px; }
 .comment-section.collapsed .comment-body{ display:none; }
 .comment-list{ display:flex; flex-direction:column; gap:10px; }
 .comment-body .icon-btn{ align-self:flex-start; }
 .note-card textarea{ min-height:140px; }
 .form-feedback{ color:var(--zs); font-weight:600; }
 .form-feedback.error{ color:#ef4444; }
-.badge-soft{ background:rgba(14,165,181,.12); color:var(--zs); border-radius:999px; padding:4px 12px; font-size:12px; font-weight:600; }
+.badge-soft{
+  background:rgba(14,165,181,.16);
+  color:#0a5160;
+  border-radius:999px;
+  padding:4px 12px;
+  font-size:12px;
+  font-weight:600;
+}
 .guest-directory{ max-height:360px; overflow:auto; display:flex; flex-direction:column; gap:10px; }
-.guest-card{ display:flex; align-items:center; justify-content:space-between; gap:12px; padding:12px 16px; border-radius:18px; border:1px solid rgba(148,163,184,.25); background:rgba(248,250,252,.8); transition:background .2s ease, transform .2s ease; text-align:left; }
-.guest-card:hover{ background:#fff; transform:translateY(-2px); box-shadow:0 14px 28px rgba(15,23,42,.08); }
+.guest-card{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  padding:12px 16px;
+  border-radius:14px;
+  border:1px solid var(--line);
+  background:#f7fbfc;
+  transition:all .2s ease;
+  text-align:left;
+}
+.guest-card:hover{ background:#fff; transform:translateY(-3px); box-shadow:0 12px 28px rgba(15,23,42,.07); }
 .guest-card .guest-info{ display:flex; align-items:center; gap:12px; }
 .guest-card .guest-meta{ font-size:12px; color:var(--muted); }
-.guest-card button{ border:none; background:var(--zs); color:#fff; border-radius:999px; padding:6px 14px; font-weight:600; }
-.message-pill{ display:flex; align-items:center; gap:8px; font-size:12px; color:var(--muted); }
+.guest-card .message-pill{
+  display:flex;
+  align-items:center;
+  gap:6px;
+  font-size:12px;
+  color:#0a5160;
+  font-weight:600;
+}
 .conversation-stream{ max-height:420px; overflow:auto; display:flex; flex-direction:column; gap:14px; padding-right:6px; }
-.conversation-bubble{ max-width:78%; padding:14px 18px; border-radius:20px; background:#f1f5f9; color:var(--ink); position:relative; box-shadow:0 12px 24px rgba(15,23,42,.08); }
-.conversation-bubble.mine{ margin-left:auto; background:var(--zs); color:#fff; box-shadow:0 18px 36px rgba(14,165,181,.22); }
+.conversation-bubble{
+  max-width:78%;
+  padding:14px 18px;
+  border-radius:18px;
+  background:#f4fbfc;
+  color:var(--ink);
+  position:relative;
+  box-shadow:0 10px 20px rgba(15,23,42,.05);
+}
+.conversation-bubble.mine{ margin-left:auto; background:var(--zs); color:#fff; box-shadow:0 12px 26px rgba(14,165,181,.22); }
 .conversation-bubble .meta{ font-size:11px; opacity:.8; margin-bottom:4px; }
-.conversation-bubble.mine .meta{ color:rgba(255,255,255,.8); }
-.bubble-placeholder{ display:inline-flex; align-items:center; gap:12px; background:rgba(14,165,181,.12); color:#0b5f6c; padding:14px 18px; border-radius:18px; font-weight:600; }
-.bubble-placeholder::before{ content:""; width:16px; height:16px; border:3px solid rgba(14,165,181,.35); border-top-color:var(--zs); border-radius:50%; animation:spin 1s linear infinite; }
+.conversation-bubble.mine .meta{ color:rgba(255,255,255,.75); }
+.bubble-placeholder{
+  display:inline-flex;
+  align-items:center;
+  gap:12px;
+  background:#eef6f7;
+  color:#0a5160;
+  padding:14px 18px;
+  border-radius:16px;
+  font-weight:600;
+}
+.bubble-placeholder::before{
+  content:"";
+  width:16px;
+  height:16px;
+  border:3px solid rgba(14,165,181,.28);
+  border-top-color:var(--zs);
+  border-radius:50%;
+  animation:spin 1s linear infinite;
+}
 .bubble-placeholder.error{ background:rgba(239,68,68,.12); color:#b91c1c; }
-.bubble-placeholder.error::before{ border-color:rgba(239,68,68,.3); border-top-color:#ef4444; }
+.bubble-placeholder.error::before{ border-color:rgba(239,68,68,.24); border-top-color:#ef4444; }
 .bubble-placeholder.empty::before{ display:none; }
 @keyframes spin{ from{ transform:rotate(0deg);} to{ transform:rotate(360deg);} }
 .conversation-footer{ display:flex; gap:12px; align-items:flex-end; padding-top:16px; }
-.conversation-footer textarea{ flex:1; border-radius:18px; resize:none; min-height:80px; }
-.conversation-footer button{ border:none; background:var(--zs); color:#fff; border-radius:16px; padding:10px 18px; font-weight:600; }
+.conversation-footer textarea{ flex:1; border-radius:14px; resize:none; min-height:80px; }
+.conversation-footer button{
+  border:none;
+  background:var(--zs);
+  color:#fff;
+  border-radius:12px;
+  padding:10px 18px;
+  font-weight:600;
+  transition:background .2s ease;
+}
+.conversation-footer button:hover{ background:#0b8d9b; }
 .profile-card{ padding:28px; }
 .profile-card h5{ font-weight:700; }
+.message-card{ padding:28px; }
 .chat-card{ padding:28px; }
 .chat-stream{ max-height:420px; overflow:auto; display:flex; flex-direction:column; gap:12px; }
-.chat-bubble{ padding:14px 18px; border-radius:18px; background:rgba(241,245,249,.8); }
-.chat-author{ font-weight:600; font-size:14px; color:var(--ink); }
+.chat-bubble{ padding:14px 18px; border-radius:16px; background:#f4fbfc; color:#0f172a; }
+.chat-author{ font-weight:600; font-size:14px; color:#0f172a; }
 .chat-time{ font-size:12px; color:var(--muted); }
-.preview-shell{ width:min(100%,980px); margin:0 auto; }
-.preview-stage{ position:relative; width:100%; border:1px dashed #cbd5e1; border-radius:20px; background:#fff; overflow:hidden; }
+.preview-shell{ width:min(100%,900px); margin:0 auto; }
+.preview-stage{ position:relative; width:100%; border:1px dashed rgba(15,23,42,.18); border-radius:18px; background:#fff; overflow:hidden; }
 .stage-scale{ position:absolute; left:0; top:0; width:960px; height:540px; transform-origin:top left; transform:scale(var(--s,1)); }
 .preview-canvas{ position:absolute; inset:0; background:linear-gradient(180deg,var(--zs-soft),#fff); }
 .pv-title{ position:absolute; font-size:28px; font-weight:800; color:#111; }
@@ -704,12 +916,26 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
 .pv-prompt{ position:absolute; color:#0f172a; font-size:16px; }
 .sticker{ position:absolute; user-select:none; pointer-events:none; }
 .smallmuted{ color:var(--muted); font-size:13px; }
-.share-toast{ position:fixed; left:50%; bottom:32px; transform:translateX(-50%); background:#0ea5b5; color:#fff; padding:12px 20px; border-radius:999px; font-weight:600; box-shadow:0 18px 30px rgba(14,165,181,.3); opacity:0; transition:.4s; pointer-events:none; }
+.share-toast{
+  position:fixed;
+  left:50%;
+  bottom:32px;
+  transform:translateX(-50%);
+  background:var(--zs);
+  color:#fff;
+  padding:10px 18px;
+  border-radius:999px;
+  font-weight:600;
+  box-shadow:0 12px 24px rgba(14,165,181,.2);
+  opacity:0;
+  transition:.4s;
+  pointer-events:none;
+}
 .share-toast.show{ opacity:1; }
 </style>
 </head>
 <body>
-<div class="container py-4">
+<div class="container-lg page-wrap py-5 px-3 px-lg-4">
   <?php flash_box(); ?>
   <section class="hero mb-4">
     <div class="d-flex flex-column flex-lg-row align-items-start align-items-lg-center justify-content-between gap-3">

--- a/public/upload.php
+++ b/public/upload.php
@@ -74,6 +74,12 @@ $pPos = isset($layoutArr['prompt'])   ? $layoutArr['prompt']   : array('x'=>24,'
 
 $token_ok = token_valid($event_id, $token);
 $guestProfile = guest_profile_current($event_id);
+if ($guestProfile && (int)$guestProfile['is_verified'] === 1) {
+  if ($token === '' || !$token_ok) {
+    $token = make_token($event_id, current_slot());
+    $token_ok = true;
+  }
+}
 
 if($_SERVER['REQUEST_METHOD']==='POST'){
   csrf_or_die();

--- a/public/upload.php
+++ b/public/upload.php
@@ -1,12 +1,13 @@
 <?php
-// public/upload.php — Misafir yükleme + galeri + Çift panelle birebir 960x540 ölçekli önizleme
 require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
+require_once __DIR__.'/../includes/guests.php';
 
 if (session_status() === PHP_SESSION_NONE) session_start();
 
-/* ---- CSRF (shim) ---- */
+install_schema();
+
 if (!function_exists('csrf_token')) {
   function csrf_token(){ if(empty($_SESSION['csrf'])) $_SESSION['csrf']=bin2hex(random_bytes(16)); return $_SESSION['csrf']; }
 }
@@ -14,7 +15,6 @@ if (!function_exists('csrf_or_die')) {
   function csrf_or_die(){ $t=$_POST['csrf']??$_POST['_csrf']??''; if(!$t || !hash_equals($_SESSION['csrf']??'', $t)){ http_response_code(400); exit('CSRF'); } }
 }
 
-/* ---- Yardımcılar ---- */
 function client_ip(){
   if(isset($_SERVER['HTTP_CLIENT_IP'])) return $_SERVER['HTTP_CLIENT_IP'];
   if(isset($_SERVER['HTTP_X_FORWARDED_FOR'])) return explode(',', $_SERVER['HTTP_X_FORWARDED_FOR'])[0];
@@ -23,12 +23,10 @@ function client_ip(){
 function is_image_mime($m){ return (bool)preg_match('~^image/(jpeg|png|webp|gif)$~i',$m); }
 function is_video_mime($m){ return (bool)preg_match('~^video/(mp4|quicktime|webm)$~i',$m); }
 
-/* ---- Parametreler ---- */
 $event_id = (int)($_GET['event'] ?? 0);
 $token    = trim($_GET['t'] ?? '');
 if ($event_id <= 0){ http_response_code(400); exit('Geçersiz istek'); }
 
-/* ---- Etkinlik satırı ---- */
 $st = pdo()->prepare("SELECT * FROM events WHERE id=? LIMIT 1");
 $st->execute([$event_id]);
 $ev = $st->fetch();
@@ -43,7 +41,6 @@ $ACCENT   = $ev['theme_accent']  ?: '#e0f7fb';
 $CAN_VIEW = (int)$ev['allow_guest_view']===1;
 $CAN_DOWN = (int)$ev['allow_guest_download']===1;
 
-/* ---- Çift panelden gelen layout/sticker ---- */
 $layout   = $ev['layout_json'] ?: '{"title":{"x":24,"y":24},"subtitle":{"x":24,"y":60},"prompt":{"x":24,"y":396}}';
 $stickers = $ev['stickers_json'] ?: '[]';
 $layoutArr   = json_decode($layout,true);
@@ -56,10 +53,173 @@ $tPos = isset($layoutArr['title'])    ? $layoutArr['title']    : array('x'=>24,'
 $sPos = isset($layoutArr['subtitle']) ? $layoutArr['subtitle'] : array('x'=>24,'y'=>60);
 $pPos = isset($layoutArr['prompt'])   ? $layoutArr['prompt']   : array('x'=>24,'y'=>396);
 
-/* ---- Dinamik QR token doğrulama ---- */
+$profile = guest_profile_current($event_id);
 $token_ok = token_valid($event_id, $token);
+$pageCsrf = csrf_token();
 
-/* ---- Yükleme ---- */
+function json_fail(string $code, string $message, int $status = 400): never {
+  http_response_code($status);
+  header('Content-Type: application/json; charset=utf-8');
+  echo json_encode(['ok' => false, 'code' => $code, 'message' => $message], JSON_UNESCAPED_UNICODE);
+  exit;
+}
+function json_ok(array $payload = []): never {
+  header('Content-Type: application/json; charset=utf-8');
+  echo json_encode(['ok' => true] + $payload, JSON_UNESCAPED_UNICODE);
+  exit;
+}
+function ensure_ajax_csrf(string $token): void {
+  if ($token === '' || !hash_equals($_SESSION['csrf'] ?? '', $token)) {
+    json_fail('csrf', 'Oturum süresi doldu. Sayfayı yenileyin.');
+  }
+}
+function ensure_profile(?array $profile): array {
+  if (!$profile) {
+    json_fail('auth', 'Bu işlem için önce misafir hesabınızla giriş yapın.');
+  }
+  return $profile;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['ajax'])) {
+  $action = $_POST['action'] ?? '';
+  ensure_ajax_csrf($_POST['csrf'] ?? '');
+
+  switch ($action) {
+    case 'load_upload':
+      $uploadId = (int)($_POST['upload_id'] ?? 0);
+      if ($uploadId <= 0) json_fail('input', 'Geçersiz kayıt.');
+      $st = pdo()->prepare("SELECT u.*, gp.display_name, gp.avatar_token, gp.id AS gp_id
+                             FROM uploads u
+                             LEFT JOIN guest_profiles gp ON gp.id=u.profile_id
+                             WHERE u.id=? AND u.event_id=? LIMIT 1");
+      $st->execute([$uploadId, $event_id]);
+      $upload = $st->fetch();
+      if (!$upload) json_fail('not_found', 'Paylaşım bulunamadı.');
+
+      $likeCount = guest_upload_like_count($uploadId);
+      $commentCount = guest_upload_comment_count($uploadId);
+      $liked = $profile ? guest_upload_is_liked($uploadId, (int)$profile['id']) : false;
+
+      $commentsStmt = pdo()->prepare("SELECT c.*, gp.display_name, gp.avatar_token
+                                       FROM guest_upload_comments c
+                                       LEFT JOIN guest_profiles gp ON gp.id=c.profile_id
+                                       WHERE c.upload_id=?
+                                       ORDER BY c.id DESC LIMIT 40");
+      $commentsStmt->execute([$uploadId]);
+      $comments = [];
+      foreach ($commentsStmt->fetchAll() as $row) {
+        $comments[] = [
+          'id' => (int)$row['id'],
+          'body' => $row['body'],
+          'display_name' => $row['display_name'] ?: ($row['guest_name'] ?: 'Misafir'),
+          'avatar_token' => $row['avatar_token'] ?: null,
+          'created_at' => $row['created_at'],
+        ];
+      }
+
+      $data = [
+        'id' => (int)$upload['id'],
+        'guest_name' => $upload['display_name'] ?: ($upload['guest_name'] ?: 'Misafir'),
+        'mime' => $upload['mime'],
+        'file_path' => '/'.$upload['file_path'],
+        'created_at' => $upload['created_at'],
+        'like_count' => $likeCount,
+        'comment_count' => $commentCount,
+        'liked' => $liked,
+        'can_download' => $CAN_DOWN,
+        'is_video' => is_video_mime($upload['mime']),
+        'share_url' => BASE_URL.'/'.$upload['file_path'],
+        'comments' => $comments,
+      ];
+      json_ok(['upload' => $data]);
+
+    case 'toggle_like':
+      $profile = ensure_profile($profile);
+      $uploadId = (int)($_POST['upload_id'] ?? 0);
+      if ($uploadId <= 0) json_fail('input', 'Geçersiz kayıt.');
+      $st = pdo()->prepare('SELECT id FROM uploads WHERE id=? AND event_id=? LIMIT 1');
+      $st->execute([$uploadId, $event_id]);
+      if (!$st->fetch()) json_fail('not_found', 'Paylaşım bulunamadı.');
+      $liked = guest_upload_is_liked($uploadId, (int)$profile['id']);
+      if ($liked) guest_upload_unlike($uploadId, (int)$profile['id']);
+      else guest_upload_like($uploadId, (int)$profile['id']);
+      $likeCount = guest_upload_like_count($uploadId);
+      json_ok(['liked' => !$liked, 'like_count' => $likeCount]);
+
+    case 'add_comment':
+      $profile = ensure_profile($profile);
+      $uploadId = (int)($_POST['upload_id'] ?? 0);
+      $body = trim($_POST['body'] ?? '');
+      if ($uploadId <= 0) json_fail('input', 'Geçersiz kayıt.');
+      $st = pdo()->prepare('SELECT id FROM uploads WHERE id=? AND event_id=? LIMIT 1');
+      $st->execute([$uploadId, $event_id]);
+      if (!$st->fetch()) json_fail('not_found', 'Paylaşım bulunamadı.');
+      $comment = guest_upload_comment_add($uploadId, $profile, $body);
+      if (!$comment) json_fail('input', 'Yorum boş olamaz.');
+      $payload = [
+        'id' => (int)$comment['id'],
+        'body' => $comment['body'],
+        'display_name' => $comment['profile_display_name'] ?: ($comment['guest_name'] ?: 'Misafir'),
+        'avatar_token' => $comment['profile_avatar_token'] ?: null,
+        'created_at' => $comment['created_at'],
+        'comment_count' => guest_upload_comment_count($uploadId),
+      ];
+      json_ok(['comment' => $payload]);
+
+    case 'load_conversation':
+      $profile = ensure_profile($profile);
+      $otherId = (int)($_POST['profile_id'] ?? 0);
+      if ($otherId <= 0) json_fail('input', 'Geçersiz profil.');
+      $other = guest_profile_find_by_id($otherId);
+      if (!$other || (int)$other['event_id'] !== $event_id) json_fail('not_found', 'Misafir bulunamadı.');
+      $messages = guest_private_conversation($event_id, (int)$profile['id'], $otherId, 80);
+      $out = [];
+      foreach ($messages as $msg) {
+        $out[] = [
+          'id' => (int)$msg['id'],
+          'sender_id' => (int)$msg['sender_profile_id'],
+          'body' => $msg['body'],
+          'created_at' => $msg['created_at'],
+        ];
+      }
+      json_ok([
+        'messages' => $out,
+        'recipient' => [
+          'id' => $otherId,
+          'name' => $other['display_name'] ?: ($other['name'] ?: 'Misafir'),
+        ],
+      ]);
+
+    case 'send_message':
+      $profile = ensure_profile($profile);
+      $otherId = (int)($_POST['profile_id'] ?? 0);
+      $body = trim($_POST['body'] ?? '');
+      if ($otherId <= 0) json_fail('input', 'Geçersiz profil.');
+      $other = guest_profile_find_by_id($otherId);
+      if (!$other || (int)$other['event_id'] !== $event_id) json_fail('not_found', 'Misafir bulunamadı.');
+      $msg = guest_private_message_to_profile($event_id, $profile, $other, $body);
+      if (!$msg) json_fail('input', 'Mesajınızı yazın.');
+      json_ok([
+        'message' => [
+          'id' => (int)$msg['id'],
+          'sender_id' => (int)$msg['sender_profile_id'],
+          'body' => $msg['body'],
+          'created_at' => $msg['created_at'],
+        ]
+      ]);
+
+    case 'host_note':
+      $profile = ensure_profile($profile);
+      $body = trim($_POST['body'] ?? '');
+      $note = guest_event_note_add($event_id, $profile, $body);
+      if (!$note) json_fail('input', 'Mesajınızı yazın.');
+      json_ok(['created_at' => $note['created_at']]);
+
+    default:
+      json_fail('action', 'Desteklenmeyen işlem.');
+  }
+}
+
 $errors=[]; $okCount=0;
 if($_SERVER['REQUEST_METHOD']==='POST' && ($_POST['do']??'')==='upload'){
   csrf_or_die();
@@ -68,6 +228,7 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ($_POST['do']??'')==='upload'){
     $errors[]='Güvenlik anahtarı zaman aşımına uğradı. Lütfen QR’ı yeniden okutun.';
   }else{
     $guest = trim($_POST['guest_name']??'');
+    $guestEmail = guest_profile_normalize_email($_POST['guest_email'] ?? '') ?: ($profile['email'] ?? '');
     if($guest===''){ $errors[]='Lütfen adınızı yazın.'; }
     if(!isset($_FILES['files'])){ $errors[]='Dosya seçilmedi.'; }
     else{
@@ -88,9 +249,9 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ($_POST['do']??'')==='upload'){
           $dest=$dir.'/'.$final;
           if(!move_uploaded_file($tmp,$dest)){ $errors[]=h($nm).': taşınamadı'; continue; }
           $rel='uploads/v'.$VID.'/'.$event_id.'/'.$final;
-          pdo()->prepare("INSERT INTO uploads (venue_id,event_id,guest_name,file_path,mime,file_size,ip,created_at)
-                          VALUES (?,?,?,?,?,?,?,?)")
-              ->execute([$VID,$event_id,$guest,$rel,$mime,$sz,client_ip(),now()]);
+          pdo()->prepare("INSERT INTO uploads (venue_id,event_id,guest_name,profile_id,guest_email,file_path,mime,file_size,ip,created_at)
+                          VALUES (?,?,?,?,?,?,?,?,?,?)")
+              ->execute([$VID,$event_id,$guest,$profile['id'] ?? null,$guestEmail ?: null,$rel,$mime,$sz,client_ip(),now()]);
           $okCount++;
         }
       }
@@ -101,49 +262,100 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ($_POST['do']??'')==='upload'){
   if($errors){ flash('err',implode('<br>',array_map('h',$errors))); header('Location:'.$to); exit; }
 }
 
-/* ---- Galeri ---- */
 $uploads=[];
 if($CAN_VIEW){
-  $st=pdo()->prepare("SELECT id,guest_name,file_path,mime,file_size,created_at
-                      FROM uploads WHERE venue_id=? AND event_id=? ORDER BY id DESC LIMIT 300");
+  $st=pdo()->prepare("SELECT u.id,u.guest_name,u.file_path,u.mime,u.file_size,u.created_at,u.profile_id,
+                            gp.display_name,
+                            (SELECT COUNT(*) FROM guest_upload_likes gl WHERE gl.upload_id=u.id) AS like_count,
+                            (SELECT COUNT(*) FROM guest_upload_comments gc WHERE gc.upload_id=u.id) AS comment_count
+                      FROM uploads u
+                      LEFT JOIN guest_profiles gp ON gp.id=u.profile_id
+                      WHERE u.venue_id=? AND u.event_id=?
+                      ORDER BY u.id DESC LIMIT 300");
   $st->execute([$VID,$event_id]);
   $uploads=$st->fetchAll();
 }
+
+$directory = $profile ? guest_event_profile_directory($event_id, (int)$profile['id']) : [];
 ?>
 <!doctype html>
 <html lang="tr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title><?=h($ev['title'])?> — Misafir Yükleme</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<meta name="csrf" content="<?=h($pageCsrf)?>">
 <style>
-:root{ --zs:<?=h($PRIMARY)?>; --zs-soft:<?=h($ACCENT)?>; --ink:#111827; --muted:#6b7280 }
-body{ background:linear-gradient(180deg,var(--zs-soft),#fff) }
-.card-lite{ border:1px solid #eef2f7; border-radius:18px; background:#fff; box-shadow:0 6px 20px rgba(17,24,39,.05) }
-.btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:12px; padding:.65rem 1rem; font-weight:700 }
-.btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:12px; font-weight:700 }
-.dropzone{ border:2px dashed #cbd5e1; border-radius:16px; padding:24px; text-align:center; background:#fff; transition:.2s }
-.dropzone.drag{ border-color:var(--zs); background:#f0fbfd }
-.smallmuted{ color:var(--muted) }
-.thumb{ overflow:hidden; border-radius:12px; border:1px solid #e5e7eb; background:#f8fafc }
-.thumb img,.thumb video{ width:100%; height:180px; object-fit:cover; display:block }
-.badge-soft{ background:#eef2ff; color:#334155 }
-
-/* === 960×540 ölçekli sahne (çift panelle birebir) === */
-.preview-shell{ width:min(100%,980px); margin:0 auto }
-.preview-stage{ position:relative; width:100%; border:1px dashed #cbd5e1; border-radius:16px; background:#fff; overflow:hidden }
-.stage-scale{ position:absolute; left:0; top:0; width:960px; height:540px; transform-origin:top left; transform:scale(var(--s,1)) }
-.preview-canvas{ position:absolute; inset:0; background:linear-gradient(180deg,var(--zs-soft),#fff) }
-.pv-title{ position:absolute; font-size:28px; font-weight:800; color:#111 }
-.pv-sub{ position:absolute; color:#334155; font-size:16px }
-.pv-prompt{ position:absolute; color:#0f172a; font-size:16px }
-.sticker{ position:absolute; user-select:none; pointer-events:none }
+:root{ --zs:<?=h($PRIMARY)?>; --zs-soft:<?=h($ACCENT)?>; --ink:#0f172a; --muted:#64748b; --card:#ffffff; --border:#e2e8f0; }
+body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:"Inter","Segoe UI",system-ui,-apple-system,sans-serif; color:var(--ink); }
+.page-shell{ max-width:1200px; margin:0 auto; }
+.card-lite{ border:1px solid rgba(148,163,184,.22); border-radius:24px; background:var(--card); box-shadow:0 25px 70px -45px rgba(15,23,42,.4); }
+.card-lite h5{ font-weight:700; }
+.btn-zs{ background:linear-gradient(135deg,var(--zs),#0b8b98); border:none; color:#fff; border-radius:14px; padding:.75rem 1.4rem; font-weight:700; letter-spacing:.01em; }
+.btn-zs:hover{ color:#fff; filter:brightness(.98); }
+.btn-zs-outline{ background:rgba(14,165,181,.08); border:1px solid rgba(14,165,181,.4); color:var(--zs); border-radius:14px; font-weight:600; padding:.65rem 1.2rem; }
+.dropzone{ border:2px dashed rgba(148,163,184,.4); border-radius:18px; padding:28px; text-align:center; background:#f8fafc; transition:.2s; }
+.dropzone.drag{ border-color:var(--zs); background:#eefcfe; }
+.smallmuted{ color:var(--muted); font-size:.92rem; }
+.gallery-shell{ margin-top:2rem; }
+.gallery-header{ display:flex; align-items:center; justify-content:space-between; gap:1rem; margin-bottom:1.5rem; }
+.gallery-stream{ column-count:1; column-gap:1.6rem; }
+@media(min-width:768px){ .gallery-stream{ column-count:2; } }
+@media(min-width:1200px){ .gallery-stream{ column-count:3; } }
+.gallery-card{ break-inside:avoid; margin-bottom:1.6rem; position:relative; }
+.gallery-card button{ all:unset; cursor:pointer; display:block; }
+.media-wrap{ position:relative; overflow:hidden; border-radius:24px; }
+.media-wrap::after{ content:""; position:absolute; inset:0; background:linear-gradient(180deg,rgba(15,23,42,0) 45%,rgba(15,23,42,.68)); opacity:0; transition:.2s; }
+.gallery-card:hover .media-wrap::after{ opacity:1; }
+.media-wrap img,.media-wrap video{ width:100%; height:auto; display:block; }
+.media-info{ position:absolute; left:0; right:0; bottom:0; padding:1.1rem 1.3rem; display:flex; flex-direction:column; gap:.55rem; color:#fff; }
+.media-meta{ display:flex; align-items:center; justify-content:space-between; gap:.75rem; font-size:.95rem; font-weight:600; text-shadow:0 6px 20px rgba(0,0,0,.35); }
+.media-actions{ display:flex; align-items:center; gap:.85rem; font-size:.92rem; }
+.media-actions span{ display:inline-flex; align-items:center; gap:.3rem; }
+.pill{ display:inline-flex; align-items:center; gap:.45rem; font-size:.82rem; font-weight:600; padding:.35rem .75rem; border-radius:999px; background:rgba(255,255,255,.16); backdrop-filter:blur(6px); }
+.muted-link{ color:var(--muted); text-decoration:none; }
+.muted-link:hover{ text-decoration:underline; }
+.preview-shell{ width:min(100%,960px); margin:0 auto; }
+.preview-stage{ position:relative; width:100%; border:1px dashed rgba(148,163,184,.45); border-radius:22px; background:#fff; overflow:hidden; }
+.stage-scale{ position:absolute; left:0; top:0; width:960px; height:540px; transform-origin:top left; transform:scale(var(--s,1)); }
+.preview-canvas{ position:absolute; inset:0; background:linear-gradient(180deg,var(--zs-soft),#fff); }
+.pv-title{ position:absolute; font-size:28px; font-weight:800; color:#111; }
+.pv-sub{ position:absolute; color:#334155; font-size:16px; }
+.pv-prompt{ position:absolute; color:#0f172a; font-size:16px; }
+.sticker{ position:absolute; user-select:none; pointer-events:none; }
+.note-card{ border-radius:20px; border:1px solid rgba(148,163,184,.28); padding:1.8rem; background:#f8fafc; }
+.note-card textarea{ border-radius:16px; border:1px solid rgba(148,163,184,.32); padding:1rem; font-size:.98rem; }
+.note-card textarea:focus{ border-color:var(--zs); box-shadow:0 0 0 .25rem rgba(14,165,181,.2); }
+.modal-media{ width:100%; border-radius:20px; background:#000; overflow:hidden; }
+.modal-media img,.modal-media video{ width:100%; height:auto; display:block; }
+.comment-list{ max-height:300px; overflow:auto; display:flex; flex-direction:column; gap:1rem; }
+.comment-item{ display:flex; gap:.9rem; }
+.comment-avatar{ width:42px; height:42px; border-radius:14px; background:rgba(14,165,181,.15); display:flex; align-items:center; justify-content:center; font-weight:700; color:var(--zs); }
+.comment-body{ flex:1; }
+.comment-body h6{ margin:0; font-size:.95rem; font-weight:700; }
+.comment-body p{ margin:.35rem 0 0; font-size:.94rem; color:var(--ink); }
+.comment-body time{ display:block; font-size:.8rem; color:var(--muted); margin-top:.2rem; }
+.like-btn{ border:none; background:rgba(14,165,181,.12); color:var(--zs); border-radius:999px; padding:.45rem 1.1rem; font-weight:600; display:inline-flex; align-items:center; gap:.45rem; }
+.like-btn.active{ background:linear-gradient(135deg,var(--zs),#0b8b98); color:#fff; }
+.share-btn{ border:none; background:rgba(15,23,42,.08); color:var(--ink); border-radius:999px; padding:.45rem 1.1rem; font-weight:600; display:inline-flex; align-items:center; gap:.45rem; }
+.offcanvas-bikare{ width:360px; }
+.chat-user{ display:flex; align-items:center; gap:.85rem; padding:.65rem .85rem; border-radius:14px; cursor:pointer; transition:.2s; }
+.chat-user:hover{ background:rgba(14,165,181,.1); }
+.chat-user.active{ background:rgba(14,165,181,.18); }
+.chat-avatar{ width:42px; height:42px; border-radius:14px; background:rgba(14,165,181,.14); display:flex; align-items:center; justify-content:center; font-weight:700; color:var(--zs); }
+.chat-window{ min-height:260px; max-height:360px; overflow:auto; display:flex; flex-direction:column; gap:.75rem; padding:1rem; background:#f8fafc; border-radius:18px; }
+.bubble{ padding:.6rem .9rem; border-radius:16px; max-width:80%; font-size:.94rem; line-height:1.5; }
+.bubble.me{ background:linear-gradient(135deg,var(--zs),#0b8b98); color:#fff; margin-left:auto; }
+.bubble.them{ background:#fff; border:1px solid rgba(148,163,184,.26); color:var(--ink); }
+.chat-form textarea{ border-radius:14px; border:1px solid rgba(148,163,184,.32); padding:.75rem; resize:none; }
+.chat-form textarea:focus{ border-color:var(--zs); box-shadow:0 0 0 .25rem rgba(14,165,181,.2); }
+@media(max-width:768px){ .card-lite{ border-radius:18px; } }
 </style>
 </head>
 <body>
-<div class="container py-4">
+<div class="container py-4 page-shell">
   <?php flash_box(); ?>
 
-  <div class="card-lite p-3 mb-4">
+  <div class="card-lite p-4 mb-4">
     <div class="preview-shell">
       <div class="preview-stage" id="pvStage">
         <div class="stage-scale" id="scaleBox">
@@ -162,16 +374,25 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff) }
         </div>
       </div>
     </div>
-    <div class="smallmuted mt-2">Önizleme, çift panelde kaydettiğiniz düzenin birebir yansımasıdır.</div>
+    <div class="smallmuted mt-3">Önizleme, çift panelde kaydettiğiniz düzenin birebir yansımasıdır.</div>
   </div>
 
   <?php if(!$token_ok): ?>
     <div class="alert alert-warning" style="border-radius:14px">Güvenlik anahtarı süresi dolmuş. Lütfen QR’ı yeniden okutun.</div>
   <?php endif; ?>
 
-  <!-- Yükleme formu -->
-  <div class="card-lite p-3 mb-4">
-    <h5 class="mb-3">Anınızı Yükleyin</h5>
+  <div class="card-lite p-4 mb-4">
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
+      <div>
+        <h5 class="mb-1">Anınızı Paylaşın</h5>
+        <div class="smallmuted">Fotoğraf veya videolarınızı yüksek çözünürlükte yükleyin. Adınızı paylaşmayı unutmayın.</div>
+      </div>
+      <?php if($profile): ?>
+        <div class="pill">✔ <?=h($profile['display_name'] ?: $profile['name'])?> olarak giriş yaptınız</div>
+      <?php else: ?>
+        <a class="btn btn-zs-outline" href="<?=BASE_URL?>/public/guest_login.php">Misafir Girişi</a>
+      <?php endif; ?>
+    </div>
     <form method="post" enctype="multipart/form-data" id="upForm" class="vstack gap-3">
       <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
       <input type="hidden" name="do" value="upload">
@@ -179,6 +400,11 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff) }
       <div>
         <label class="form-label">Adınız</label>
         <input class="form-control" name="guest_name" placeholder="Ad Soyad" required <?= !$token_ok?'disabled':'' ?>>
+      </div>
+      <div>
+        <label class="form-label">E-posta (opsiyonel)</label>
+        <input type="email" class="form-control" name="guest_email" placeholder="ornek@eposta.com" <?= !$token_ok?'disabled':'' ?>>
+        <div class="form-text">E-postanızı eklemeniz, galeriye tekrar girebilmeniz ve şifrenizi belirlemeniz için önerilir.</div>
       </div>
       <div class="dropzone" id="drop">
         <p class="m-0">
@@ -194,35 +420,72 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff) }
     </form>
   </div>
 
-  <!-- Galeri -->
-  <div class="card-lite p-3">
-    <div class="d-flex justify-content-between align-items-center mb-2">
-      <h5 class="m-0">Galeri</h5>
-      <?php if(!$CAN_VIEW): ?><span class="badge bg-secondary">Gizli</span>
-      <?php else: ?><?= $CAN_DOWN?'<span class="badge badge-soft">İndirme açık</span>':'<span class="badge bg-secondary">İndirme kapalı</span>' ?><?php endif; ?>
+  <?php if($profile): ?>
+    <div class="note-card mb-4">
+      <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
+        <div>
+          <h5 class="mb-1">Etkinlik sahibine mesaj gönder</h5>
+          <div class="smallmuted">Güzel dileklerinizi veya teşekkürlerinizi iletebilirsiniz.</div>
+        </div>
+        <button class="btn btn-zs-outline" type="button" data-bs-toggle="offcanvas" data-bs-target="#messagesPanel">Misafirlerle Mesajlaş</button>
+      </div>
+      <form id="hostNoteForm" class="vstack gap-3">
+        <textarea name="note" rows="3" placeholder="Mesajınızı yazın..."></textarea>
+        <div class="d-flex align-items-center justify-content-between gap-3 flex-wrap">
+          <div class="smallmuted" id="hostNoteStatus"></div>
+          <button class="btn btn-zs" type="submit">Mesajı Gönder</button>
+        </div>
+      </form>
+    </div>
+  <?php endif; ?>
+
+  <div class="card-lite p-4">
+    <div class="gallery-header">
+      <div>
+        <h5 class="mb-1">Galeri</h5>
+        <div class="smallmuted">Sevdiklerinizin paylaştığı anları keşfedin, beğenin ve yorum yapın.</div>
+      </div>
+      <?php if(!$CAN_VIEW): ?>
+        <span class="pill">Galeri gizli</span>
+      <?php else: ?>
+        <span class="pill">İndirme <?= $CAN_DOWN ? 'açık' : 'kapalı' ?></span>
+      <?php endif; ?>
     </div>
     <?php if(!$CAN_VIEW): ?>
       <div class="smallmuted">Galeri bu etkinlikte gizli.</div>
     <?php else: ?>
       <?php if(!$uploads): ?>
-        <div class="smallmuted">Henüz yükleme yok.</div>
+        <div class="smallmuted">Henüz paylaşım yapılmadı. İlk anıyı siz yükleyin!</div>
       <?php else: ?>
-        <div class="row g-3">
+        <div class="gallery-stream" id="galleryStream">
           <?php foreach($uploads as $u):
             $path = '/'.$u['file_path'];
-            $isImg=is_image_mime($u['mime']); $isVid=is_video_mime($u['mime']); ?>
-            <div class="col-6 col-md-4 col-lg-3">
-              <div class="thumb">
-                <?php if($isImg): ?><img src="<?=h($path)?>" alt="">
-                <?php elseif($isVid): ?><video src="<?=h($path)?>" muted></video>
-                <?php else: ?><div class="p-4 text-center smallmuted">Dosya</div><?php endif; ?>
+            $isImg=is_image_mime($u['mime']); $isVid=is_video_mime($u['mime']);
+            $displayName = $u['display_name'] ?: ($u['guest_name'] ?: 'Misafir');
+          ?>
+          <article class="gallery-card" data-upload="<?=intval($u['id'])?>">
+            <button type="button" class="gallery-open" data-upload="<?=intval($u['id'])?>">
+              <div class="media-wrap">
+                <?php if($isImg): ?>
+                  <img src="<?=h($path)?>" alt="<?=h($displayName)?> paylaşımı">
+                <?php elseif($isVid): ?>
+                  <video src="<?=h($path)?>" muted playsinline></video>
+                <?php else: ?>
+                  <div style="padding:4rem 1rem;text-align:center;color:var(--muted);background:#f1f5f9;">Dosya önizlemesi desteklenmiyor</div>
+                <?php endif; ?>
+                <div class="media-info">
+                  <div class="media-meta">
+                    <span><?=h($displayName)?></span>
+                    <span><?=date('d.m.Y H:i', strtotime($u['created_at']))?></span>
+                  </div>
+                  <div class="media-actions">
+                    <span>❤️ <?= (int)$u['like_count'] ?></span>
+                    <span>💬 <?= (int)$u['comment_count'] ?></span>
+                  </div>
+                </div>
               </div>
-              <div class="d-flex justify-content-between align-items-center mt-1">
-                <span class="small text-truncate" title="<?=h($u['guest_name'])?>"><?=h($u['guest_name'])?></span>
-                <?php if($CAN_DOWN): ?><a class="btn btn-sm btn-zs-outline" href="<?=h($path)?>" download>İndir</a><?php endif; ?>
-              </div>
-              <div class="small smallmuted"><?=number_format($u['file_size']/1048576,1)?> MB • <?=date('d.m.Y H:i', strtotime($u['created_at']))?></div>
-            </div>
+            </button>
+          </article>
           <?php endforeach; ?>
         </div>
       <?php endif; ?>
@@ -230,6 +493,69 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff) }
   </div>
 </div>
 
+<div class="modal fade" id="uploadModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content" style="border-radius:24px; border:none;">
+      <div class="modal-body p-4">
+        <div class="row g-4">
+          <div class="col-lg-7">
+            <div class="modal-media" id="modalMedia"></div>
+          </div>
+          <div class="col-lg-5 d-flex flex-column gap-3">
+            <div>
+              <h5 id="modalTitle" class="mb-0"></h5>
+              <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
+                <button class="like-btn" type="button" id="modalLike"><span>❤️</span> <span id="modalLikeCount">0</span></button>
+                <button class="share-btn" type="button" id="modalShare">Paylaş</button>
+                <a class="btn btn-sm btn-zs-outline d-none" id="modalDownload" download>İndir</a>
+              </div>
+            </div>
+            <div>
+              <div class="d-flex align-items-center gap-2 mb-2"><strong>Yorumlar</strong><span class="pill" id="modalCommentCount">0</span></div>
+              <div class="comment-list" id="modalComments"></div>
+            </div>
+            <?php if($profile): ?>
+              <form id="commentForm" class="vstack gap-2">
+                <textarea id="commentText" rows="3" class="form-control" placeholder="Yorum yaz..." required></textarea>
+                <button class="btn btn-zs" type="submit">Yorumu Gönder</button>
+              </form>
+            <?php else: ?>
+              <div class="smallmuted">Yorum yapmak için <a href="<?=BASE_URL?>/public/guest_login.php" class="muted-link">misafir girişi</a> yapın.</div>
+            <?php endif; ?>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer" style="border:none; padding:0 2rem 1.5rem;">
+        <button class="btn btn-zs-outline" data-bs-dismiss="modal">Kapat</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<?php if($profile): ?>
+<div class="offcanvas offcanvas-end offcanvas-bikare" tabindex="-1" id="messagesPanel">
+  <div class="offcanvas-header">
+    <h5 class="offcanvas-title">Mesajlar</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
+  </div>
+  <div class="offcanvas-body d-flex flex-column gap-3">
+    <div>
+      <div class="smallmuted mb-2">Misafir listesi</div>
+      <div id="chatUsers" class="d-flex flex-column gap-1"></div>
+    </div>
+    <div>
+      <div class="smallmuted mb-2" id="chatHeading">Mesaj seçilmedi</div>
+      <div class="chat-window" id="chatWindow"></div>
+    </div>
+    <form id="chatForm" class="chat-form vstack gap-2">
+      <textarea id="chatMessage" rows="2" placeholder="Mesajınızı yazın..." required></textarea>
+      <button class="btn btn-zs" type="submit">Gönder</button>
+    </form>
+  </div>
+</div>
+<?php endif; ?>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 // 960x540 sahneyi container'a orantılı sığdır
 (function(){
@@ -238,7 +564,6 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff) }
   window.addEventListener('resize',fit,{passive:true}); new ResizeObserver(fit).observe(stage); fit();
 })();
 
-// Drag&Drop
 const dz=document.getElementById('drop'), fi=document.getElementById('fileI'), lst=document.getElementById('list'), fm=document.getElementById('upForm');
 if(dz){
   ['dragenter','dragover'].forEach(ev=>dz.addEventListener(ev,e=>{e.preventDefault();dz.classList.add('drag');}));
@@ -248,6 +573,231 @@ if(dz){
 fi?.addEventListener('change',e=>renderList(e.target.files));
 function renderList(files){ if(!files||!files.length){ lst.innerHTML=''; return; } let out='<ul class="m-0 ps-3">'; for(let i=0;i<files.length;i++){ const f=files[i]; out+=`<li>${esc(f.name)} — ${(f.size/1048576).toFixed(1)} MB</li>`; } lst.innerHTML=out+'</ul>'; }
 function esc(s){return s.replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[m]));}
-fm?.addEventListener('submit',e=>{ const name=fm.querySelector('[name=guest_name]').value.trim(); if(!name){e.preventDefault(); alert('Lütfen adınızı yazın.');} const fs=fi?.files||[]; if(!fs.length){e.preventDefault(); alert('Lütfen dosya seçin.');} });
+fm?.addEventListener('submit',e=>{ const name=fm.querySelector('[name=guest_name]').value.trim(); if(!name){e.preventDefault();alert('Lütfen adınızı yazın.');} const fs=fi?.files||[]; if(!fs.length){e.preventDefault(); alert('Lütfen dosya seçin.');} });
+
+const csrfMeta=document.querySelector('meta[name="csrf"]');
+const csrfToken=csrfMeta?csrfMeta.content:'';
+const galleryModal=document.getElementById('uploadModal');
+const modalTitle=document.getElementById('modalTitle');
+const modalMedia=document.getElementById('modalMedia');
+const modalLike=document.getElementById('modalLike');
+const modalLikeCount=document.getElementById('modalLikeCount');
+const modalCommentCount=document.getElementById('modalCommentCount');
+const modalComments=document.getElementById('modalComments');
+const commentForm=document.getElementById('commentForm');
+const commentTextarea=document.getElementById('commentText');
+const downloadBtn=document.getElementById('modalDownload');
+let activeUploadId=null;
+let bootstrapModal=null;
+
+function fmtDate(tr){
+  if(!tr) return '';
+  const d=new Date(tr.replace(' ','T'));
+  if(isNaN(d)) return tr;
+  return d.toLocaleString('tr-TR',{day:'2-digit',month:'2-digit',year:'numeric',hour:'2-digit',minute:'2-digit'});
+}
+function renderComment(c){
+  const initials=(c.display_name||'M').trim().split(/\s+/).map(p=>p.charAt(0)).join('').substring(0,2).toUpperCase();
+  return `<div class="comment-item"><div class="comment-avatar">${initials}</div><div class="comment-body"><h6>${escapeHtml(c.display_name||'Misafir')}</h6><p>${escapeHtml(c.body)}</p><time>${fmtDate(c.created_at)}</time></div></div>`;
+}
+function escapeHtml(str){
+  return String(str).replace(/[&<>"']/g,m=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#039;"}[m]));
+}
+function loadUpload(id){
+  activeUploadId=id;
+  fetch(window.location.href,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded','X-Requested-With':'XMLHttpRequest'},body:new URLSearchParams({ajax:'1',action:'load_upload',upload_id:id,csrf:csrfToken})})
+    .then(r=>r.json())
+    .then(data=>{
+      if(!data.ok) throw new Error(data.message||'Bir hata oluştu');
+      const up=data.upload;
+      modalTitle.textContent=`${up.guest_name} · ${fmtDate(up.created_at)}`;
+      modalMedia.innerHTML='';
+      if(up.is_video){
+        const vid=document.createElement('video');
+        vid.src=up.file_path;
+        vid.controls=true;
+        vid.playsInline=true;
+        modalMedia.appendChild(vid);
+      }else{
+        const img=document.createElement('img');
+        img.src=up.file_path;
+        img.alt=up.guest_name;
+        modalMedia.appendChild(img);
+      }
+      modalLike.dataset.active=up.liked?'1':'0';
+      modalLike.classList.toggle('active', !!up.liked);
+      modalLikeCount.textContent=up.like_count;
+      modalCommentCount.textContent=up.comment_count;
+      if(up.can_download){
+        downloadBtn.classList.remove('d-none');
+        downloadBtn.href=up.file_path;
+      }else{
+        downloadBtn.classList.add('d-none');
+      }
+      modalComments.innerHTML='';
+      if(!up.comments.length){
+        modalComments.innerHTML='<div class="smallmuted">Henüz yorum yok. İlk yorumu siz yazın!</div>';
+      }else{
+        up.comments.slice().reverse().forEach(c=>{ modalComments.insertAdjacentHTML('beforeend', renderComment(c)); });
+      }
+      if(!bootstrapModal){ bootstrapModal = new bootstrap.Modal(galleryModal); }
+      bootstrapModal.show();
+    })
+    .catch(err=>{ alert(err.message||'Bir hata oluştu'); });
+}
+
+document.querySelectorAll('.gallery-open').forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    const id=btn.dataset.upload;
+    if(id) loadUpload(id);
+  });
+});
+
+modalLike?.addEventListener('click',()=>{
+  if(!activeUploadId) return;
+  fetch(window.location.href,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded','X-Requested-With':'XMLHttpRequest'},body:new URLSearchParams({ajax:'1',action:'toggle_like',upload_id:activeUploadId,csrf:csrfToken})})
+    .then(r=>r.json())
+    .then(data=>{
+      if(!data.ok) throw new Error(data.message||'Bir hata oluştu');
+      modalLike.dataset.active=data.liked?'1':'0';
+      modalLike.classList.toggle('active', !!data.liked);
+      modalLikeCount.textContent=data.like_count;
+      const card=document.querySelector(`.gallery-card[data-upload="${activeUploadId}"] .media-actions span:first-child`);
+      if(card) card.textContent=`❤️ ${data.like_count}`;
+    })
+    .catch(err=>{ alert(err.message||'Giriş yapmanız gerekiyor.'); });
+});
+
+commentForm?.addEventListener('submit',ev=>{
+  ev.preventDefault();
+  if(!activeUploadId) return;
+  const body=commentTextarea.value.trim();
+  if(!body){ commentTextarea.focus(); return; }
+  commentTextarea.disabled=true;
+  fetch(window.location.href,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded','X-Requested-With':'XMLHttpRequest'},body:new URLSearchParams({ajax:'1',action:'add_comment',upload_id:activeUploadId,body:body,csrf:csrfToken})})
+    .then(r=>r.json())
+    .then(data=>{
+      if(!data.ok) throw new Error(data.message||'Bir hata oluştu');
+      if(modalComments.querySelector('.smallmuted')) modalComments.innerHTML='';
+      modalComments.insertAdjacentHTML('beforeend', renderComment(data.comment));
+      modalCommentCount.textContent=data.comment.comment_count;
+      const card=document.querySelector(`.gallery-card[data-upload="${activeUploadId}"] .media-actions span:last-child`);
+      if(card) card.textContent=`💬 ${data.comment.comment_count}`;
+      commentTextarea.value='';
+    })
+    .catch(err=>{ alert(err.message||'Bir hata oluştu'); })
+    .finally(()=>{ commentTextarea.disabled=false; commentTextarea.focus(); });
+});
+
+const shareBtn=document.getElementById('modalShare');
+shareBtn?.addEventListener('click',()=>{
+  if(!activeUploadId) return;
+  const link=downloadBtn?.href||window.location.href;
+  if(navigator.share){
+    navigator.share({ title: document.title, url: link }).catch(()=>{});
+  }else if(navigator.clipboard){
+    navigator.clipboard.writeText(link).then(()=>{ shareBtn.textContent='Bağlantı kopyalandı'; setTimeout(()=>shareBtn.textContent='Paylaş',2000); }).catch(()=>{ alert('Bağlantı: '+link); });
+  }else{
+    alert('Bağlantı: '+link);
+  }
+});
+
+const hostForm=document.getElementById('hostNoteForm');
+const hostStatus=document.getElementById('hostNoteStatus');
+hostForm?.addEventListener('submit',ev=>{
+  ev.preventDefault();
+  const body=hostForm.note.value.trim();
+  if(!body){ hostStatus.textContent='Mesajınızı yazın.'; return; }
+  hostStatus.textContent='Gönderiliyor...';
+  fetch(window.location.href,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded','X-Requested-With':'XMLHttpRequest'},body:new URLSearchParams({ajax:'1',action:'host_note',body:body,csrf:csrfToken})})
+    .then(r=>r.json())
+    .then(data=>{
+      if(!data.ok) throw new Error(data.message||'Bir hata oluştu');
+      hostStatus.textContent='Mesajınız iletildi. Teşekkür ederiz!';
+      hostForm.note.value='';
+    })
+    .catch(err=>{ hostStatus.textContent=err.message||'Bir sorun oluştu.'; });
+});
+
+<?php if($profile): ?>
+const directory = <?=json_encode($directory, JSON_UNESCAPED_UNICODE)?>;
+const currentProfileId = <?= (int)$profile['id'] ?>;
+const chatUsers=document.getElementById('chatUsers');
+const chatWindow=document.getElementById('chatWindow');
+const chatHeading=document.getElementById('chatHeading');
+const chatForm=document.getElementById('chatForm');
+const chatMessage=document.getElementById('chatMessage');
+let activeChatId=null;
+
+function initials(name){
+  return name.trim().split(/\s+/).map(p=>p.charAt(0)).join('').substring(0,2).toUpperCase();
+}
+function renderDirectory(){
+  if(!chatUsers) return;
+  chatUsers.innerHTML='';
+  if(!directory.length){
+    chatUsers.innerHTML='<div class="smallmuted">Henüz doğrulanmış başka misafir yok.</div>';
+    chatForm.classList.add('d-none');
+    return;
+  }
+  directory.forEach(item=>{
+    const btn=document.createElement('div');
+    btn.className='chat-user';
+    btn.dataset.profileId=item.id;
+    btn.innerHTML=`<div class="chat-avatar">${initials(item.display_name || 'Misafir')}</div><div><div class="fw-semibold">${escapeHtml(item.display_name || 'Misafir')}</div><div class="smallmuted">${item.email||''}</div></div>`;
+    btn.addEventListener('click',()=>selectChat(item.id, item.display_name || 'Misafir'));
+    chatUsers.appendChild(btn);
+  });
+}
+function selectChat(id,name){
+  activeChatId=id;
+  chatMessage.value='';
+  chatWindow.innerHTML='<div class="smallmuted">Yükleniyor...</div>';
+  chatUsers.querySelectorAll('.chat-user').forEach(el=>{
+    el.classList.toggle('active', parseInt(el.dataset.profileId,10)===id);
+  });
+  fetch(window.location.href,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded','X-Requested-With':'XMLHttpRequest'},body:new URLSearchParams({ajax:'1',action:'load_conversation',profile_id:id,csrf:csrfToken})})
+    .then(r=>r.json())
+    .then(data=>{
+      if(!data.ok) throw new Error(data.message||'Bir hata oluştu');
+      chatHeading.textContent=data.recipient.name+' ile sohbet';
+      chatWindow.innerHTML='';
+      if(!data.messages.length){
+        chatWindow.innerHTML='<div class="smallmuted">İlk mesajı siz gönderin.</div>';
+      }else{
+        data.messages.forEach(msg=>{
+          const bubble=document.createElement('div');
+          bubble.className='bubble '+(msg.sender_id===currentProfileId?'me':'them');
+          bubble.textContent=msg.body;
+          chatWindow.appendChild(bubble);
+        });
+        chatWindow.scrollTop=chatWindow.scrollHeight;
+      }
+    })
+    .catch(err=>{ chatWindow.innerHTML='<div class="smallmuted">'+escapeHtml(err.message||'Bir hata oluştu')+'</div>'; });
+}
+chatForm?.addEventListener('submit',ev=>{
+  ev.preventDefault();
+  if(!activeChatId){ chatHeading.textContent='Önce bir misafir seçin.'; return; }
+  const body=chatMessage.value.trim();
+  if(!body){ chatMessage.focus(); return; }
+  chatMessage.disabled=true;
+  fetch(window.location.href,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded','X-Requested-With':'XMLHttpRequest'},body:new URLSearchParams({ajax:'1',action:'send_message',profile_id:activeChatId,body:body,csrf:csrfToken})})
+    .then(r=>r.json())
+    .then(data=>{
+      if(!data.ok) throw new Error(data.message||'Bir hata oluştu');
+      if(chatWindow.querySelector('.smallmuted')) chatWindow.innerHTML='';
+      const bubble=document.createElement('div');
+      bubble.className='bubble me';
+      bubble.textContent=data.message.body;
+      chatWindow.appendChild(bubble);
+      chatWindow.scrollTop=chatWindow.scrollHeight;
+      chatMessage.value='';
+    })
+    .catch(err=>{ alert(err.message||'Bir hata oluştu'); })
+    .finally(()=>{ chatMessage.disabled=false; chatMessage.focus(); });
+});
+renderDirectory();
+<?php endif; ?>
 </script>
 </body></html>

--- a/public/upload.php
+++ b/public/upload.php
@@ -603,26 +603,39 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
 .dropzone.drag{ border-color:var(--zs); background:rgba(14,165,181,.08); }
 .form-text{ color:var(--muted); }
 .gallery-card{ padding:28px; }
-.gallery-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(220px,1fr)); gap:24px; }
-@media(min-width:768px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(240px,1fr)); } }
-@media(min-width:1400px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(260px,1fr)); } }
-.gallery-item{ display:flex; flex-direction:column; border-radius:22px; overflow:hidden; background:#fff; border:1px solid rgba(148,163,184,.18); box-shadow:0 16px 32px rgba(15,23,42,.08); transition:transform .2s ease, box-shadow .2s ease; }
-.gallery-item:hover{ transform:translateY(-4px); box-shadow:0 20px 44px rgba(15,23,42,.12); }
-.gallery-media{ position:relative; width:100%; background:#020617; display:flex; align-items:center; justify-content:center; padding:16px; min-height:160px; }
-.gallery-media img,.gallery-media video{ width:100%; height:auto; max-height:320px; display:block; object-fit:contain; border-radius:14px; box-shadow:0 6px 18px rgba(15,23,42,.22); }
-.gallery-header{ display:flex; align-items:center; gap:12px; padding:18px 20px 12px; }
-.avatar{ width:46px; height:46px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:700; letter-spacing:.5px; }
-.gallery-actions{ display:flex; align-items:center; justify-content:space-between; padding:12px 20px 4px; gap:12px; }
-.action-buttons{ display:flex; gap:10px; }
-.icon-btn{ border:none; background:rgba(248,250,252,.9); border-radius:999px; padding:8px 16px; display:flex; align-items:center; gap:8px; font-weight:600; color:var(--muted); cursor:pointer; }
-.icon-btn.active{ background:rgba(14,165,181,.12); color:var(--zs); }
-.icon-btn:hover{ background:rgba(14,165,181,.18); color:var(--zs); }
-.gallery-meta{ font-size:13px; color:var(--muted); }
-.gallery-body{ padding:8px 20px 20px; }
-.comment{ padding:10px 14px; border-radius:14px; background:rgba(241,245,249,.6); margin-top:8px; }
-.comment strong{ display:block; font-size:13px; color:var(--ink); }
-.comment p{ margin:4px 0 0; font-size:13px; color:var(--muted); }
+.gallery-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(280px,1fr)); gap:28px; }
+@media(min-width:768px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(320px,1fr)); } }
+@media(min-width:1400px){ .gallery-grid{ grid-template-columns:repeat(auto-fill, minmax(360px,1fr)); } }
+.gallery-item{ display:flex; flex-direction:column; border-radius:26px; overflow:hidden; background:linear-gradient(172deg, rgba(6,66,82,.94) 0%, rgba(8,104,124,.88) 45%, rgba(12,146,170,.82) 100%); border:1px solid rgba(14,165,181,.35); box-shadow:0 28px 60px rgba(4,31,45,.28); color:#f1fbfd; position:relative; transition:transform .25s ease, box-shadow .25s ease; }
+.gallery-item:hover{ transform:translateY(-6px); box-shadow:0 32px 70px rgba(4,31,45,.35); }
+.gallery-media{ position:relative; width:100%; background:rgba(2,27,36,.7); display:flex; align-items:center; justify-content:center; padding:10px; }
+.gallery-media img,.gallery-media video{ width:100%; height:auto; max-height:420px; display:block; object-fit:contain; border-radius:18px; box-shadow:0 18px 38px rgba(1,14,20,.45); }
+.gallery-header{ display:flex; align-items:center; gap:14px; padding:18px 22px; background:rgba(3,23,31,.45); border-bottom:1px solid rgba(255,255,255,.08); }
+.gallery-author{ font-weight:700; font-size:15px; color:#fff; letter-spacing:.02em; }
+.avatar{ width:46px; height:46px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:700; letter-spacing:.5px; box-shadow:0 8px 18px rgba(4,31,45,.35); border:2px solid rgba(255,255,255,.2); }
+.gallery-actions{ display:flex; align-items:center; justify-content:space-between; padding:14px 22px 12px; gap:18px; background:rgba(3,23,31,.45); border-top:1px solid rgba(255,255,255,.08); }
+.action-buttons{ display:flex; align-items:center; gap:12px; }
+.icon-btn{ border:none; background:rgba(255,255,255,.12); border-radius:999px; padding:9px 18px; display:flex; align-items:center; gap:8px; font-weight:600; color:#e0f6f9; cursor:pointer; transition:background .2s ease, color .2s ease; }
+.icon-btn span{ display:inline-flex; align-items:center; }
+.icon-btn .like-count{ font-variant-numeric:tabular-nums; }
+.icon-btn.active{ background:rgba(255,255,255,.22); color:#fff; }
+.icon-btn:hover{ background:rgba(255,255,255,.26); color:#fff; }
+.icon-btn:disabled{ cursor:not-allowed; opacity:.55; }
+.gallery-actions .btn{ border-radius:999px; border:1px solid rgba(255,255,255,.28); color:#fff; background:transparent; font-weight:600; }
+.gallery-actions .btn:hover{ background:rgba(255,255,255,.18); color:#fff; }
+.gallery-meta{ font-size:13px; color:rgba(226,248,250,.8); }
+.gallery-body{ padding:16px 22px 24px; background:rgba(3,23,31,.32); color:#f1fbfd; }
+.gallery-body p{ color:rgba(226,248,250,.88); }
+.gallery-body .smallmuted{ color:rgba(226,248,250,.82); }
+.comment{ padding:12px 16px; border-radius:18px; background:rgba(255,255,255,.12); margin-top:10px; color:#f1fbfd; }
+.gallery-item .comment strong{ display:block; font-size:13px; color:#fff; }
+.gallery-item .comment p{ margin:6px 0 0; font-size:13px; color:rgba(226,248,250,.88); }
+.gallery-item .comment .smallmuted{ color:rgba(226,248,250,.65); }
+.gallery-item .comment.smallmuted{ color:rgba(226,248,250,.82); }
 .comment-form textarea{ resize:vertical; border-radius:16px; }
+.gallery-item .comment-form textarea{ background:rgba(255,255,255,.08); border-color:rgba(255,255,255,.18); color:#fff; }
+.gallery-item .comment-form textarea::placeholder{ color:rgba(226,248,250,.6); }
+.gallery-item .comment-form textarea:focus{ background:rgba(3,23,31,.6); border-color:rgba(255,255,255,.45); box-shadow:0 0 0 .25rem rgba(14,165,181,.35); }
 .note-card textarea{ min-height:140px; }
 .form-feedback{ color:var(--zs); font-weight:600; }
 .form-feedback.error{ color:#ef4444; }
@@ -798,7 +811,7 @@ body{ background:linear-gradient(180deg,var(--zs-soft),#fff); font-family:'Inter
                   <?=h(avatar_initial($name))?>
                 </div>
                 <div>
-                  <div style="font-weight:600; color:var(--ink);"><?=h($name)?></div>
+                  <div class="gallery-author"><?=h($name)?></div>
                   <div class="gallery-meta"><?=relative_time($u['created_at'])?></div>
                 </div>
               </div>

--- a/public/upload.php
+++ b/public/upload.php
@@ -1,13 +1,12 @@
 <?php
+// public/upload.php — Misafir yükleme + galeri + Çift panelle birebir 960x540 ölçekli önizleme
 require_once __DIR__.'/../config.php';
 require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/functions.php';
-require_once __DIR__.'/../includes/dealers.php';
-require_once __DIR__.'/../includes/guests.php';
-require_once __DIR__.'/../includes/mailer.php';
 
-install_schema();
+if (session_status() === PHP_SESSION_NONE) session_start();
 
+/* ---- CSRF (shim) ---- */
 if (!function_exists('csrf_token')) {
   function csrf_token(){ if(empty($_SESSION['csrf'])) $_SESSION['csrf']=bin2hex(random_bytes(16)); return $_SESSION['csrf']; }
 }
@@ -15,6 +14,7 @@ if (!function_exists('csrf_or_die')) {
   function csrf_or_die(){ $t=$_POST['csrf']??$_POST['_csrf']??''; if(!$t || !hash_equals($_SESSION['csrf']??'', $t)){ http_response_code(400); exit('CSRF'); } }
 }
 
+/* ---- Yardımcılar ---- */
 function client_ip(){
   if(isset($_SERVER['HTTP_CLIENT_IP'])) return $_SERVER['HTTP_CLIENT_IP'];
   if(isset($_SERVER['HTTP_X_FORWARDED_FOR'])) return explode(',', $_SERVER['HTTP_X_FORWARDED_FOR'])[0];
@@ -22,112 +22,20 @@ function client_ip(){
 }
 function is_image_mime($m){ return (bool)preg_match('~^image/(jpeg|png|webp|gif)$~i',$m); }
 function is_video_mime($m){ return (bool)preg_match('~^video/(mp4|quicktime|webm)$~i',$m); }
-function relative_time($dt){
-  if(!$dt) return '';
-  $ts = is_numeric($dt) ? (int)$dt : strtotime($dt);
-  if(!$ts) return '';
-  $diff = time() - $ts;
-  if($diff < 60) return 'az önce';
-  if($diff < 3600) return floor($diff/60).' dk önce';
-  if($diff < 86400) return floor($diff/3600).' sa önce';
-  if($diff < 172800) return 'dün';
-  return date('d.m.Y H:i', $ts);
-}
-function avatar_colors(string $seed): array {
-  $palette = ['#0ea5b5','#0b8d9b','#13b8c9','#0a6c78'];
-  $text = ['#ffffff','#ffffff','#044047','#e6fffb'];
-  $idx = hexdec(substr($seed,0,2)) % count($palette);
-  return [$palette[$idx], $text[$idx] ?? '#fff'];
-}
-function avatar_initial(string $name): string {
-  $name = trim($name);
-  if($name==='') return 'M';
-  return mb_strtoupper(mb_substr($name,0,1,'UTF-8'),'UTF-8');
-}
 
-function is_ajax_request(): bool {
-  if (!empty($_POST['ajax']) && $_POST['ajax'] === '1') {
-    return true;
-  }
-  $xrw = strtolower($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '');
-  if ($xrw === 'xmlhttprequest') {
-    return true;
-  }
-  $accept = $_SERVER['HTTP_ACCEPT'] ?? '';
-  return stripos($accept, 'application/json') !== false;
-}
-
-function json_response($data, int $status = 200): void {
-  http_response_code($status);
-  header('Content-Type: application/json');
-  echo json_encode($data, JSON_UNESCAPED_UNICODE);
-  exit;
-}
-
-function render_comment_block(array $c): string {
-  $cName = $c['profile_display_name'] ?? '';
-  if ($cName === '' && !empty($c['guest_name'])) {
-    $cName = $c['guest_name'];
-  }
-  if ($cName === '') {
-    $cName = 'Misafir';
-  }
-  $body = nl2br(h($c['body'] ?? ''));
-  $time = relative_time($c['created_at'] ?? now());
-  return '<div class="comment">'
-        .'<strong>'.h($cName).'</strong>'
-        .'<div class="smallmuted">'.$time.'</div>'
-        .'<p>'.$body.'</p>'
-        .'</div>';
-}
-
-function event_host_email(array $event): string {
-  $email = $event['contact_email'] ?? '';
-  if (!$email && !empty($event['couple_username'])) {
-    $email = $event['couple_username'];
-  }
-  $email = trim((string)$email);
-  if ($email !== '' && filter_var($email, FILTER_VALIDATE_EMAIL)) {
-    return $email;
-  }
-  return '';
-}
-
-function respond_error(string $message, string $redirect, bool $wantsJson, string $anchor = '', int $status = 400): void {
-  if ($wantsJson) {
-    json_response(['success' => false, 'error' => $message], $status);
-  }
-  flash('err', $message);
-  header('Location:'.$redirect.$anchor);
-  exit;
-}
-
-function respond_success(string $message, string $redirect, bool $wantsJson, array $payload = [], string $anchor = ''): void {
-  if ($wantsJson) {
-    $payload = array_merge(['success' => true, 'message' => $message], $payload);
-    json_response($payload);
-  }
-  flash('ok', $message);
-  header('Location:'.$redirect.$anchor);
-  exit;
-}
-
+/* ---- Parametreler ---- */
 $event_id = (int)($_GET['event'] ?? 0);
 $token    = trim($_GET['t'] ?? '');
 if ($event_id <= 0){ http_response_code(400); exit('Geçersiz istek'); }
 
+/* ---- Etkinlik satırı ---- */
 $st = pdo()->prepare("SELECT * FROM events WHERE id=? LIMIT 1");
 $st->execute([$event_id]);
 $ev = $st->fetch();
 if (!$ev || (int)$ev['is_active']!==1){ http_response_code(404); exit('Etkinlik bulunamadı veya pasif.'); }
 
-$eventTimestamp = !empty($ev['event_date']) ? strtotime($ev['event_date']) : null;
-$uploadDeadline = $eventTimestamp ? strtotime('+10 days', $eventTimestamp) : null;
-if($uploadDeadline === false){ $uploadDeadline = null; }
-$uploadsLocked  = ($uploadDeadline !== null && $uploadDeadline !== false && time() > $uploadDeadline);
-
 $VID      = (int)$ev['venue_id'];
-$TITLE    = $ev['guest_title'] ?: 'BİKARE Etkinliğimize Hoş Geldiniz';
+$TITLE    = $ev['guest_title'] ?: 'Düğünümüze Hoş Geldiniz';
 $SUBTITLE = $ev['guest_subtitle'] ?: 'En güzel anlarınızı bizimle paylaşın';
 $PROMPT   = $ev['guest_prompt'] ?: 'Adınızı yazıp anınızı yükleyin.';
 $PRIMARY  = $ev['theme_primary'] ?: '#0ea5b5';
@@ -135,6 +43,7 @@ $ACCENT   = $ev['theme_accent']  ?: '#e0f7fb';
 $CAN_VIEW = (int)$ev['allow_guest_view']===1;
 $CAN_DOWN = (int)$ev['allow_guest_download']===1;
 
+/* ---- Çift panelden gelen layout/sticker ---- */
 $layout   = $ev['layout_json'] ?: '{"title":{"x":24,"y":24},"subtitle":{"x":24,"y":60},"prompt":{"x":24,"y":396}}';
 $stickers = $ev['stickers_json'] ?: '[]';
 $layoutArr   = json_decode($layout,true);
@@ -147,1549 +56,198 @@ $tPos = isset($layoutArr['title'])    ? $layoutArr['title']    : array('x'=>24,'
 $sPos = isset($layoutArr['subtitle']) ? $layoutArr['subtitle'] : array('x'=>24,'y'=>60);
 $pPos = isset($layoutArr['prompt'])   ? $layoutArr['prompt']   : array('x'=>24,'y'=>396);
 
+/* ---- Dinamik QR token doğrulama ---- */
 $token_ok = token_valid($event_id, $token);
-$guestProfile = guest_profile_current($event_id);
-if ($guestProfile && (int)$guestProfile['is_verified'] === 1) {
-  if ($token === '' || !$token_ok) {
-    $token = make_token($event_id, current_slot());
-    $token_ok = true;
-  }
-}
 
-if($_SERVER['REQUEST_METHOD']==='POST'){
+/* ---- Yükleme ---- */
+$errors=[]; $okCount=0;
+if($_SERVER['REQUEST_METHOD']==='POST' && ($_POST['do']??'')==='upload'){
   csrf_or_die();
-  $action = $_POST['do'] ?? '';
-  $wantsJson = is_ajax_request();
-  $redirect = BASE_URL.'/public/upload.php?event='.$event_id.'&t='.rawurlencode($token);
-
-  if($action === 'upload'){
-    $errors=[]; $okCount=0; $verificationFlash=null;
-    if($uploadsLocked){
-      $errors[]='Bu etkinlik için yüklemeler kapatıldı.';
-    }
-    $p_token = trim($_POST['t']??'');
-    if(!token_valid($event_id,$p_token)){
-      $errors[]='Güvenlik anahtarı zaman aşımına uğradı. Lütfen QR’ı yeniden okutun.';
-    }else{
-      $guest = trim($_POST['guest_name']??'');
-      $guestEmail = trim($_POST['guest_email']??'');
-      if($guest===''){ $errors[]='Lütfen adınızı yazın.'; }
-      if($guestEmail!==''){ if(!filter_var($guestEmail, FILTER_VALIDATE_EMAIL)){ $errors[]='Geçerli bir e-posta adresi yazın.'; } }
-      $marketingOpt = isset($_POST['marketing_opt_in']);
-      $profileForUpload = $guestProfile;
-      if($guestEmail!=='' && !$errors){
-        try {
-          $profileForUpload = guest_profile_upsert($event_id, $guest, $guestEmail, $marketingOpt);
-          if($profileForUpload){
-            if((int)$profileForUpload['is_verified']===1){
-              guest_profile_set_session($event_id, (int)$profileForUpload['id']);
-              $guestProfile = $profileForUpload;
-            }else{
-              $lastSent = $profileForUpload['last_verification_sent_at'] ?? null;
-              if(!$lastSent || strtotime($lastSent) < time()-600){
-                guest_profile_send_verification($profileForUpload, $ev);
-                $verificationFlash = 'Profilinizi doğrulayabilmeniz için e-posta gönderildi.';
-              }
-            }
-          }
-        } catch(Throwable $e){
-          $errors[]='Profil oluşturulurken bir hata oluştu: '.$e->getMessage();
-        }
-      }
-      if(!isset($_FILES['files'])){ $errors[]='Dosya seçilmedi.'; }
+  $p_token = trim($_POST['t']??'');
+  if(!token_valid($event_id,$p_token)){
+    $errors[]='Güvenlik anahtarı zaman aşımına uğradı. Lütfen QR’ı yeniden okutun.';
+  }else{
+    $guest = trim($_POST['guest_name']??'');
+    if($guest===''){ $errors[]='Lütfen adınızı yazın.'; }
+    if(!isset($_FILES['files'])){ $errors[]='Dosya seçilmedi.'; }
+    else{
+      $f=$_FILES['files'];
+      $n=is_array($f['name'])?count($f['name']):0;
+      if($n<=0) $errors[]='Dosya seçilmedi.';
       else{
-        $f=$_FILES['files'];
-        $n=is_array($f['name'])?count($f['name']):0;
-        if($n<=0) $errors[]='Dosya seçilmedi.';
-        else{
-          $dir=ensure_upload_dir($VID,$event_id);
-          $profileId = $profileForUpload['id'] ?? ($guestProfile['id'] ?? null);
-          $profileEmail = $profileForUpload['email'] ?? ($guestProfile['email'] ?? null);
-          for($i=0;$i<$n;$i++){
-            if($f['error'][$i]!==UPLOAD_ERR_OK){ $errors[]='Yükleme hatası (kod '.$f['error'][$i].')'; continue; }
-            $tmp=$f['tmp_name'][$i]; $nm=$f['name'][$i]; $sz=(int)$f['size'][$i];
-            if($sz<=0 || $sz>MAX_UPLOAD_BYTES){ $errors[]=h($nm).': limit '.round(MAX_UPLOAD_BYTES/1048576).' MB'; continue; }
-            $fi=finfo_open(FILEINFO_MIME_TYPE); $mime=finfo_file($fi,$tmp); finfo_close($fi);
-            if(!isset(ALLOWED_MIMES[$mime])){ $errors[]=h($nm).': desteklenmeyen tür ('.$mime.')'; continue; }
-            $ext=ALLOWED_MIMES[$mime];
-            $base=preg_replace('~[^a-zA-Z0-9-_]+~','_', pathinfo($nm,PATHINFO_FILENAME)); if($base==='') $base='file';
-            $final=$base.'_'.date('Ymd_His').'_'.$i.'_'.bin2hex(random_bytes(3)).'.'.$ext;
-            $dest=$dir.'/'.$final;
-            if(!move_uploaded_file($tmp,$dest)){ $errors[]=h($nm).': taşınamadı'; continue; }
-            $rel='uploads/v'.$VID.'/'.$event_id.'/'.$final;
-            pdo()->prepare("INSERT INTO uploads (venue_id,event_id,guest_name,profile_id,guest_email,file_path,mime,file_size,ip,created_at)
-                            VALUES (?,?,?,?,?,?,?,?,?,?)")
-                ->execute([$VID,$event_id,$guest,$profileId,$profileEmail,$rel,$mime,$sz,client_ip(),now()]);
-            $okCount++;
-          }
+        $dir=ensure_upload_dir($VID,$event_id);
+        for($i=0;$i<$n;$i++){
+          if($f['error'][$i]!==UPLOAD_ERR_OK){ $errors[]='Yükleme hatası (kod '.$f['error'][$i].')'; continue; }
+          $tmp=$f['tmp_name'][$i]; $nm=$f['name'][$i]; $sz=(int)$f['size'][$i];
+          if($sz<=0 || $sz>MAX_UPLOAD_BYTES){ $errors[]=h($nm).': limit '.round(MAX_UPLOAD_BYTES/1048576).' MB'; continue; }
+          $fi=finfo_open(FILEINFO_MIME_TYPE); $mime=finfo_file($fi,$tmp); finfo_close($fi);
+          if(!isset(ALLOWED_MIMES[$mime])){ $errors[]=h($nm).': desteklenmeyen tür ('.$mime.')'; continue; }
+          $ext=ALLOWED_MIMES[$mime];
+          $base=preg_replace('~[^a-zA-Z0-9-_]+~','_', pathinfo($nm,PATHINFO_FILENAME)); if($base==='') $base='file';
+          $final=$base.'_'.date('Ymd_His').'_'.$i.'_'.bin2hex(random_bytes(3)).'.'.$ext;
+          $dest=$dir.'/'.$final;
+          if(!move_uploaded_file($tmp,$dest)){ $errors[]=h($nm).': taşınamadı'; continue; }
+          $rel='uploads/v'.$VID.'/'.$event_id.'/'.$final;
+          pdo()->prepare("INSERT INTO uploads (venue_id,event_id,guest_name,file_path,mime,file_size,ip,created_at)
+                          VALUES (?,?,?,?,?,?,?,?)")
+              ->execute([$VID,$event_id,$guest,$rel,$mime,$sz,client_ip(),now()]);
+          $okCount++;
         }
       }
     }
-    if ($okCount > 0 && !empty($ev['dealer_id'])) {
-      $pdo = pdo();
-      $ownTxn = !$pdo->inTransaction();
-      if ($ownTxn) { $pdo->beginTransaction(); }
-      try {
-        $lock = $pdo->prepare("SELECT dealer_id, dealer_credit_consumed_at FROM events WHERE id=? FOR UPDATE");
-        $lock->execute([$event_id]);
-        if ($row = $lock->fetch()) {
-          $dealerId = (int)$row['dealer_id'];
-          $consumedAt = $row['dealer_credit_consumed_at'];
-          if ($dealerId > 0 && empty($consumedAt)) {
-            dealer_consume_event_credit($dealerId, $event_id);
-            $stamp = now();
-            $pdo->prepare("UPDATE events SET dealer_credit_consumed_at=?, updated_at=? WHERE id=?")
-                ->execute([$stamp, $stamp, $event_id]);
-            $ev['dealer_credit_consumed_at'] = $stamp;
-          }
-        }
-        if ($ownTxn) { $pdo->commit(); }
-      } catch (Throwable $consumeErr) {
-        if ($ownTxn && $pdo->inTransaction()) { $pdo->rollBack(); }
-        error_log('Dealer credit consumption failed for event '.$event_id.': '.$consumeErr->getMessage());
-      }
-    }
-    if($okCount>0){
-      $msg = $okCount.' dosya yüklendi. Teşekkürler!';
-      if($verificationFlash) $msg .= '<br>'.$verificationFlash;
-      flash('ok',$msg);
-      header('Location:'.$redirect); exit;
-    }
-    if($errors){ flash('err',implode('<br>',array_map('h',$errors))); header('Location:'.$redirect); exit; }
-    header('Location:'.$redirect); exit;
   }
-
-  if($action === 'like' || $action === 'unlike'){
-    $uploadId = (int)($_POST['upload_id'] ?? 0);
-    if(!$guestProfile || (int)$guestProfile['is_verified']!==1){
-      respond_error('Beğenmek için e-postanızı doğrulayın.', $redirect, $wantsJson);
-    }
-    $st = pdo()->prepare('SELECT id FROM uploads WHERE id=? AND event_id=? LIMIT 1');
-    $st->execute([$uploadId,$event_id]);
-    if(!$st->fetch()){
-      respond_error('Kayıt bulunamadı.', $redirect, $wantsJson);
-    }
-    if($action==='like'){
-      guest_upload_like($uploadId, (int)$guestProfile['id']);
-    } else {
-      guest_upload_unlike($uploadId, (int)$guestProfile['id']);
-    }
-    guest_profile_touch((int)$guestProfile['id']);
-    $likes = guest_upload_like_count($uploadId);
-    $isLiked = guest_upload_is_liked($uploadId, (int)$guestProfile['id']);
-    if($wantsJson){
-      json_response(['success'=>true,'liked'=>$isLiked,'likes'=>$likes]);
-    }
-    header('Location:'.$redirect.'#media-'.$uploadId); exit;
-  }
-
-  if($action === 'comment'){
-    $uploadId = (int)($_POST['upload_id'] ?? 0);
-    $body = trim($_POST['comment_body'] ?? '');
-    if(!$guestProfile || (int)$guestProfile['is_verified']!==1){
-      respond_error('Yorum yapmak için e-postanızı doğrulayın.', $redirect, $wantsJson, '#media-'.$uploadId);
-    }
-    $st = pdo()->prepare('SELECT id FROM uploads WHERE id=? AND event_id=? LIMIT 1');
-    $st->execute([$uploadId,$event_id]);
-    if(!$st->fetch()){
-      respond_error('Kayıt bulunamadı.', $redirect, $wantsJson, '#media-'.$uploadId);
-    }
-    if($body===''){
-      respond_error('Yorum metni boş olamaz.', $redirect, $wantsJson, '#media-'.$uploadId);
-    }
-    $commentRow = guest_upload_comment_add($uploadId, $guestProfile, $body);
-    guest_profile_touch((int)$guestProfile['id']);
-    $count = guest_upload_comment_count($uploadId);
-    if($wantsJson){
-      $html = $commentRow ? render_comment_block($commentRow) : '';
-      json_response(['success'=>true,'html'=>$html,'count'=>$count]);
-    }
-    flash('ok','Yorumunuz paylaşıldı.');
-    header('Location:'.$redirect.'#media-'.$uploadId); exit;
-  }
-
-  if($action === 'message_guest'){
-    $uploadId = (int)($_POST['upload_id'] ?? 0);
-    $messageBody = trim($_POST['message_body'] ?? '');
-    if(!$guestProfile || (int)$guestProfile['is_verified']!==1){
-      respond_error('Mesaj gönderebilmek için e-postanızı doğrulayın.', $redirect, $wantsJson, '#media-'.$uploadId);
-    }
-    if($messageBody===''){
-      respond_error('Mesaj boş olamaz.', $redirect, $wantsJson, '#media-'.$uploadId);
-    }
-    $st = pdo()->prepare('SELECT u.*, gp.display_name AS profile_display_name, gp.email AS profile_email FROM uploads u LEFT JOIN guest_profiles gp ON gp.id=u.profile_id WHERE u.id=? AND u.event_id=? LIMIT 1');
-    $st->execute([$uploadId,$event_id]);
-    $target = $st->fetch();
-    if(!$target){
-      respond_error('Kayıt bulunamadı.', $redirect, $wantsJson, '#media-'.$uploadId);
-    }
-    if($target['profile_id'] && isset($guestProfile['id']) && (int)$target['profile_id'] === (int)$guestProfile['id']){
-      respond_error('Kendi içeriğinize mesaj gönderemezsiniz.', $redirect, $wantsJson, '#media-'.$uploadId);
-    }
-    $recipientEmail = $target['profile_email'] ?? $target['guest_email'] ?? null;
-    if($recipientEmail){
-      $recipientEmail = trim($recipientEmail);
-      if($recipientEmail === '' || !filter_var($recipientEmail, FILTER_VALIDATE_EMAIL)){
-        $recipientEmail = null;
-      }
-    }
-    if(!$target['profile_id'] && !$recipientEmail){
-      respond_error('Bu misafir henüz iletişim bilgisi paylaşmadı.', $redirect, $wantsJson, '#media-'.$uploadId, 409);
-    }
-    $recipientName = $target['profile_display_name'] ?: ($target['guest_name'] ?: 'Misafir');
-    $recipient = [
-      'profile_id' => $target['profile_id'] ? (int)$target['profile_id'] : null,
-      'upload_id' => $uploadId,
-      'email' => $recipientEmail,
-      'name' => $recipientName
-    ];
-    guest_private_message_send($event_id, $guestProfile, $recipient, $messageBody);
-    if($recipientEmail){
-      $senderName = $guestProfile['display_name'] ?: ($guestProfile['name'] ?? 'Misafir');
-      $galleryUrl = public_upload_url($event_id).'#media-'.$uploadId;
-      $html = '<div style="font-family:Inter,Arial,sans-serif;background:#f8fafc;padding:24px">'
-            .'<div style="max-width:520px;margin:0 auto;background:#ffffff;border-radius:18px;padding:32px;box-shadow:0 18px 45px rgba(15,23,42,0.08);">'
-            .'<h2 style="margin-top:0;color:#0ea5b5;font-size:22px;">BİKARE topluluğundan yeni mesaj</h2>'
-            .'<p style="color:#475569;font-size:15px;line-height:1.6;">Merhaba '.h($recipientName).', '.h($senderName).' sana özel bir mesaj gönderdi:</p>'
-            .'<blockquote style="margin:18px 0;padding:18px;border-left:4px solid #0ea5b5;background:#f1fcfd;border-radius:14px;color:#0f172a;line-height:1.6;">'.nl2br(h($messageBody)).'</blockquote>'
-            .'<p style="color:#475569;font-size:14px;line-height:1.6;">Etkinlik sayfasına geri dönmek istersen aşağıdaki bağlantıya tıklayabilirsin.</p>'
-            .'<p style="text-align:center;margin:24px 0"><a href="'.h($galleryUrl).'" style="background:#0ea5b5;color:#fff;text-decoration:none;padding:12px 22px;border-radius:999px;font-weight:600;display:inline-block;">Misafir Alanını Aç</a></p>'
-            .'</div></div>';
-      send_smtp_mail($recipientEmail, 'BİKARE misafirinden yeni mesaj', $html);
-    }
-    $successMsg = 'Mesajınız ilgili misafire iletildi.';
-    if($wantsJson){
-      json_response(['success'=>true,'message'=>$successMsg]);
-    }
-    flash('ok',$successMsg);
-    header('Location:'.$redirect.'#media-'.$uploadId); exit;
-  }
-
-  if($action === 'conversation'){
-    $targetId = (int)($_POST['target_profile_id'] ?? 0);
-    if(!$guestProfile || (int)$guestProfile['is_verified']!==1){
-      json_response(['success'=>false,'error'=>'Mesajlaşma için e-postanızı doğrulayın.'], 403);
-    }
-    if($targetId <= 0){
-      json_response(['success'=>false,'error'=>'Geçerli bir misafir seçin.'], 422);
-    }
-    $targetProfile = guest_profile_find_by_id($targetId);
-    if(!$targetProfile || (int)$targetProfile['event_id'] !== $event_id){
-      json_response(['success'=>false,'error'=>'Misafir bulunamadı.'], 404);
-    }
-    if((int)$targetProfile['id'] === (int)$guestProfile['id']){
-      json_response(['success'=>false,'error'=>'Kendinize mesaj gönderemezsiniz.'], 409);
-    }
-    $raw = guest_private_conversation($event_id, (int)$guestProfile['id'], (int)$targetProfile['id']);
-    $messages = [];
-    foreach($raw as $row){
-      $isMine = (int)$row['sender_profile_id'] === (int)$guestProfile['id'];
-      $senderName = $isMine ? 'Siz' : ($row['sender_display_name'] ?: 'Misafir');
-      $messages[] = [
-        'id' => (int)$row['id'],
-        'body' => $row['body'],
-        'body_html' => nl2br(h($row['body'] ?? '')),
-        'meta' => $senderName.' • '.relative_time($row['created_at']),
-        'isMine' => $isMine,
-        'created_at' => $row['created_at'],
-      ];
-    }
-    json_response([
-      'success' => true,
-      'messages' => $messages,
-      'target' => [
-        'id' => (int)$targetProfile['id'],
-        'name' => $targetProfile['display_name'] ?: ($targetProfile['name'] ?? 'Misafir')
-      ]
-    ]);
-  }
-
-  if($action === 'message_profile'){
-    $targetId = (int)($_POST['target_profile_id'] ?? 0);
-    $messageBody = trim($_POST['message_body'] ?? '');
-    $uploadContext = (int)($_POST['context_upload_id'] ?? 0);
-    if(!$guestProfile || (int)$guestProfile['is_verified']!==1){
-      json_response(['success'=>false,'error'=>'Mesaj gönderebilmek için e-postanızı doğrulayın.'], 403);
-    }
-    if($targetId <= 0){
-      json_response(['success'=>false,'error'=>'Geçerli bir misafir seçin.'], 422);
-    }
-    if($messageBody === ''){
-      json_response(['success'=>false,'error'=>'Mesaj boş olamaz.'], 422);
-    }
-    $targetProfile = guest_profile_find_by_id($targetId);
-    if(!$targetProfile || (int)$targetProfile['event_id'] !== $event_id){
-      json_response(['success'=>false,'error'=>'Misafir bulunamadı.'], 404);
-    }
-    if((int)$targetProfile['id'] === (int)$guestProfile['id']){
-      json_response(['success'=>false,'error'=>'Kendinize mesaj gönderemezsiniz.'], 409);
-    }
-    try {
-      $row = guest_private_message_to_profile(
-        $event_id,
-        $guestProfile,
-        $targetProfile,
-        $messageBody,
-        $uploadContext > 0 ? $uploadContext : null
-      );
-    } catch (Throwable $e) {
-      error_log('guest_private_message_to_profile failed: '.$e->getMessage());
-      $row = null;
-    }
-    if(!$row){
-      json_response(['success'=>false,'error'=>'Mesaj gönderilirken bir hata oluştu.'], 500);
-    }
-    $recipientEmail = $targetProfile['email'] ?? null;
-    if($recipientEmail){
-      $recipientEmail = trim($recipientEmail);
-      if($recipientEmail !== '' && filter_var($recipientEmail, FILTER_VALIDATE_EMAIL)){
-        $recipientName = $targetProfile['display_name'] ?: ($targetProfile['name'] ?? 'Misafir');
-        $senderName = $guestProfile['display_name'] ?: ($guestProfile['name'] ?? 'Misafir');
-        $galleryUrl = public_upload_url($event_id);
-        if($uploadContext > 0){
-          $galleryUrl .= '#media-'.$uploadContext;
-        }
-        $html = '<div style="font-family:Inter,Arial,sans-serif;background:#f8fafc;padding:24px">'
-              .'<div style="max-width:520px;margin:0 auto;background:#ffffff;border-radius:18px;padding:32px;box-shadow:0 18px 45px rgba(15,23,42,0.08);">'
-              .'<h2 style="margin-top:0;color:#0ea5b5;font-size:22px;">BİKARE topluluğundan yeni mesaj</h2>'
-              .'<p style="color:#475569;font-size:15px;line-height:1.6;">Merhaba '.h($recipientName).', '.h($senderName).' sana özel bir mesaj gönderdi:</p>'
-              .'<blockquote style="margin:18px 0;padding:18px;border-left:4px solid #0ea5b5;background:#f1fcfd;border-radius:14px;color:#0f172a;line-height:1.6;">'.nl2br(h($messageBody)).'</blockquote>'
-              .'<p style="color:#475569;font-size:14px;line-height:1.6;">Etkinlik sayfasına geri dönmek istersen aşağıdaki bağlantıya tıklayabilirsin.</p>'
-              .'<p style="text-align:center;margin:24px 0"><a href="'.h($galleryUrl).'" style="background:#0ea5b5;color:#fff;text-decoration:none;padding:12px 22px;border-radius:999px;font-weight:600;display:inline-block;">Misafir Alanını Aç</a></p>'
-              .'</div></div>';
-        send_smtp_mail($recipientEmail, 'BİKARE misafirinden yeni mesaj', $html);
-      }
-    }
-    $entry = [
-      'id' => (int)$row['id'],
-      'body' => $row['body'],
-      'body_html' => nl2br(h($row['body'] ?? '')),
-      'meta' => 'Siz • '.relative_time($row['created_at']),
-      'isMine' => true,
-      'created_at' => $row['created_at']
-    ];
-    json_response([
-      'success' => true,
-      'message' => 'Mesajınız ilgili misafire iletildi.',
-      'entry' => $entry
-    ]);
-  }
-
-  if($action === 'note_host'){
-    $body = trim($_POST['host_message'] ?? '');
-    if(!$guestProfile || (int)$guestProfile['is_verified']!==1){
-      respond_error('Özel not göndermek için e-postanızı doğrulayın.', $redirect, $wantsJson, '#host-note');
-    }
-    if($body===''){
-      respond_error('Mesaj boş olamaz.', $redirect, $wantsJson, '#host-note');
-    }
-    guest_event_note_add($event_id, $guestProfile, $body);
-    guest_profile_touch((int)$guestProfile['id']);
-    $hostEmail = event_host_email($ev);
-    if($hostEmail){
-      $senderName = $guestProfile['display_name'] ?: ($guestProfile['name'] ?? 'Misafir');
-      $senderEmail = $guestProfile['email'] ?? '';
-      $galleryUrl = public_upload_url($event_id);
-      $html = '<div style="font-family:Inter,Arial,sans-serif;background:#f8fafc;padding:24px">'
-            .'<div style="max-width:520px;margin:0 auto;background:#ffffff;border-radius:18px;padding:32px;box-shadow:0 18px 45px rgba(15,23,42,0.08);">'
-            .'<h2 style="margin-top:0;color:#0ea5b5;font-size:22px;">Misafirlerinizden yeni bir not</h2>'
-            .'<p style="color:#475569;font-size:15px;line-height:1.6;">'.h($senderName).' etkinliğiniz için güzel bir mesaj bıraktı:</p>'
-            .'<blockquote style="margin:18px 0;padding:18px;border-left:4px solid #0ea5b5;background:#f1fcfd;border-radius:14px;color:#0f172a;line-height:1.6;">'.nl2br(h($body)).'</blockquote>'
-            .($senderEmail ? '<p style="color:#94a3b8;font-size:13px;">Gönderen e-posta: '.h($senderEmail).'</p>' : '')
-            .'<p style="text-align:center;margin:24px 0"><a href="'.h($galleryUrl).'" style="background:#0ea5b5;color:#fff;text-decoration:none;padding:12px 22px;border-radius:999px;font-weight:600;display:inline-block;">Etkinlik Alanını Aç</a></p>'
-            .'</div></div>';
-      send_smtp_mail($hostEmail, 'BİKARE etkinliğiniz için yeni bir misafir notu', $html);
-    }
-    $successMsg = 'Mesajınız etkinlik sahibine gönderildi.';
-    if($wantsJson){
-      json_response(['success'=>true,'message'=>$successMsg]);
-    }
-    flash('ok',$successMsg);
-    header('Location:'.$redirect.'#host-note'); exit;
-  }
-
-  if($action === 'chat'){
-    if(!$guestProfile || (int)$guestProfile['is_verified']!==1){
-      flash('err','Sohbete katılmak için e-postanızı doğrulayın.');
-      header('Location:'.$redirect.'#chat'); exit;
-    }
-    $message = trim($_POST['chat_message'] ?? '');
-    if($message===''){ flash('err','Mesaj boş olamaz.'); header('Location:'.$redirect.'#chat'); exit; }
-    guest_chat_add_message($event_id, $guestProfile, $message, null);
-    flash('ok','Mesajın paylaşıldı.');
-    header('Location:'.$redirect.'#chat'); exit;
-  }
-  if($action === 'profile'){
-    if(!$guestProfile){ flash('err','Profilinizi düzenlemek için önce e-posta adresinizle kayıt olun.'); header('Location:'.$redirect.'#profile'); exit; }
-    $display = trim($_POST['display_name'] ?? '');
-    $bio = trim($_POST['bio'] ?? '');
-    $avatar = trim($_POST['avatar_token'] ?? '');
-    $marketing = isset($_POST['profile_marketing']);
-    guest_profile_update((int)$guestProfile['id'], $display, $bio, $avatar, $marketing);
-    flash('ok','Profiliniz güncellendi.');
-    header('Location:'.$redirect.'#profile'); exit;
-  }
-  if($action === 'resend_verification'){
-    if(!$guestProfile){ flash('err','Önce e-posta adresinizle bir içerik yükleyin.'); header('Location:'.$redirect); exit; }
-    if((int)$guestProfile['is_verified']===1){ flash('ok','Profiliniz zaten doğrulandı.'); header('Location:'.$redirect); exit; }
-    $lastSent = $guestProfile['last_verification_sent_at'] ?? null;
-    if($lastSent && strtotime($lastSent) > time()-300){
-      flash('err','Yeni bir bağlantı göndermeden önce birkaç dakika bekleyin.');
-      header('Location:'.$redirect); exit;
-    }
-    guest_profile_send_verification($guestProfile, $ev);
-    flash('ok','Doğrulama bağlantısı e-posta adresinize gönderildi.');
-    header('Location:'.$redirect); exit;
-  }
+  $to=BASE_URL.'/public/upload.php?event='.$event_id.'&t='.rawurlencode($token);
+  if($okCount>0){ flash('ok',$okCount.' dosya yüklendi. Teşekkürler!'); header('Location:'.$to); exit; }
+  if($errors){ flash('err',implode('<br>',array_map('h',$errors))); header('Location:'.$to); exit; }
 }
 
-
-$guestProfile = guest_profile_current($event_id);
-$profileVerified = $guestProfile && (int)$guestProfile['is_verified']===1;
-$guestDirectory = [];
-if ($guestProfile && $profileVerified) {
-  $guestDirectory = guest_event_profile_directory($event_id, (int)$guestProfile['id']);
-}
-
-$uploads=[]; $uploadLikes=[]; $uploadLikedByMe=[]; $uploadComments=[]; $commentCounts=[];
+/* ---- Galeri ---- */
+$uploads=[];
 if($CAN_VIEW){
-  $st=pdo()->prepare("SELECT u.id,u.guest_name,u.profile_id,u.guest_email,u.file_path,u.mime,u.file_size,u.created_at,
-                             gp.display_name AS profile_display_name,gp.avatar_token AS profile_avatar_token,gp.is_verified AS profile_verified
-                      FROM uploads u
-                      LEFT JOIN guest_profiles gp ON gp.id=u.profile_id
-                      WHERE u.venue_id=? AND u.event_id=?
-                      ORDER BY u.id DESC LIMIT 300");
+  $st=pdo()->prepare("SELECT id,guest_name,file_path,mime,file_size,created_at
+                      FROM uploads WHERE venue_id=? AND event_id=? ORDER BY id DESC LIMIT 300");
   $st->execute([$VID,$event_id]);
   $uploads=$st->fetchAll();
-  $uploadIds = array_column($uploads,'id');
-  if($uploadIds){
-    $placeholders = implode(',', array_fill(0,count($uploadIds),'?'));
-    $st=pdo()->prepare("SELECT upload_id, COUNT(*) AS cnt FROM guest_upload_likes WHERE upload_id IN ($placeholders) GROUP BY upload_id");
-    $st->execute($uploadIds);
-    foreach($st->fetchAll() as $row){ $uploadLikes[(int)$row['upload_id']] = (int)$row['cnt']; }
-    if($profileVerified){
-      $params = array_merge([(int)$guestProfile['id']], $uploadIds);
-      $st=pdo()->prepare("SELECT upload_id FROM guest_upload_likes WHERE profile_id=? AND upload_id IN ($placeholders)");
-      $st->execute($params);
-      foreach($st->fetchAll() as $row){ $uploadLikedByMe[(int)$row['upload_id']] = true; }
-    }
-    $st=pdo()->prepare("SELECT c.*, gp.display_name AS profile_display_name, gp.avatar_token AS profile_avatar_token
-                         FROM guest_upload_comments c
-                         LEFT JOIN guest_profiles gp ON gp.id=c.profile_id
-                         WHERE c.upload_id IN ($placeholders)
-                         ORDER BY c.created_at ASC");
-    $st->execute($uploadIds);
-    foreach($st->fetchAll() as $c){
-      $uid = (int)$c['upload_id'];
-      if(!isset($uploadComments[$uid])) $uploadComments[$uid]=[];
-      $uploadComments[$uid][] = $c;
-      $commentCounts[$uid] = ($commentCounts[$uid] ?? 0) + 1;
-    }
-  }
 }
-
-$chatMessages=[];
-$st = pdo()->prepare("SELECT m.*, gp.display_name, gp.avatar_token FROM guest_chat_messages m
-                      LEFT JOIN guest_profiles gp ON gp.id=m.profile_id
-                      WHERE m.event_id=? ORDER BY m.id DESC LIMIT 60");
-$st->execute([$event_id]);
-$chatMessages = array_reverse($st->fetchAll());
 ?>
 <!doctype html>
 <html lang="tr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title><?=h($ev['title'])?> — Misafir Sosyal Alanı</title>
+<title><?=h($ev['title'])?> — Misafir Yükleme</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <style>
-:root{
-  --zs:<?=h($PRIMARY)?>;
-  --zs-soft:<?=h($ACCENT)?>;
-  --ink:#0f172a;
-  --muted:#5f6b7e;
-  --line:rgba(15,23,42,.08);
-  --surface:#ffffff;
-}
-body{
-  background:#f5f9fa;
-  font-family:'Inter','Helvetica Neue',Arial,sans-serif;
-  color:var(--ink);
-}
-.page-wrap{ max-width:1200px; margin:0 auto; }
-.card-lite{
-  border:1px solid var(--line);
-  border-radius:18px;
-  background:var(--surface);
-  box-shadow:0 12px 28px rgba(15,23,42,.04);
-}
-.btn-zs{
-  background:var(--zs);
-  border:none;
-  color:#fff;
-  border-radius:12px;
-  padding:.6rem 1.1rem;
-  font-weight:600;
-  transition:background .2s ease, box-shadow .2s ease;
-}
-.btn-zs:disabled{ background:rgba(148,163,184,.5); }
-.btn-zs:not(:disabled):hover{ background:#0b8d9b; color:#fff; box-shadow:0 10px 18px rgba(14,165,181,.18); }
-.btn-zs-outline{
-  background:transparent;
-  border:1px solid var(--zs);
-  color:var(--zs);
-  border-radius:12px;
-  font-weight:600;
-  padding:.55rem 1.1rem;
-  transition:all .2s ease;
-}
-.btn-zs-outline:hover{ background:var(--zs); color:#fff; }
-.hero{
-  background:var(--surface);
-  border:1px solid var(--line);
-  border-radius:20px;
-  padding:32px;
-}
-.hero-badge{
-  display:inline-flex;
-  align-items:center;
-  gap:8px;
-  background:rgba(14,165,181,.14);
-  color:var(--zs);
-  padding:6px 14px;
-  border-radius:999px;
-  font-size:14px;
-  font-weight:600;
-}
-.page-grid{ display:grid; gap:28px; margin-top:32px; }
-@media (min-width:992px){ .page-grid{ grid-template-columns:2fr 1fr; } }
-.upload-card{ padding:28px; }
-.upload-card h5{ font-weight:700; }
-.dropzone{
-  border:2px dashed rgba(15,23,42,.12);
-  border-radius:18px;
-  padding:32px;
-  text-align:center;
-  background:#f2fafb;
-  transition:all .2s ease;
-}
-.dropzone.drag{ border-color:var(--zs); background:rgba(14,165,181,.12); }
-.form-text{ color:var(--muted); }
-.gallery-card{ padding:28px; }
-.gallery-grid{
-  display:grid;
-  grid-template-columns:repeat(auto-fill,minmax(280px,1fr));
-  gap:28px;
-  align-items:stretch;
-}
-@media (min-width:1200px){ .gallery-grid{ grid-template-columns:repeat(auto-fill,minmax(340px,1fr)); } }
-.gallery-item{
-  display:flex;
-  flex-direction:column;
-  border-radius:18px;
-  overflow:hidden;
-  background:var(--surface);
-  border:1px solid var(--line);
-  box-shadow:0 10px 28px rgba(15,23,42,.05);
-  transition:transform .2s ease, box-shadow .2s ease;
-  height:100%;
-}
-.gallery-item:hover{ transform:translateY(-4px); box-shadow:0 16px 34px rgba(15,23,42,.08); }
-.gallery-media{
-  position:relative;
-  width:100%;
-  background:#edf7f8;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  padding:18px 18px 0;
-}
-.gallery-media img,
-.gallery-media video{
-  width:100%;
-  height:auto;
-  max-height:360px;
-  display:block;
-  object-fit:contain;
-  border-radius:14px;
-  box-shadow:none;
-}
-.gallery-header{
-  display:flex;
-  align-items:center;
-  gap:14px;
-  padding:18px 22px;
-  background:#f7fbfc;
-  border-bottom:1px solid var(--line);
-}
-.gallery-author{ font-weight:700; font-size:15px; color:#0f172a; letter-spacing:.01em; }
-.avatar{
-  width:44px;
-  height:44px;
-  border-radius:50%;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  font-weight:700;
-  letter-spacing:.4px;
-  border:2px solid rgba(14,165,181,.18);
-  box-shadow:none;
-}
-.gallery-actions{
-  display:flex;
-  align-items:center;
-  justify-content:space-between;
-  padding:16px 22px 14px;
-  gap:16px;
-  background:#fff;
-  border-top:1px solid var(--line);
-}
-.action-buttons{ display:flex; align-items:center; gap:10px; }
-.icon-btn{
-  border:none;
-  background:#eef6f7;
-  border-radius:999px;
-  padding:8px 16px;
-  display:flex;
-  align-items:center;
-  gap:8px;
-  font-weight:600;
-  color:#0a5160;
-  cursor:pointer;
-  transition:background .2s ease, color .2s ease;
-}
-.icon-btn span{ display:inline-flex; align-items:center; }
-.icon-btn .like-count{ font-variant-numeric:tabular-nums; }
-.icon-btn.active{ background:var(--zs); color:#fff; }
-.icon-btn:not(.active):hover{ background:rgba(14,165,181,.18); color:#064752; }
-.icon-btn:disabled{ cursor:not-allowed; opacity:.6; }
-.gallery-actions .btn{
-  border-radius:12px;
-  border:1px solid rgba(14,165,181,.28);
-  color:#0a4d58;
-  background:transparent;
-  font-weight:600;
-  padding:.5rem 1rem;
-}
-.gallery-actions .btn:hover{ background:var(--zs); color:#fff; }
-.gallery-meta{ font-size:13px; color:#5f7a8a; }
-.gallery-body{
-  padding:20px 22px 24px;
-  background:var(--surface);
-  color:var(--ink);
-  display:flex;
-  flex-direction:column;
-  gap:16px;
-  flex:1;
-}
-.gallery-body .comment-section{ margin-top:auto; }
-.gallery-body p{ color:#2f4f5d; }
-.gallery-body .smallmuted{ color:#5f7a8a; }
-.comment{
-  padding:12px 14px;
-  border-radius:14px;
-  background:#edf7f8;
-  margin-top:0;
-  color:#0a4550;
-}
-.gallery-item .comment strong{ display:block; font-size:13px; color:#0a4550; }
-.gallery-item .comment p{ margin:6px 0 0; font-size:13px; color:#0b5f6c; }
-.gallery-item .comment .smallmuted{ color:#5f7a8a; }
-.comment-form textarea{ resize:vertical; border-radius:14px; }
-.gallery-item .comment-form textarea{ background:#f4fbfc; border-color:rgba(14,165,181,.25); color:var(--ink); }
-.gallery-item .comment-form textarea::placeholder{ color:#86aab2; }
-.gallery-item .comment-form textarea:focus{ background:#ecfbfd; border-color:rgba(14,165,181,.4); box-shadow:0 0 0 .25rem rgba(14,165,181,.18); }
-.comment-form{ display:flex; flex-direction:column; gap:10px; }
-.comment-form .btn{ align-self:flex-end; }
-.comment-section{ margin-top:16px; padding-top:12px; border-top:1px solid var(--line); }
-.comment-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; }
-.comment-toggle{
-  border:none;
-  background:#eef6f7;
-  color:#0a5160;
-  font-weight:600;
-  padding:6px 14px;
-  border-radius:999px;
-  cursor:pointer;
-  transition:background .2s ease, color .2s ease;
-}
-.comment-toggle:hover{ background:rgba(14,165,181,.18); color:#064752; }
-.comment-body{ margin-top:12px; display:flex; flex-direction:column; gap:12px; }
-.comment-section.collapsed .comment-body{ display:none; }
-.comment-list{ display:flex; flex-direction:column; gap:10px; }
-.comment-body .icon-btn{ align-self:flex-start; }
-.note-card textarea{ min-height:140px; }
-.form-feedback{ color:var(--zs); font-weight:600; }
-.form-feedback.error{ color:#ef4444; }
-.badge-soft{
-  background:rgba(14,165,181,.16);
-  color:#0a5160;
-  border-radius:999px;
-  padding:4px 12px;
-  font-size:12px;
-  font-weight:600;
-}
-.guest-directory{ max-height:360px; overflow:auto; display:flex; flex-direction:column; gap:10px; }
-.guest-card{
-  display:flex;
-  align-items:center;
-  justify-content:space-between;
-  gap:12px;
-  padding:12px 16px;
-  border-radius:14px;
-  border:1px solid var(--line);
-  background:#f7fbfc;
-  transition:all .2s ease;
-  text-align:left;
-}
-.guest-card:hover{ background:#fff; transform:translateY(-3px); box-shadow:0 12px 28px rgba(15,23,42,.07); }
-.guest-card .guest-info{ display:flex; align-items:center; gap:12px; }
-.guest-card .guest-meta{ font-size:12px; color:var(--muted); }
-.guest-card .message-pill{
-  display:flex;
-  align-items:center;
-  gap:6px;
-  font-size:12px;
-  color:#0a5160;
-  font-weight:600;
-}
-.conversation-stream{ max-height:420px; overflow:auto; display:flex; flex-direction:column; gap:14px; padding-right:6px; }
-.conversation-bubble{
-  max-width:78%;
-  padding:14px 18px;
-  border-radius:18px;
-  background:#f4fbfc;
-  color:var(--ink);
-  position:relative;
-  box-shadow:0 10px 20px rgba(15,23,42,.05);
-}
-.conversation-bubble.mine{ margin-left:auto; background:var(--zs); color:#fff; box-shadow:0 12px 26px rgba(14,165,181,.22); }
-.conversation-bubble .meta{ font-size:11px; opacity:.8; margin-bottom:4px; }
-.conversation-bubble.mine .meta{ color:rgba(255,255,255,.75); }
-.bubble-placeholder{
-  display:inline-flex;
-  align-items:center;
-  gap:12px;
-  background:#eef6f7;
-  color:#0a5160;
-  padding:14px 18px;
-  border-radius:16px;
-  font-weight:600;
-}
-.bubble-placeholder::before{
-  content:"";
-  width:16px;
-  height:16px;
-  border:3px solid rgba(14,165,181,.28);
-  border-top-color:var(--zs);
-  border-radius:50%;
-  animation:spin 1s linear infinite;
-}
-.bubble-placeholder.error{ background:rgba(239,68,68,.12); color:#b91c1c; }
-.bubble-placeholder.error::before{ border-color:rgba(239,68,68,.24); border-top-color:#ef4444; }
-.bubble-placeholder.empty::before{ display:none; }
-@keyframes spin{ from{ transform:rotate(0deg);} to{ transform:rotate(360deg);} }
-.conversation-footer{ display:flex; gap:12px; align-items:flex-end; padding-top:16px; }
-.conversation-footer textarea{ flex:1; border-radius:14px; resize:none; min-height:80px; }
-.conversation-footer button{
-  border:none;
-  background:var(--zs);
-  color:#fff;
-  border-radius:12px;
-  padding:10px 18px;
-  font-weight:600;
-  transition:background .2s ease;
-}
-.conversation-footer button:hover{ background:#0b8d9b; }
-.profile-card{ padding:28px; }
-.profile-card h5{ font-weight:700; }
-.message-card{ padding:28px; }
-.chat-card{ padding:28px; }
-.chat-stream{ max-height:420px; overflow:auto; display:flex; flex-direction:column; gap:12px; }
-.chat-bubble{ padding:14px 18px; border-radius:16px; background:#f4fbfc; color:#0f172a; }
-.chat-author{ font-weight:600; font-size:14px; color:#0f172a; }
-.chat-time{ font-size:12px; color:var(--muted); }
-.preview-shell{ width:min(100%,900px); margin:0 auto; }
-.preview-stage{ position:relative; width:100%; border:1px dashed rgba(15,23,42,.18); border-radius:18px; background:#fff; overflow:hidden; }
-.stage-scale{ position:absolute; left:0; top:0; width:960px; height:540px; transform-origin:top left; transform:scale(var(--s,1)); }
-.preview-canvas{ position:absolute; inset:0; background:linear-gradient(180deg,var(--zs-soft),#fff); }
-.pv-title{ position:absolute; font-size:28px; font-weight:800; color:#111; }
-.pv-sub{ position:absolute; color:#334155; font-size:16px; }
-.pv-prompt{ position:absolute; color:#0f172a; font-size:16px; }
-.sticker{ position:absolute; user-select:none; pointer-events:none; }
-.smallmuted{ color:var(--muted); font-size:13px; }
-.share-toast{
-  position:fixed;
-  left:50%;
-  bottom:32px;
-  transform:translateX(-50%);
-  background:var(--zs);
-  color:#fff;
-  padding:10px 18px;
-  border-radius:999px;
-  font-weight:600;
-  box-shadow:0 12px 24px rgba(14,165,181,.2);
-  opacity:0;
-  transition:.4s;
-  pointer-events:none;
-}
-.share-toast.show{ opacity:1; }
+:root{ --zs:<?=h($PRIMARY)?>; --zs-soft:<?=h($ACCENT)?>; --ink:#111827; --muted:#6b7280 }
+body{ background:linear-gradient(180deg,var(--zs-soft),#fff) }
+.card-lite{ border:1px solid #eef2f7; border-radius:18px; background:#fff; box-shadow:0 6px 20px rgba(17,24,39,.05) }
+.btn-zs{ background:var(--zs); border:none; color:#fff; border-radius:12px; padding:.65rem 1rem; font-weight:700 }
+.btn-zs-outline{ background:#fff; border:1px solid var(--zs); color:var(--zs); border-radius:12px; font-weight:700 }
+.dropzone{ border:2px dashed #cbd5e1; border-radius:16px; padding:24px; text-align:center; background:#fff; transition:.2s }
+.dropzone.drag{ border-color:var(--zs); background:#f0fbfd }
+.smallmuted{ color:var(--muted) }
+.thumb{ overflow:hidden; border-radius:12px; border:1px solid #e5e7eb; background:#f8fafc }
+.thumb img,.thumb video{ width:100%; height:180px; object-fit:cover; display:block }
+.badge-soft{ background:#eef2ff; color:#334155 }
+
+/* === 960×540 ölçekli sahne (çift panelle birebir) === */
+.preview-shell{ width:min(100%,980px); margin:0 auto }
+.preview-stage{ position:relative; width:100%; border:1px dashed #cbd5e1; border-radius:16px; background:#fff; overflow:hidden }
+.stage-scale{ position:absolute; left:0; top:0; width:960px; height:540px; transform-origin:top left; transform:scale(var(--s,1)) }
+.preview-canvas{ position:absolute; inset:0; background:linear-gradient(180deg,var(--zs-soft),#fff) }
+.pv-title{ position:absolute; font-size:28px; font-weight:800; color:#111 }
+.pv-sub{ position:absolute; color:#334155; font-size:16px }
+.pv-prompt{ position:absolute; color:#0f172a; font-size:16px }
+.sticker{ position:absolute; user-select:none; pointer-events:none }
 </style>
 </head>
 <body>
-<div class="container-lg page-wrap py-5 px-3 px-lg-4">
+<div class="container py-4">
   <?php flash_box(); ?>
-  <section class="hero mb-4">
-    <div class="d-flex flex-column flex-lg-row align-items-start align-items-lg-center justify-content-between gap-3">
-      <div>
-        <span class="hero-badge">BİKARE Misafir Alanı</span>
-        <h1 class="mt-3 mb-2" style="font-weight:800; font-size:32px; color:var(--ink);"><?=h($TITLE)?></h1>
-        <p class="mb-3" style="font-size:16px; color:var(--muted); max-width:560px;"><?=h($SUBTITLE)?></p>
-        <?php if($guestProfile): ?>
-          <?php if($profileVerified): ?>
-            <div class="badge-soft">Hoş geldin, <?=h($guestProfile['display_name'] ?: $guestProfile['name'])?>! Profilin doğrulandı.</div>
-          <?php else: ?>
-            <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-2">
-              <div class="badge-soft">E-posta doğrulaması bekleniyor</div>
-              <form method="post" class="d-flex">
-                <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-                <input type="hidden" name="do" value="resend_verification">
-                <button class="btn btn-zs-outline btn-sm">Bağlantıyı tekrar gönder</button>
-              </form>
-            </div>
-          <?php endif; ?>
-        <?php else: ?>
-          <div class="badge-soft">Adınızı ve e-postanızı paylaşarak misafir topluluğuna katılın.</div>
-        <?php endif; ?>
-      </div>
-      <div class="text-end smallmuted">
-        <div>Etkinlik Tarihi: <?= $ev['event_date'] ? date('d.m.Y', strtotime($ev['event_date'])) : 'Belirtilmedi' ?></div>
-        <?php if($uploadDeadline): ?>
-          <div>Yükleme Süresi: <?= date('d.m.Y', $uploadDeadline) ?><?= $uploadsLocked ? ' • Kapalı' : '' ?></div>
-        <?php endif; ?>
-        <div>Misafir bağlantısı bu sayfadır.</div>
+
+  <div class="card-lite p-3 mb-4">
+    <div class="preview-shell">
+      <div class="preview-stage" id="pvStage">
+        <div class="stage-scale" id="scaleBox">
+          <div class="preview-canvas">
+            <div class="pv-title"  style="left:<?= (int)$tPos['x']?>px; top:<?= (int)$tPos['y']?>px;"><?=h($TITLE)?></div>
+            <div class="pv-sub"    style="left:<?= (int)$sPos['x']?>px; top:<?= (int)$sPos['y']?>px;"><?=h($SUBTITLE)?></div>
+            <div class="pv-prompt" style="left:<?= (int)$pPos['x']?>px; top:<?= (int)$pPos['y']?>px;"><?=h($PROMPT)?></div>
+            <?php foreach($stickersArr as $st){
+              $txt = isset($st['txt'])?$st['txt']:'💍';
+              $x   = isset($st['x'])?(int)$st['x']:20;
+              $y   = isset($st['y'])?(int)$st['y']:90;
+              $sz  = isset($st['size'])?(int)$st['size']:32; ?>
+              <div class="sticker" style="left:<?=$x?>px; top:<?=$y?>px; font-size:<?=$sz?>px"><?=$txt?></div>
+            <?php } ?>
+          </div>
+        </div>
       </div>
     </div>
-  </section>
-  <div class="page-grid">
-    <div class="vstack gap-4">
-      <div class="card-lite upload-card">
-        <h5 class="mb-3">Anınızı Yükleyin</h5>
-        <p class="smallmuted mb-4">Fotoğraflar, videolar ve GIF’ler yüksek kalitede saklanır. Yükledikten sonra topluluk beğenebilir, yorum yapabilir ve paylaşabilir.</p>
-        <?php if($uploadsLocked): ?>
-          <div class="alert alert-warning" role="alert">Bu etkinlik için yüklemeler etkinlik tarihinden 10 gün sonra otomatik olarak kapanır. Yeni içerik ekleyemezsiniz.</div>
-        <?php endif; ?>
-        <form method="post" enctype="multipart/form-data" id="upForm" class="vstack gap-4" <?= $uploadsLocked ? 'data-locked="1"' : '' ?>>
-          <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-          <input type="hidden" name="do" value="upload">
-          <input type="hidden" name="t" value="<?=h($token)?>">
-          <div class="row g-3">
-            <div class="col-md-6">
-              <label class="form-label">Adınız Soyadınız *</label>
-              <input class="form-control" name="guest_name" placeholder="Ör. Ayşe Yılmaz" required <?= (!$token_ok || $uploadsLocked)?'disabled':'' ?>>
-            </div>
-            <div class="col-md-6">
-              <label class="form-label">E-posta (opsiyonel)</label>
-              <input class="form-control" type="email" name="guest_email" placeholder="ornek@mail.com" <?= (!$token_ok || $uploadsLocked)?'disabled':'' ?>>
-              <div class="form-text">Düğün sonrasında size gönderilecek kullanıcı adı ve şifreniz için e-posta adresinizi paylaşabilirsiniz.</div>
-            </div>
-          </div>
-          <div class="form-check">
-            <input class="form-check-input" type="checkbox" name="marketing_opt_in" value="1" id="marketingOpt" <?= (!$token_ok || $uploadsLocked)?'disabled':'' ?>>
-            <label class="form-check-label" for="marketingOpt">BİKARE’den kampanya ve yenilik bildirimleri almak istiyorum.</label>
-          </div>
-          <div class="dropzone" id="drop" <?= (!$token_ok || $uploadsLocked)?'data-disabled="1"':'' ?>>
-            <p class="m-0">
-              <strong>Dosyalarınızı buraya sürükleyin</strong> veya
-              <label class="text-decoration-underline" style="cursor:pointer">cihazınızdan seçin
-                <input type="file" name="files[]" id="fileI" accept="<?=implode(',',array_keys(ALLOWED_MIMES))?>" multiple hidden <?= (!$token_ok || $uploadsLocked)?'disabled':'' ?>>
-              </label>
-            </p>
-            <div class="form-text mt-2">İzinli formatlar: jpg, png, webp, gif, mp4, mov, webm. Maksimum <?=round(MAX_UPLOAD_BYTES/1048576)?> MB / dosya.</div>
-          </div>
-          <div id="list" class="smallmuted"></div>
-          <div class="d-grid d-sm-flex align-items-center gap-3">
-            <button class="btn btn-zs" <?= (!$token_ok || $uploadsLocked)?'disabled':'' ?>>Anımı Paylaş</button>
-            <?php if(!$token_ok): ?><span class="text-danger small">Güvenlik anahtarınızın süresi doldu. Lütfen QR kodu yeniden okutun.</span><?php endif; ?>
-            <?php if($uploadsLocked): ?><span class="text-danger small">Yükleme süresi sona erdi.</span><?php endif; ?>
-          </div>
-        </form>
-      </div>
+    <div class="smallmuted mt-2">Önizleme, çift panelde kaydettiğiniz düzenin birebir yansımasıdır.</div>
+  </div>
 
-      <div class="card-lite p-3">
-        <div class="preview-shell">
-          <div class="preview-stage" id="pvStage">
-            <div class="stage-scale" id="scaleBox">
-              <div class="preview-canvas">
-                <div class="pv-title"  style="left:<?= (int)$tPos['x']?>px; top:<?= (int)$tPos['y']?>px;"><?=h($TITLE)?></div>
-                <div class="pv-sub"    style="left:<?= (int)$sPos['x']?>px; top:<?= (int)$sPos['y']?>px;"><?=h($SUBTITLE)?></div>
-                <div class="pv-prompt" style="left:<?= (int)$pPos['x']?>px; top:<?= (int)$pPos['y']?>px;"><?=h($PROMPT)?></div>
-                <?php foreach($stickersArr as $st){
-                  $txt = isset($st['txt'])?$st['txt']:'💍';
-                  $x   = isset($st['x'])?(int)$st['x']:20;
-                  $y   = isset($st['y'])?(int)$st['y']:90;
-                  $sz  = isset($st['size'])?(int)$st['size']:32; ?>
-                  <div class="sticker" style="left:<?=$x?>px; top:<?=$y?>px; font-size:<?=$sz?>px"><?=$txt?></div>
-                <?php } ?>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="smallmuted mt-2 text-center">Bu önizleme çift panelinde kayıtlı tasarımın birebir halidir.</div>
-      </div>
+  <?php if(!$token_ok): ?>
+    <div class="alert alert-warning" style="border-radius:14px">Güvenlik anahtarı süresi dolmuş. Lütfen QR’ı yeniden okutun.</div>
+  <?php endif; ?>
 
-      <div class="card-lite gallery-card" id="galeri">
-        <div class="d-flex justify-content-between align-items-center mb-3">
-          <div>
-            <h5 class="mb-0">Topluluk Galerisi</h5>
-            <div class="smallmuted">Paylaşılan tüm fotoğraf ve videolar burada toplanır.</div>
-          </div>
-          <div>
-            <?php if(!$CAN_VIEW): ?><span class="badge bg-secondary">Galeri gizli</span>
-            <?php else: ?>
-              <span class="badge-soft"><?= $CAN_DOWN ? 'İndirme açık' : 'İndirme kapalı' ?></span>
-            <?php endif; ?>
-          </div>
-        </div>
-        <?php if(!$CAN_VIEW): ?>
-          <div class="smallmuted">Galeri bu etkinlikte sadece çift tarafından görüntülenebilir.</div>
-        <?php elseif(!$uploads): ?>
-          <div class="smallmuted">Henüz yükleme yapılmadı. İlk paylaşımı siz yapın!</div>
-        <?php else: ?>
-          <div class="gallery-grid">
-            <?php foreach($uploads as $u):
-              $path = '/'.$u['file_path'];
-              $isImg=is_image_mime($u['mime']); $isVid=is_video_mime($u['mime']);
-              $name = $u['profile_display_name'] ?: $u['guest_name'];
-              $seed = guest_profile_avatar_seed([
-                'avatar_token'=>$u['profile_avatar_token'],
-                'email'=>$u['guest_email'] ?? ('upload'.$u['id'].'@guest'),
-                'id'=> $u['profile_id'] ? (int)$u['profile_id'] : (int)$u['id']
-              ]);
-              [$bg,$fg] = avatar_colors($seed);
-              $liked = !empty($uploadLikedByMe[$u['id']]);
-              $likes = $uploadLikes[$u['id']] ?? 0;
-              $comments = $uploadComments[$u['id']] ?? [];
-              $commentCount = $commentCounts[$u['id']] ?? 0;
-            ?>
-            <div class="gallery-item" id="media-<?=$u['id']?>">
-              <div class="gallery-header">
-                <div class="avatar" style="background:<?=$bg?>;color:<?=$fg?>;">
-                  <?=h(avatar_initial($name))?>
-                </div>
-                <div>
-                  <div class="gallery-author"><?=h($name)?></div>
-                  <div class="gallery-meta"><?=relative_time($u['created_at'])?></div>
-                </div>
-              </div>
-              <div class="gallery-media">
+  <!-- Yükleme formu -->
+  <div class="card-lite p-3 mb-4">
+    <h5 class="mb-3">Anınızı Yükleyin</h5>
+    <form method="post" enctype="multipart/form-data" id="upForm" class="vstack gap-3">
+      <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
+      <input type="hidden" name="do" value="upload">
+      <input type="hidden" name="t" value="<?=h($token)?>">
+      <div>
+        <label class="form-label">Adınız</label>
+        <input class="form-control" name="guest_name" placeholder="Ad Soyad" required <?= !$token_ok?'disabled':'' ?>>
+      </div>
+      <div class="dropzone" id="drop">
+        <p class="m-0">
+          <b>Dosyalarınızı buraya sürükleyin</b> veya
+          <label class="text-decoration-underline" style="cursor:pointer">bilgisayardan seçin
+            <input type="file" name="files[]" id="fileI" accept="<?=implode(',',array_keys(ALLOWED_MIMES))?>" multiple hidden <?= !$token_ok?'disabled':'' ?>>
+          </label>
+        </p>
+        <div class="smallmuted mt-2">İzinli: jpg, png, webp, gif, mp4, mov, webm — Maks: <?=round(MAX_UPLOAD_BYTES/1048576)?> MB/dosya</div>
+      </div>
+      <div id="list" class="smallmuted"></div>
+      <div class="d-grid"><button class="btn btn-zs" <?= !$token_ok?'disabled':'' ?>>Yükle</button></div>
+    </form>
+  </div>
+
+  <!-- Galeri -->
+  <div class="card-lite p-3">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <h5 class="m-0">Galeri</h5>
+      <?php if(!$CAN_VIEW): ?><span class="badge bg-secondary">Gizli</span>
+      <?php else: ?><?= $CAN_DOWN?'<span class="badge badge-soft">İndirme açık</span>':'<span class="badge bg-secondary">İndirme kapalı</span>' ?><?php endif; ?>
+    </div>
+    <?php if(!$CAN_VIEW): ?>
+      <div class="smallmuted">Galeri bu etkinlikte gizli.</div>
+    <?php else: ?>
+      <?php if(!$uploads): ?>
+        <div class="smallmuted">Henüz yükleme yok.</div>
+      <?php else: ?>
+        <div class="row g-3">
+          <?php foreach($uploads as $u):
+            $path = '/'.$u['file_path'];
+            $isImg=is_image_mime($u['mime']); $isVid=is_video_mime($u['mime']); ?>
+            <div class="col-6 col-md-4 col-lg-3">
+              <div class="thumb">
                 <?php if($isImg): ?><img src="<?=h($path)?>" alt="">
-                <?php elseif($isVid): ?><video src="<?=h($path)?>" controls playsinline></video>
+                <?php elseif($isVid): ?><video src="<?=h($path)?>" muted></video>
                 <?php else: ?><div class="p-4 text-center smallmuted">Dosya</div><?php endif; ?>
               </div>
-              <div class="gallery-actions">
-                <div class="action-buttons">
-                  <form method="post" class="d-inline ajax-like" data-upload="<?=$u['id']?>">
-                    <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-                    <input type="hidden" name="do" value="<?= $liked ? 'unlike' : 'like' ?>">
-                    <input type="hidden" name="upload_id" value="<?=$u['id']?>">
-                    <button type="submit" class="icon-btn like-button <?= $liked?'active':'' ?>" data-liked="<?= $liked ? '1' : '0' ?>" <?= !$profileVerified?'disabled title="Beğenmek için e-posta doğrulaması gerekir"':'' ?>>
-                      <span class="like-icon"><?= $liked ? '❤️' : '🤍' ?></span>
-                      <span class="like-count"><?= $likes ?></span>
-                    </button>
-                  </form>
-                  <button class="icon-btn share-btn" type="button" data-share="<?=h(BASE_URL.$path)?>"><span>🔗</span>Paylaş</button>
-                </div>
-                <?php if($CAN_DOWN): ?>
-                  <a class="btn btn-sm btn-zs-outline" href="<?=h($path)?>" download>İndir</a>
-                <?php endif; ?>
+              <div class="d-flex justify-content-between align-items-center mt-1">
+                <span class="small text-truncate" title="<?=h($u['guest_name'])?>"><?=h($u['guest_name'])?></span>
+                <?php if($CAN_DOWN): ?><a class="btn btn-sm btn-zs-outline" href="<?=h($path)?>" download>İndir</a><?php endif; ?>
               </div>
-              <div class="gallery-body">
-                <div class="comment-section collapsed" data-upload="<?=$u['id']?>">
-                  <div class="comment-header">
-                    <div class="comment-meta smallmuted">Yorumlar (<span class="comment-count" data-upload="<?=$u['id']?>"><?=$commentCount?></span>)</div>
-                    <button class="comment-toggle" type="button" data-upload="<?=$u['id']?>" data-label-collapsed="<?=h($commentCount>0 ? 'Yorumları Göster' : 'Yorum Yaz')?>" data-label-expanded="<?=h('Yorumları Gizle')?>"><?= $commentCount>0 ? 'Yorumları Göster' : 'Yorum Yaz' ?></button>
-                  </div>
-                  <div class="comment-body">
-                    <div class="comment-list" data-upload="<?=$u['id']?>">
-                      <?php foreach($comments as $c): ?>
-                        <?=render_comment_block($c)?>
-                      <?php endforeach; ?>
-                    </div>
-                    <?php if($profileVerified): ?>
-                      <form method="post" class="comment-form ajax-comment" data-upload="<?=$u['id']?>">
-                        <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-                        <input type="hidden" name="do" value="comment">
-                        <input type="hidden" name="upload_id" value="<?=$u['id']?>">
-                        <textarea class="form-control" name="comment_body" rows="2" placeholder="Güzel bir not bırak..." required></textarea>
-                        <div class="text-end mt-2"><button class="btn btn-sm btn-zs">Yorumu Gönder</button></div>
-                      </form>
-                      <?php
-                        $isOwnUpload = $u['profile_id'] && isset($guestProfile['id']) && (int)$u['profile_id'] === (int)$guestProfile['id'];
-                        $canMessageGuest = !$isOwnUpload && (int)$u['profile_id'] > 0;
-                        $targetName = $u['profile_display_name'] ?: ($u['guest_name'] ?: 'Misafir');
-                      ?>
-                      <?php if($canMessageGuest): ?>
-                        <button type="button" class="icon-btn message-open" data-target-profile="<?=$u['profile_id']?>" data-target-name="<?=h($targetName)?>" data-upload-id="<?=$u['id']?>">💬 Mesaj Gönder</button>
-                      <?php elseif($isOwnUpload): ?>
-                        <div class="comment smallmuted">Bu içerik size ait. Sohbet alanından diğer misafirlerle iletişim kurabilirsiniz.</div>
-                      <?php else: ?>
-                        <div class="comment smallmuted">Bu misafir henüz iletişim bilgisi paylaşmadı.</div>
-                      <?php endif; ?>
-                    <?php elseif($guestProfile && !$profileVerified): ?>
-                      <div class="comment">Yorum yapabilmek için e-posta adresinizi doğrulayın.</div>
-                    <?php else: ?>
-                      <div class="comment">Yorum yapmak için önce e-posta adresinizi paylaşarak içerik yükleyin.</div>
-                    <?php endif; ?>
-                  </div>
-                </div>
-              </div>
+              <div class="small smallmuted"><?=number_format($u['file_size']/1048576,1)?> MB • <?=date('d.m.Y H:i', strtotime($u['created_at']))?></div>
             </div>
-            <?php endforeach; ?>
-          </div>
-        <?php endif; ?>
-      </div>
-
-    </div>
-    <div class="vstack gap-4">
-      <div class="card-lite profile-card" id="profile">
-        <h5 class="mb-3">Profiliniz</h5>
-        <?php if($guestProfile): ?>
-          <form method="post" class="vstack gap-3">
-            <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-            <input type="hidden" name="do" value="profile">
-            <div>
-              <label class="form-label">Görünen Ad</label>
-              <input class="form-control" name="display_name" value="<?=h($guestProfile['display_name'] ?: $guestProfile['name'])?>">
-            </div>
-            <div>
-              <label class="form-label">Hakkınızda</label>
-              <textarea class="form-control" name="bio" rows="3" placeholder="Misafir defterine kısa bir not bırakın."><?=h($guestProfile['bio'] ?? '')?></textarea>
-            </div>
-            <div class="form-check">
-              <input class="form-check-input" type="checkbox" name="profile_marketing" value="1" id="profileMarketing" <?= !empty($guestProfile['marketing_opt_in'])?'checked':'' ?>>
-              <label class="form-check-label" for="profileMarketing">BİKARE’den kampanya ve yenilik bildirimleri almak istiyorum.</label>
-            </div>
-            <div class="d-flex justify-content-between align-items-center">
-              <div class="smallmuted">E-postanız: <?=h($guestProfile['email'] ?? '—')?> <?= $profileVerified ? '<span class="badge-soft ms-2">Doğrulandı</span>' : '' ?></div>
-              <button class="btn btn-sm btn-zs">Kaydet</button>
-            </div>
-          </form>
-        <?php else: ?>
-          <div class="smallmuted">E-posta adresinizle içerik yüklediğinizde profilinizi düzenleyebilir ve topluluk özelliklerini kullanabilirsiniz.</div>
-        <?php endif; ?>
-      </div>
-
-      <div class="card-lite message-card" id="messages">
-        <div class="d-flex justify-content-between align-items-center mb-3">
-          <h5 class="m-0">Mesaj Kutusu</h5>
-          <?php if($guestDirectory): ?><span class="badge-soft"><?=count($guestDirectory)?> kişi</span><?php endif; ?>
+          <?php endforeach; ?>
         </div>
-        <?php if(!$guestProfile): ?>
-          <div class="smallmuted">Misafirlere mesaj gönderebilmek için önce adınızı ve e-postanızı paylaşarak bir içerik yükleyin.</div>
-        <?php elseif(!$profileVerified): ?>
-          <div class="smallmuted">E-postanızı doğruladıktan sonra diğer misafirlerle birebir mesajlaşabilirsiniz.</div>
-        <?php elseif(!$guestDirectory): ?>
-          <div class="smallmuted">Şu anda mesajlaşabileceğiniz başka bir misafir yok. İlk sohbeti başlatmak için arkadaşlarınızı davet edin!</div>
-        <?php else: ?>
-          <div class="guest-directory">
-            <?php foreach($guestDirectory as $gd):
-              $seed = guest_profile_avatar_seed([
-                'avatar_token' => $gd['avatar_token'],
-                'email' => $gd['email'],
-                'id' => $gd['id']
-              ]);
-              [$bg,$fg] = avatar_colors($seed);
-              $display = $gd['display_name'];
-              $lastSeen = $gd['last_seen_at'] ?: $gd['last_login_at'];
-              $statusText = $lastSeen ? ('Son aktif '.relative_time($lastSeen)) : 'Yeni katıldı';
-              if($gd['is_verified']) {
-                $statusText = 'Doğrulandı • '.$statusText;
-              }
-            ?>
-              <button type="button" class="guest-card message-open" data-target-profile="<?=$gd['id']?>" data-target-name="<?=h($display)?>" data-upload-id="">
-                <div class="guest-info">
-                  <div class="avatar" style="width:42px;height:42px;background:<?=$bg?>;color:<?=$fg?>;">
-                    <?=h(avatar_initial($display))?>
-                  </div>
-                  <div>
-                    <div class="fw-semibold"><?=h($display)?></div>
-                    <div class="guest-meta"><?=h($statusText)?></div>
-                  </div>
-                </div>
-                <span class="message-pill"><span>💬</span>Mesaj</span>
-              </button>
-            <?php endforeach; ?>
-          </div>
-        <?php endif; ?>
-      </div>
-
-      <div class="card-lite chat-card" id="chat">
-        <div class="d-flex justify-content-between align-items-center mb-3">
-          <h5 class="m-0">Misafir Sohbeti</h5>
-          <span class="badge-soft"><?=count($chatMessages)?> mesaj</span>
-        </div>
-        <div class="chat-stream mb-3">
-          <?php if(!$chatMessages): ?>
-            <div class="smallmuted">Sohbeti başlatmak için ilk mesajınızı yazın.</div>
-          <?php else: ?>
-            <?php foreach($chatMessages as $msg):
-              $display = $msg['display_name'] ?: 'Misafir';
-              $seed = guest_profile_avatar_seed([
-                'avatar_token'=>$msg['avatar_token'],
-                'email'=>$msg['profile_id'] ? ('profile'.$msg['profile_id'].'@chat') : ('chat'.$msg['id'].'@guest'),
-                'id'=> $msg['profile_id'] ? (int)$msg['profile_id'] : (int)$msg['id']
-              ]);
-              [$bg,$fg] = avatar_colors($seed);
-            ?>
-              <div class="chat-bubble">
-                <div class="d-flex align-items-center gap-2">
-                  <div class="avatar" style="width:38px;height:38px;background:<?=$bg?>;color:<?=$fg?>;font-size:13px;">
-                    <?=h(avatar_initial($display))?>
-                  </div>
-                  <div>
-                    <div class="chat-author"><?=h($display)?></div>
-                    <div class="chat-time"><?=relative_time($msg['created_at'])?></div>
-                  </div>
-                </div>
-                <div class="mt-2" style="white-space:pre-wrap; font-size:14px; color:var(--muted);"><?=nl2br(h($msg['message']))?></div>
-              </div>
-            <?php endforeach; ?>
-          <?php endif; ?>
-        </div>
-        <?php if($profileVerified): ?>
-          <form method="post" class="vstack gap-3">
-            <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-            <input type="hidden" name="do" value="chat">
-            <textarea class="form-control" name="chat_message" rows="2" placeholder="Kutlama mesajınızı yazın" required></textarea>
-            <div class="text-end"><button class="btn btn-sm btn-zs">Gönder</button></div>
-          </form>
-        <?php elseif($guestProfile && !$profileVerified): ?>
-          <div class="smallmuted">Sohbete katılmak için e-posta adresinizi doğrulayın.</div>
-        <?php else: ?>
-          <div class="smallmuted">Sohbete katılmak için önce e-posta adresinizle içerik yükleyin.</div>
-        <?php endif; ?>
-      </div>
-
-      <div class="card-lite note-card" id="host-note">
-        <h5 class="mb-3">Etkinlik Sahibine Mesaj</h5>
-        <?php if($profileVerified): ?>
-          <form method="post" class="vstack gap-3 ajax-host-note">
-            <input type="hidden" name="csrf" value="<?=h(csrf_token())?>">
-            <input type="hidden" name="do" value="note_host">
-            <textarea class="form-control" name="host_message" rows="3" placeholder="Çifte iletmek istediğiniz iyi dilekleri yazın" required></textarea>
-            <div class="d-flex justify-content-between align-items-center">
-              <small class="text-muted">Mesajınız etkinlik sahibine iletilecek.</small>
-              <button class="btn btn-sm btn-zs">Gönder</button>
-            </div>
-            <div class="form-feedback small" data-role="feedback" hidden></div>
-          </form>
-        <?php elseif($guestProfile && !$profileVerified): ?>
-          <div class="smallmuted">Özel not gönderebilmek için e-posta adresinizi doğrulayın.</div>
-        <?php else: ?>
-          <div class="smallmuted">Özel not göndermek için önce e-posta adresinizle içerik yükleyin.</div>
-        <?php endif; ?>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="share-toast" id="shareToast">Bağlantı kopyalandı!</div>
-
-<div class="modal fade" id="messageModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
-    <div class="modal-content" style="border-radius:24px; border:none; box-shadow:0 28px 60px rgba(15,23,42,.18);">
-      <div class="modal-header" style="border-bottom:none; padding:24px 28px 12px;">
-        <div>
-          <div class="hero-badge" id="messageModalBadge" style="font-size:12px;">Misafir Mesajı</div>
-          <h5 class="modal-title mt-2" id="messageModalLabel">Mesajlaşma</h5>
-        </div>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
-      </div>
-      <div class="modal-body" style="padding:0 28px 28px;">
-        <div class="conversation-stream" id="conversationStream">
-          <div class="bubble-placeholder empty">Bir misafir seçerek sohbeti başlatabilirsiniz.</div>
-        </div>
-        <form class="conversation-footer" id="conversationForm" autocomplete="off">
-          <textarea class="form-control" name="message_body" placeholder="Kutlama mesajınızı yazın" required></textarea>
-          <button type="submit">Gönder</button>
-        </form>
-        <div class="smallmuted mt-2" id="conversationHint">Mesajlarınız alıcıya e-posta olarak da iletilir.</div>
-      </div>
-    </div>
+      <?php endif; ?>
+    <?php endif; ?>
   </div>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
+// 960x540 sahneyi container'a orantılı sığdır
 (function(){
   const stage=document.getElementById('pvStage'), box=document.getElementById('scaleBox');
   function fit(){ if(!stage||!box) return; const W=stage.clientWidth, S=W/960; box.style.setProperty('--s',S); stage.style.height=(540*S)+'px'; }
   window.addEventListener('resize',fit,{passive:true}); new ResizeObserver(fit).observe(stage); fit();
 })();
 
+// Drag&Drop
 const dz=document.getElementById('drop'), fi=document.getElementById('fileI'), lst=document.getElementById('list'), fm=document.getElementById('upForm');
-const uploadsLocked = fm?.dataset.locked === '1';
-if(dz && !dz.dataset.disabled && !uploadsLocked){
+if(dz){
   ['dragenter','dragover'].forEach(ev=>dz.addEventListener(ev,e=>{e.preventDefault();dz.classList.add('drag');}));
   ['dragleave','drop'].forEach(ev=>dz.addEventListener(ev,e=>{e.preventDefault();dz.classList.remove('drag');}));
   dz.addEventListener('drop',e=>{ const fs=e.dataTransfer.files; if(fs&&fi){ fi.files=fs; renderList(fs); } });
 }
-fi?.addEventListener('change',e=>{ if(uploadsLocked){ e.target.value=''; return; } renderList(e.target.files); });
+fi?.addEventListener('change',e=>renderList(e.target.files));
 function renderList(files){ if(!files||!files.length){ lst.innerHTML=''; return; } let out='<ul class="m-0 ps-3">'; for(let i=0;i<files.length;i++){ const f=files[i]; out+=`<li>${esc(f.name)} — ${(f.size/1048576).toFixed(1)} MB</li>`; } lst.innerHTML=out+'</ul>'; }
 function esc(s){return s.replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[m]));}
-fm?.addEventListener('submit',e=>{ if(uploadsLocked){ e.preventDefault(); alert('Bu etkinlik için yüklemeler kapatıldı.'); return; } const name=fm.querySelector('[name=guest_name]').value.trim(); if(!name){e.preventDefault(); alert('Lütfen adınızı yazın.');} const fs=fi?.files||[]; if(!fs.length){e.preventDefault(); alert('Lütfen dosya seçin.');} });
-
-document.querySelectorAll('.comment-section').forEach(section=>{
-  const toggle=section.querySelector('.comment-toggle');
-  if(!toggle) return;
-  const collapsedLabel=toggle.dataset.labelCollapsed || 'Yorumları Göster';
-  const expandedLabel=toggle.dataset.labelExpanded || 'Yorumları Gizle';
-  toggle.textContent=collapsedLabel;
-  toggle.addEventListener('click',()=>{
-    const isCollapsed=section.classList.toggle('collapsed');
-    toggle.textContent=isCollapsed?collapsedLabel:expandedLabel;
-  });
-});
-
-const csrfToken='<?=h(csrf_token())?>';
-const shareButtons=document.querySelectorAll('.share-btn');
-const toast=document.getElementById('shareToast');
-let toastTimer;
-
-let audioCtx=null;
-function playMessageSound(){
-  try{
-    const Ctx=window.AudioContext||window.webkitAudioContext;
-    if(!Ctx) return;
-    if(!audioCtx){ audioCtx=new Ctx(); }
-    if(audioCtx.state==='suspended'){ audioCtx.resume().catch(()=>{}); }
-    const now=audioCtx.currentTime;
-    const osc=audioCtx.createOscillator();
-    const gain=audioCtx.createGain();
-    osc.type='sine';
-    osc.frequency.setValueAtTime(880, now);
-    gain.gain.setValueAtTime(0.0001, now);
-    gain.gain.exponentialRampToValueAtTime(0.22, now+0.02);
-    gain.gain.exponentialRampToValueAtTime(0.0001, now+0.5);
-    osc.connect(gain).connect(audioCtx.destination);
-    osc.start(now);
-    osc.stop(now+0.5);
-  }catch(e){/* sessizce yoksay */}
-}
-
-function showToast(message){
-  if(!toast) return;
-  toast.textContent=message;
-  toast.classList.add('show');
-  clearTimeout(toastTimer);
-  toastTimer=setTimeout(()=>toast.classList.remove('show'),2200);
-}
-shareButtons.forEach(btn=>btn.addEventListener('click',async()=>{
-  const url=btn.dataset.share;
-  if(navigator.share){
-    try{ await navigator.share({url}); return; }catch(err){}
-  }
-  try{
-    await navigator.clipboard.writeText(url);
-    showToast('Bağlantı kopyalandı!');
-  }catch(err){
-    showToast('Bağlantı kopyalanamadı.');
-  }
-}));
-function postFormUrl(){
-  return window.location.href.split('#')[0];
-}
-async function postFormData(fd){
-  const response=await fetch(postFormUrl(),{
-    method:'POST',
-    body:fd,
-    headers:{'X-Requested-With':'XMLHttpRequest','Accept':'application/json'},
-    credentials:'same-origin'
-  });
-  let data=null;
-  try{ data=await response.json(); }catch(err){}
-  if(!response.ok || !data){
-    throw new Error(data && data.error ? data.error : 'Bir sorun oluştu. Lütfen tekrar deneyin.');
-  }
-  if(data.success===false){
-    throw new Error(data.error || 'Bir sorun oluştu. Lütfen tekrar deneyin.');
-  }
-  return data;
-}
-async function sendAjax(form){
-  const fd=new FormData(form);
-  return postFormData(fd);
-}
-document.querySelectorAll('.ajax-like').forEach(form=>{
-  form.addEventListener('submit',async e=>{
-    e.preventDefault();
-    if(form.dataset.loading==='1') return;
-    form.dataset.loading='1';
-    const btn=form.querySelector('.like-button');
-    btn?.setAttribute('disabled','disabled');
-    try{
-      const data=await sendAjax(form);
-      const liked=!!data.liked;
-      const doInput=form.querySelector('input[name=do]');
-      if(doInput) doInput.value=liked?'unlike':'like';
-      if(btn){
-        btn.classList.toggle('active',liked);
-        btn.dataset.liked=liked?'1':'0';
-        const icon=btn.querySelector('.like-icon');
-        const count=btn.querySelector('.like-count');
-        if(icon) icon.textContent=liked?'❤️':'🤍';
-        if(count && typeof data.likes!=='undefined') count.textContent=data.likes;
-      }
-    }catch(err){
-      showToast(err.message || 'Bir sorun oluştu. Lütfen tekrar deneyin.');
-    }finally{
-      btn?.removeAttribute('disabled');
-      delete form.dataset.loading;
-    }
-  });
-});
-document.querySelectorAll('.ajax-comment').forEach(form=>{
-  form.addEventListener('submit',async e=>{
-    e.preventDefault();
-    if(form.dataset.loading==='1') return;
-    form.dataset.loading='1';
-    const submit=form.querySelector('button[type=submit]');
-    submit?.setAttribute('disabled','disabled');
-    try{
-      const data=await sendAjax(form);
-      const section=form.closest('.comment-section');
-      const list=section?.querySelector('.comment-list');
-      if(list && data.html){ list.insertAdjacentHTML('beforeend', data.html); }
-      const countEl=section?.querySelector('.comment-count');
-      if(countEl && typeof data.count!=='undefined'){ countEl.textContent=data.count; }
-      const textarea=form.querySelector('textarea');
-      if(textarea) textarea.value='';
-      if(section){
-        section.classList.remove('collapsed');
-        const toggle=section.querySelector('.comment-toggle');
-        if(toggle){
-          const expandedLabel=toggle.dataset.labelExpanded || 'Yorumları Gizle';
-          toggle.textContent=expandedLabel;
-        }
-      }
-      showToast('Yorumun paylaşıldı!');
-    }catch(err){
-      showToast(err.message || 'Yorum gönderilemedi.');
-    }finally{
-      submit?.removeAttribute('disabled');
-      delete form.dataset.loading;
-    }
-  });
-});
-function handleFeedback(form, message, isError=false){
-  const feedback=form.querySelector('[data-role=\"feedback\"]');
-  if(!feedback) return;
-  feedback.textContent=message;
-  feedback.hidden=false;
-  feedback.classList.toggle('error',!!isError);
-}
-function setConversationState(message, variant='info'){
-  if(!conversationStream) return;
-  const el=document.createElement('div');
-  const classes=['bubble-placeholder'];
-  if(variant==='error'){ classes.push('error'); }
-  if(variant==='empty'){ classes.push('empty'); }
-  el.className=classes.join(' ');
-  el.textContent=message;
-  conversationStream.innerHTML='';
-  conversationStream.appendChild(el);
-}
-function buildConversationBubble(entry){
-  const bubble=document.createElement('div');
-  bubble.className='conversation-bubble'+(entry.isMine?' mine':'');
-  if(entry.meta){
-    const meta=document.createElement('div');
-    meta.className='meta';
-    meta.textContent=entry.meta;
-    bubble.appendChild(meta);
-  }
-  const body=document.createElement('div');
-  body.className='body';
-  if(entry.body_html){
-    body.innerHTML=entry.body_html;
-  }else if(entry.body){
-    body.textContent=entry.body;
-  }
-  bubble.appendChild(body);
-  return bubble;
-}
-  function renderConversation(entries, options={}){
-    if(!conversationStream) return;
-    const notify=!!options.notify;
-    const prevLatest=conversationLatestId;
-    let highest=conversationLatestId;
-    let newFromOthers=0;
-    conversationStream.innerHTML='';
-    if(!entries || !entries.length){
-      conversationLatestId=highest;
-      setConversationState('Henüz mesaj yok. İlk mesajı siz gönderebilirsiniz.', 'empty');
-      return;
-    }
-    entries.forEach(entry=>{
-      conversationStream.appendChild(buildConversationBubble(entry));
-      const entryId=parseInt(entry.id ?? '0',10);
-      if(entryId && entryId>highest){ highest=entryId; }
-      if(notify && entryId>prevLatest && !entry.isMine){ newFromOthers++; }
-    });
-    conversationLatestId=highest;
-    conversationStream.scrollTop = conversationStream.scrollHeight;
-    if(notify && newFromOthers>0){ playMessageSound(); }
-  }
-  function appendConversationEntry(entry){
-    if(!conversationStream) return;
-    const placeholder=conversationStream.querySelector('.bubble-placeholder');
-    if(placeholder){
-      conversationStream.innerHTML='';
-    }
-    conversationStream.appendChild(buildConversationBubble(entry));
-    const entryId=parseInt(entry.id ?? '0',10);
-    if(entryId && entryId>conversationLatestId){ conversationLatestId=entryId; }
-    conversationStream.scrollTop = conversationStream.scrollHeight;
-  }
-  async function requestAction(action, params={}){
-    const fd=new FormData();
-    fd.append('csrf', csrfToken);
-    fd.append('do', action);
-    Object.entries(params).forEach(([key,value])=>{
-      if(value===undefined || value===null) return;
-      fd.append(key, value);
-    });
-    return postFormData(fd);
-  }
-const messageModalEl=document.getElementById('messageModal');
-const conversationStream=document.getElementById('conversationStream');
-const messageModalLabel=document.getElementById('messageModalLabel');
-const messageModalBadge=document.getElementById('messageModalBadge');
-const conversationForm=document.getElementById('conversationForm');
-const conversationTextarea=conversationForm ? conversationForm.querySelector('textarea') : null;
-const messageModal=messageModalEl ? new bootstrap.Modal(messageModalEl) : null;
-let activeRecipient=null;
-let conversationLatestId=0;
-let conversationPollTimer=null;
-let conversationLoading=false;
-
-  async function loadConversation(recipientId, options={}){
-    if(!conversationStream) return;
-    const notify=!!options.notify;
-    const showLoader=!!options.showLoader;
-    if(conversationLoading){ return; }
-    if(showLoader || !conversationStream.childElementCount){
-      setConversationState('Mesajlar yükleniyor...');
-    }
-    conversationLoading=true;
-    try{
-      const data=await requestAction('conversation',{target_profile_id:recipientId});
-      renderConversation(data.messages || [], {notify});
-    }catch(err){
-      if(showLoader){
-        setConversationState(err.message || 'Mesajlar getirilemedi.', 'error');
-      }else{
-        showToast(err.message || 'Mesajlar getirilemedi.');
-      }
-    }finally{
-      conversationLoading=false;
-    }
-  }
-
-  function startConversationPolling(){
-    stopConversationPolling();
-    if(!activeRecipient) return;
-    conversationPollTimer=setInterval(()=>{
-      if(!activeRecipient) return;
-      loadConversation(activeRecipient.id,{notify:true});
-    }, 6000);
-  }
-
-  function stopConversationPolling(){
-    if(conversationPollTimer){
-      clearInterval(conversationPollTimer);
-      conversationPollTimer=null;
-    }
-    conversationLoading=false;
-  }
-
-document.querySelectorAll('.message-open').forEach(btn=>{
-  btn.addEventListener('click',()=>{
-    if(!messageModal) return;
-    const profileId=parseInt(btn.dataset.targetProfile || '0',10);
-    if(!profileId){
-      showToast('Mesajlaşma için uygun bir misafir bulunamadı.');
-      return;
-    }
-    activeRecipient={
-      id:profileId,
-      name:btn.dataset.targetName || 'Misafir',
-      uploadId:btn.dataset.uploadId || ''
-    };
-    if(messageModalLabel){ messageModalLabel.textContent=activeRecipient.name; }
-    if(messageModalBadge){ messageModalBadge.textContent='Misafir Mesajı'; }
-    if(conversationTextarea){ conversationTextarea.value=''; }
-    conversationLatestId=0;
-    setConversationState('Mesajlar yükleniyor...');
-    messageModal.show();
-    loadConversation(profileId,{showLoader:true});
-    startConversationPolling();
-  });
-});
-
-conversationForm?.addEventListener('submit',async e=>{
-  e.preventDefault();
-  if(!activeRecipient){
-    showToast('Önce mesajlaşacağınız misafiri seçin.');
-    return;
-  }
-  const message=conversationTextarea?.value.trim();
-  if(!message) return;
-  if(conversationForm.dataset.loading==='1') return;
-  conversationForm.dataset.loading='1';
-  const submit=conversationForm.querySelector('button[type=submit]');
-  submit?.setAttribute('disabled','disabled');
-  try{
-    const payload={ target_profile_id: activeRecipient.id, message_body: message };
-    if(activeRecipient.uploadId){ payload.context_upload_id = activeRecipient.uploadId; }
-    const data=await requestAction('message_profile', payload);
-    if(conversationTextarea) conversationTextarea.value='';
-    if(data.entry){ appendConversationEntry(data.entry); }
-    showToast(data.message || 'Mesajınız gönderildi.');
-  }catch(err){
-    showToast(err.message || 'Mesaj gönderilemedi.');
-  }finally{
-    submit?.removeAttribute('disabled');
-    delete conversationForm.dataset.loading;
-  }
-});
-
-messageModalEl?.addEventListener('hidden.bs.modal',()=>{
-  stopConversationPolling();
-  activeRecipient=null;
-  conversationLatestId=0;
-  setConversationState('Bir misafir seçerek sohbeti başlatabilirsiniz.', 'empty');
-});
-document.querySelectorAll('.ajax-host-note').forEach(form=>{
-  form.addEventListener('submit',async e=>{
-    e.preventDefault();
-    if(form.dataset.loading==='1') return;
-    form.dataset.loading='1';
-    const submit=form.querySelector('button[type=submit]');
-    const textarea=form.querySelector('textarea');
-    const feedback=form.querySelector('[data-role=\"feedback\"]');
-    if(feedback){ feedback.hidden=true; feedback.classList.remove('error'); }
-    submit?.setAttribute('disabled','disabled');
-    try{
-      const data=await sendAjax(form);
-      if(textarea) textarea.value='';
-      handleFeedback(form, data.message || 'Mesajınız gönderildi.');
-      showToast(data.message || 'Mesajınız gönderildi.');
-    }catch(err){
-      handleFeedback(form, err.message || 'Mesaj gönderilemedi.', true);
-      showToast(err.message || 'Mesaj gönderilemedi.');
-    }finally{
-      submit?.removeAttribute('disabled');
-      delete form.dataset.loading;
-    }
-  });
-});</script>
+fm?.addEventListener('submit',e=>{ const name=fm.querySelector('[name=guest_name]').value.trim(); if(!name){e.preventDefault(); alert('Lütfen adınızı yazın.');} const fs=fi?.files||[]; if(!fs.length){e.preventDefault(); alert('Lütfen dosya seçin.');} });
+</script>
 </body></html>

--- a/qr.php
+++ b/qr.php
@@ -22,5 +22,17 @@ if ($dc && $dc['ev_id']){
   redirect($dest, 301);
 }
 
+$st3=pdo()->prepare(
+  "SELECT dq.*, e.id AS ev_id FROM dealer_qr_codes dq "
+ ."LEFT JOIN events e ON e.id=dq.target_event_id "
+ ."WHERE dq.code=? LIMIT 1"
+);
+$st3->execute([$code]);
+$dq=$st3->fetch();
+if ($dq && $dq['ev_id']){
+  $dest = public_upload_url((int)$dq['ev_id']);
+  redirect($dest, 301);
+}
+
 http_response_code(404);
 exit('Hedef yok');

--- a/qr.php
+++ b/qr.php
@@ -7,8 +7,20 @@ $code=trim($_GET['code']??'');
 if ($code===''){ http_response_code(404); exit('QR yok'); }
 
 $st=pdo()->prepare("SELECT q.*, e.id AS ev_id FROM qr_codes q LEFT JOIN events e ON e.id=q.target_event_id WHERE q.code=?");
-$st->execute([$code]); $q=$st->fetch();
-if (!$q || !$q['ev_id']){ http_response_code(404); exit('Hedef yok'); }
+$st->execute([$code]);
+$q=$st->fetch();
+if ($q && $q['ev_id']){
+  $dest = public_upload_url((int)$q['ev_id']);
+  redirect($dest, 301);
+}
 
-$dest = public_upload_url((int)$q['ev_id']);
-redirect($dest, 301);
+$st2=pdo()->prepare("SELECT dc.*, e.id AS ev_id FROM dealer_codes dc LEFT JOIN events e ON e.id=dc.target_event_id WHERE dc.code=? LIMIT 1");
+$st2->execute([$code]);
+$dc=$st2->fetch();
+if ($dc && $dc['ev_id']){
+  $dest = public_upload_url((int)$dc['ev_id']);
+  redirect($dest, 301);
+}
+
+http_response_code(404);
+exit('Hedef yok');


### PR DESCRIPTION
## Summary
- extend the users schema with role and last_login fields plus backfill to guarantee at least one superadmin
- update authentication, first-run login, and shared admin layout helpers to create the first superadmin and surface role-aware navigation
- restyle the admin area with the new layout and add a management screen for inviting admins, changing roles, and resetting passwords

## Testing
- php -l includes/db.php
- php -l includes/auth.php
- php -l admin/login.php
- php -l admin/dashboard.php
- php -l admin/dealers.php
- php -l admin/users.php
- php -l admin/venues.php
- php -l admin/venue_events.php
- php -l admin/partials/ui.php
- php -l admin/team.php

------
https://chatgpt.com/codex/tasks/task_e_68e062b7f0088324b0c1289e088aaa22