### PR TITLE
Allow configuring application secrets via environment

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,12 +1,29 @@
 <?php
 /* ===================== CONFIG ====================== */
-const DB_HOST   = 'srv1776.hstgr.io';
-const DB_NAME   = 'u111878875_foto';
-const DB_USER   = 'u111878875_foto';
-const DB_PASS   = 'Zero671901*';
-const BASE_URL  = 'https://drive.demozerosoft.com.tr'; // kök URL (sonda / yok)
-const APP_NAME  = 'BİKARE';
-const SECRET_KEY = 'CHANGE_THIS_LONG_RANDOM_SECRET_32+CHARS';
+if (!function_exists('config_env')) {
+  /**
+   * Küçük bir yardımcı: .env veya ortam değişkenlerinden değer okur.
+   *
+   * getenv() boş string dönebildiği için yalnızca false olduğunda
+   * varsayılanı kullanıyoruz.
+   */
+  function config_env(string $key, $default = null) {
+    $value = getenv($key);
+    return $value === false ? $default : $value;
+  }
+}
+
+define('DB_HOST', config_env('APP_DB_HOST', '127.0.0.1'));
+define('DB_NAME', config_env('APP_DB_NAME', 'dugun'));
+define('DB_USER', config_env('APP_DB_USER', 'dugun'));
+define('DB_PASS', config_env('APP_DB_PASS', 'secret'));
+
+$baseUrl = (string)config_env('APP_BASE_URL', 'http://localhost');
+$baseUrl = $baseUrl !== '' ? rtrim($baseUrl, '/') : 'http://localhost';
+define('BASE_URL', $baseUrl); // kök URL (sonda / yok)
+
+define('APP_NAME', config_env('APP_NAME', 'BİKARE'));
+define('SECRET_KEY', config_env('APP_SECRET_KEY', 'CHANGE_THIS_LONG_RANDOM_SECRET_32+CHARS'));
 
 const MAX_UPLOAD_BYTES = 25 * 1024 * 1024; // 25 MB
 const ALLOWED_MIMES = [
@@ -14,25 +31,29 @@ const ALLOWED_MIMES = [
   'video/mp4'=>'mp4','video/quicktime'=>'mov','video/webm'=>'webm',
   
 ];
-const MAIL_FROM = 'test@zerosoft.com.tr';
-const MAIL_FROM_NAME = 'BİKARE';
-const SMTP_HOST = 'smtp.hostinger.com';
-const SMTP_PORT = 465;
-const SMTP_USER = 'test@zerosoft.com.tr';
-const SMTP_PASS = 'Zero671901*';
-const SMTP_SECURE = 'SSL';
+define('MAIL_FROM', config_env('MAIL_FROM', 'no-reply@example.com'));
+define('MAIL_FROM_NAME', config_env('MAIL_FROM_NAME', APP_NAME));
+define('SMTP_HOST', config_env('SMTP_HOST', ''));
+$smtpPort = config_env('SMTP_PORT', null);
+$smtpPort = is_numeric($smtpPort) ? (int)$smtpPort : 465;
+define('SMTP_PORT', $smtpPort);
+define('SMTP_USER', config_env('SMTP_USER', ''));
+define('SMTP_PASS', config_env('SMTP_PASS', ''));
+define('SMTP_SECURE', strtoupper((string)config_env('SMTP_SECURE', 'tls')));
 /* ================= PAYTR ================== */
-const PAYTR_MERCHANT_ID  = '615552';
-const PAYTR_MERCHANT_KEY = 'TnzafFzaQwrpF23s';
-const PAYTR_MERCHANT_SALT= 'eNaS2ot4C8naRR47';
-const PAYTR_OK_URL       = BASE_URL.'/couple/paytr_ok.php';
-const PAYTR_FAIL_URL     = BASE_URL.'/couple/paytr_fail.php';
-const PAYTR_CALLBACK_URL = BASE_URL.'/couple/paytr_callback.php';
-const PAYTR_SITE_OK_URL  = BASE_URL.'/order_paytr_ok.php';
-const PAYTR_SITE_FAIL_URL= BASE_URL.'/order_paytr_fail.php';
-const PAYTR_DEALER_OK_URL   = BASE_URL.'/dealer/paytr_ok.php';
-const PAYTR_DEALER_FAIL_URL = BASE_URL.'/dealer/paytr_fail.php';
-const PAYTR_TEST_MODE    = 1; // 1=test, 0=canlı
+define('PAYTR_MERCHANT_ID', config_env('PAYTR_MERCHANT_ID', '')); 
+define('PAYTR_MERCHANT_KEY', config_env('PAYTR_MERCHANT_KEY', ''));
+define('PAYTR_MERCHANT_SALT', config_env('PAYTR_MERCHANT_SALT', ''));
+define('PAYTR_OK_URL', BASE_URL.'/couple/paytr_ok.php');
+define('PAYTR_FAIL_URL', BASE_URL.'/couple/paytr_fail.php');
+define('PAYTR_CALLBACK_URL', BASE_URL.'/couple/paytr_callback.php');
+define('PAYTR_SITE_OK_URL', BASE_URL.'/order_paytr_ok.php');
+define('PAYTR_SITE_FAIL_URL', BASE_URL.'/order_paytr_fail.php');
+define('PAYTR_DEALER_OK_URL', BASE_URL.'/dealer/paytr_ok.php');
+define('PAYTR_DEALER_FAIL_URL', BASE_URL.'/dealer/paytr_fail.php');
+$paytrTest = config_env('PAYTR_TEST_MODE', null);
+$paytrTest = ($paytrTest === null || $paytrTest === '') ? 1 : (int)$paytrTest;
+define('PAYTR_TEST_MODE', $paytrTest); // 1=test, 0=canlı
 /* ========================================= */
 
 /* =================================================== */


### PR DESCRIPTION
## Summary
- read database, SMTP and PayTR credentials from environment variables instead of hard-coding production values
- add a small helper for safely fetching environment values while keeping sensible defaults for local development

## Testing
- php -l config.php

------
https://chatgpt.com/codex/tasks/task_e_68e46aaafce883248e53265e2462eefe